### PR TITLE
Adds link to example template in add position modal

### DIFF
--- a/civictechprojects/static/css/projects.css
+++ b/civictechprojects/static/css/projects.css
@@ -271,3 +271,8 @@ th, td {
   text-transform: none;
   font-style: italic;
 }
+
+.modal-hint {
+  font-size: 0.8rem;
+  font-style: italic;
+}

--- a/common/components/forms/PositionEntryModal.jsx
+++ b/common/components/forms/PositionEntryModal.jsx
@@ -25,7 +25,7 @@ type State = {|
 class PositionEntryModal extends React.PureComponent<Props,State> {
   close: Function;
   save: Function;
-  
+
   constructor(props: Props): void {
     super(props);
     this.state = {
@@ -35,7 +35,7 @@ class PositionEntryModal extends React.PureComponent<Props,State> {
         descriptionUrl: ""
       }
     };
-  
+
     this.close = this.close.bind(this);
     this.save = this.save.bind(this);
   }
@@ -55,17 +55,17 @@ class PositionEntryModal extends React.PureComponent<Props,State> {
       });
     }
   }
-  
+
   componentWillReceiveProps(nextProps: Props): void {
     this.setState({ showModal: nextProps.showModal });
     this.resetModal(nextProps.existingPosition);
   }
-  
+
   close(): void {
     this.setState({showModal: false});
     this.props.onCancel();
   }
-  
+
   save(): void {
     if(this.state.positionInfo.descriptionUrl) {
       this.state.positionInfo.descriptionUrl = url.appendHttpIfMissingProtocol(this.state.positionInfo.descriptionUrl);
@@ -73,17 +73,17 @@ class PositionEntryModal extends React.PureComponent<Props,State> {
     this.props.onSavePosition(this.state.positionInfo);
     this.close();
   }
-  
+
   onRoleChange(role: $ReadOnlyArray<TagDefinition>): void {
     this.state.positionInfo.roleTag = role[0];
     this.forceUpdate();
   }
-  
+
   onDescriptionChange(event: SyntheticInputEvent<HTMLInputElement>): void {
     this.state.positionInfo.descriptionUrl = event.target.value;
     this.forceUpdate();
   }
-  
+
   render(): React$Node {
     return (
       <div>
@@ -103,9 +103,9 @@ class PositionEntryModal extends React.PureComponent<Props,State> {
                       onSelection={this.onRoleChange.bind(this)}
                     />
                   </div>
-  
+
                 <div className="form-group">
-                  <label htmlFor="link-position-description">Link to Description</label>
+                  <label htmlFor="link-position-description">Link to Description <span className="modal-hint"><a href="https://docs.google.com/document/d/142NH4uRblJP6XvKdmW4GiFwoOmVWY6BJfEjGrlSP3Uk/edit" rel="noopener noreferrer" target="_blank">(Example template)</a></span></label>
                   <input type="text" className="form-control" id="link-position-description" maxLength="2075" value={this.state.positionInfo.descriptionUrl} onChange={this.onDescriptionChange.bind(this)}/>
                 </div>
               </Modal.Body>

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -33926,9 +33926,7 @@ var EditProjectForm = function (_React$PureComponent) {
       //combine arrays prior to sending to backend
       var formFields = this.state.formFields;
       formFields.project_links = formFields.project_links.concat(eLinksArray);
-      // setState new combined array
       this.setState({ formFields: formFields });
-      // this.setState({ formFields: { project_links: combinedArray }});
       this.forceUpdate();
     }
   }, {
@@ -35093,7 +35091,7 @@ Value.propTypes = {
 };
 
 /*!
-  Copyright (c) 2018 Jed Watson.
+  Copyright (c) 2017 Jed Watson.
   Licensed under the MIT License (MIT), see
   http://jedwatson.github.io/react-select
 */
@@ -35649,8 +35647,8 @@ var Select$1 = function (_React$Component) {
 					break;
 				case 46:
 					// delete
+					event.preventDefault();
 					if (!this.state.inputValue && this.props.deleteRemoves) {
-						event.preventDefault();
 						this.popValue();
 					}
 					break;
@@ -36081,7 +36079,7 @@ var Select$1 = function (_React$Component) {
 			}
 			return __WEBPACK_IMPORTED_MODULE_3_react___default.a.createElement(
 				'div',
-				{ className: className, key: 'input-wrap', style: { display: 'inline-block' } },
+				{ className: className, key: 'input-wrap' },
 				__WEBPACK_IMPORTED_MODULE_3_react___default.a.createElement('input', _extends({ id: this.props.id }, inputProps))
 			);
 		}
@@ -74659,7 +74657,16 @@ var PositionEntryModal = function (_React$PureComponent) {
               __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
                 'label',
                 { htmlFor: 'link-position-description' },
-                'Link to Description'
+                'Link to Description ',
+                __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                  'span',
+                  { className: 'modal-hint' },
+                  __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                    'a',
+                    { href: 'https://docs.google.com/document/d/142NH4uRblJP6XvKdmW4GiFwoOmVWY6BJfEjGrlSP3Uk/edit', rel: 'noopener noreferrer', target: '_blank' },
+                    '(Example template)'
+                  )
+                )
               ),
               __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement('input', { type: 'text', className: 'form-control', id: 'link-position-description', maxLength: '2075', value: this.state.positionInfo.descriptionUrl, onChange: this.onDescriptionChange.bind(this) })
             )


### PR DESCRIPTION
Adds a link to the example template in the Add Position modal when creating/editing a project.

To test, log in and create or edit a project. Add a position with the `Open Positions` modal. Next to the Position Description header, you should see `(example template)` which links out to google doc template. It opens in a new window (to prevent possible issues with the modal) and has some basic style applied, this can be modified in projects.css, by updating the .modal-hint class.

