### PR TITLE
Make contact project button grayed out when it is disabled

### DIFF
--- a/civictechprojects/static/css/ProjectSearchBar.css
+++ b/civictechprojects/static/css/ProjectSearchBar.css
@@ -28,3 +28,8 @@
   margin-right: 34px;
   margin-top: 16px;
 }
+
+button.ProjectSearchBar-submit:disabled {
+  background-color: #ededed;
+  color: #7a7a7a;
+}

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -68389,7 +68389,7 @@ Value.propTypes = {
 };
 
 /*!
-  Copyright (c) 2017 Jed Watson.
+  Copyright (c) 2018 Jed Watson.
   Licensed under the MIT License (MIT), see
   http://jedwatson.github.io/react-select
 */
@@ -68945,8 +68945,8 @@ var Select$1 = function (_React$Component) {
 					break;
 				case 46:
 					// delete
-					event.preventDefault();
 					if (!this.state.inputValue && this.props.deleteRemoves) {
+						event.preventDefault();
 						this.popValue();
 					}
 					break;
@@ -69377,7 +69377,7 @@ var Select$1 = function (_React$Component) {
 			}
 			return __WEBPACK_IMPORTED_MODULE_3_react___default.a.createElement(
 				'div',
-				{ className: className, key: 'input-wrap' },
+				{ className: className, key: 'input-wrap', style: { display: 'inline-block' } },
 				__WEBPACK_IMPORTED_MODULE_3_react___default.a.createElement('input', _extends({ id: this.props.id }, inputProps))
 			);
 		}
@@ -75269,7 +75269,9 @@ var MyProjectsController = function (_React$PureComponent) {
         //TODO: this should be ProjectAPIUtils.delete, not post
         __WEBPACK_IMPORTED_MODULE_1__utils_ProjectAPIUtils_js__["a" /* default */].post(url, {},
         // success callback
-        this.removeProjectFromList.bind(this));
+        this.removeProjectFromList.bind(this)
+        //TODO: handle errors
+        );
       };
       this.setState({
         showConfirmDeleteModal: false


### PR DESCRIPTION
The change I made may affect other buttons as well (selector used: `button.ProjectSearchBar-submit:disabled` - will affect all buttons in class.ProjectSearchBar when they are disabled). I figured this is a good thing because for usability we want buttons to be grayed out if they are disabled. If this isn't the way to go, let me know.