### PR TITLE
Add __str__ implementation for projects and tags

### DIFF
--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -39,6 +39,9 @@ class Project(models.Model):
     project_url = models.CharField(max_length=2083, blank=True)
     project_links = models.CharField(max_length=5000, blank=True)
 
+    def __str__(self):
+        return str(self.id) + ':' + self.project_name
+
     def hydrate_to_json(self):
         files = ProjectFile.objects.filter(file_project=self.id)
         thumbnail_files = list(files.filter(file_category=FileCategory.THUMBNAIL.value))

--- a/common/models/tags.py
+++ b/common/models/tags.py
@@ -13,6 +13,12 @@ class Tag(models.Model):
     subcategory = models.CharField(max_length=200, blank=True)
     parent = models.CharField(max_length=100, blank=True)
 
+    def __str__(self):
+        prefix = self.category
+        if self.subcategory:
+            prefix += '->' + self.subcategory
+        return prefix + '->' + self.tag_name
+
     @staticmethod
     def get_by_name(name):
         # TODO: Get from in-memory cache


### PR DESCRIPTION
We need to add a __str__ implementation for the project and tag objects so that on the admin pages, the objects in question are listed by their names/id's, not a generic 'Object object'.