### PR TITLE
Signup form submits on keypress of enter/return

### DIFF
--- a/common/components/componentsBySection/FindProjects/AlertSignupModal.jsx
+++ b/common/components/componentsBySection/FindProjects/AlertSignupModal.jsx
@@ -65,7 +65,8 @@ class AlertSignupModal extends React.PureComponent<Props, State> {
     this.forceUpdate();
   }
 
-  handleSubmit() {
+  handleSubmit(event) {
+    event.preventDefault();
     ProjectAPIUtils.post("/alert/create/",
       {
         email: this.state.formFields.email,

--- a/common/components/componentsBySection/FindProjects/AlertSignupModal.jsx
+++ b/common/components/componentsBySection/FindProjects/AlertSignupModal.jsx
@@ -50,7 +50,7 @@ class AlertSignupModal extends React.PureComponent<Props, State> {
     this.closeModal = this.closeModal.bind(this, this.props.handleClose);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
-    
+
   componentWillReceiveProps(nextProps: Props): void {
     let formFields: FormFields = this.state.formFields;
     formFields.filters = nextProps.searchFilters;
@@ -59,7 +59,7 @@ class AlertSignupModal extends React.PureComponent<Props, State> {
       formFields: formFields
     });
   }
-  
+
   onFormFieldChange(formFieldName: string, event: SyntheticInputEvent<HTMLInputElement>): void {
     this.state.formFields[formFieldName] = event.target.value;
     this.forceUpdate();
@@ -89,18 +89,19 @@ class AlertSignupModal extends React.PureComponent<Props, State> {
                  onHide={this.closeModal}
                  style={{paddingTop:'20%'}}
           >
+            <form onSubmit={this.handleSubmit}>
               <Modal.Header >
                   <Modal.Title>Sign Up For Alerts</Modal.Title>
               </Modal.Header>
               <Modal.Body>
                 <p>Enter your email address and location to sign up for relevant alerts.  As new projects are added that meet your search parameters, we will send them your way!</p>
-  
+
                 <div className="form-group">
                   <label htmlFor="email">Email</label>
                   <input type="text" className="form-control" id="email" name="email" maxLength="254"
                          value={this.state.formFields.email} onChange={this.onFormFieldChange.bind(this, "email")}/>
                 </div>
-                
+
                 <div className="form-group">
                   <label htmlFor="country">Country</label>
                   <Select
@@ -114,7 +115,7 @@ class AlertSignupModal extends React.PureComponent<Props, State> {
                     multi={false}
                   />
                 </div>
-  
+
                 <div className="form-group">
                   <label htmlFor="postal_code">Zip/Postal Code</label>
                   <input type="text" className="form-control" id="postal_code" name="postal_code" maxLength="10"
@@ -123,8 +124,9 @@ class AlertSignupModal extends React.PureComponent<Props, State> {
               </Modal.Body>
               <Modal.Footer>
                 <Button onClick={this.closeModal}>{"Cancel"}</Button>
-                <Button disabled={!this.state.formFields.email || !this.state.formFields.postal_code} onClick={this.handleSubmit}>Submit</Button>
+                <Button disabled={!this.state.formFields.email || !this.state.formFields.postal_code} type="submit" onClick={this.handleSubmit}>Submit</Button>
               </Modal.Footer>
+            </form>
           </Modal>
       </div>
     );

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -75686,7 +75686,6 @@ var AlertSignupModal = function (_React$PureComponent) {
   }, {
     key: 'closeModal',
     value: function closeModal() {
-      alert('closeModal fired');
       this.props.handleClose();
     }
   }, {

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -75668,9 +75668,10 @@ var AlertSignupModal = function (_React$PureComponent) {
     }
   }, {
     key: 'handleSubmit',
-    value: function handleSubmit() {
+    value: function handleSubmit(event) {
       var _this2 = this;
 
+      event.preventDefault();
       __WEBPACK_IMPORTED_MODULE_2__utils_ProjectAPIUtils_js__["a" /* default */].post("/alert/create/", {
         email: this.state.formFields.email,
         filters: this.state.formFields.filters,

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -75686,6 +75686,7 @@ var AlertSignupModal = function (_React$PureComponent) {
   }, {
     key: 'closeModal',
     value: function closeModal() {
+      alert('closeModal fired');
       this.props.handleClose();
     }
   }, {
@@ -75701,76 +75702,80 @@ var AlertSignupModal = function (_React$PureComponent) {
             style: { paddingTop: '20%' }
           },
           __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-            __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["g" /* Modal */].Header,
-            null,
+            'form',
+            { onSubmit: this.handleSubmit },
             __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-              __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["g" /* Modal */].Title,
+              __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["g" /* Modal */].Header,
               null,
-              'Sign Up For Alerts'
-            )
-          ),
-          __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-            __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["g" /* Modal */].Body,
-            null,
+              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["g" /* Modal */].Title,
+                null,
+                'Sign Up For Alerts'
+              )
+            ),
             __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-              'p',
+              __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["g" /* Modal */].Body,
               null,
-              'Enter your email address and location to sign up for relevant alerts.  As new projects are added that meet your search parameters, we will send them your way!'
-            ),
-            __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-              'div',
-              { className: 'form-group' },
               __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-                'label',
-                { htmlFor: 'email' },
-                'Email'
+                'p',
+                null,
+                'Enter your email address and location to sign up for relevant alerts.  As new projects are added that meet your search parameters, we will send them your way!'
               ),
-              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement('input', { type: 'text', className: 'form-control', id: 'email', name: 'email', maxLength: '254',
-                value: this.state.formFields.email, onChange: this.onFormFieldChange.bind(this, "email") })
-            ),
-            __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-              'div',
-              { className: 'form-group' },
               __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-                'label',
-                { htmlFor: 'country' },
-                'Country'
+                'div',
+                { className: 'form-group' },
+                __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                  'label',
+                  { htmlFor: 'email' },
+                  'Email'
+                ),
+                __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement('input', { type: 'text', className: 'form-control', id: 'email', name: 'email', maxLength: '254',
+                  value: this.state.formFields.email, onChange: this.onFormFieldChange.bind(this, "email") })
               ),
-              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(__WEBPACK_IMPORTED_MODULE_3_react_select__["a" /* default */], {
-                id: 'country',
-                name: 'country',
-                options: this.state.countries,
-                value: this.state.formFields.country,
-                className: 'form-control',
-                simpleValue: false,
-                clearable: false,
-                multi: false
-              })
-            ),
-            __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-              'div',
-              { className: 'form-group' },
               __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-                'label',
-                { htmlFor: 'postal_code' },
-                'Zip/Postal Code'
+                'div',
+                { className: 'form-group' },
+                __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                  'label',
+                  { htmlFor: 'country' },
+                  'Country'
+                ),
+                __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(__WEBPACK_IMPORTED_MODULE_3_react_select__["a" /* default */], {
+                  id: 'country',
+                  name: 'country',
+                  options: this.state.countries,
+                  value: this.state.formFields.country,
+                  className: 'form-control',
+                  simpleValue: false,
+                  clearable: false,
+                  multi: false
+                })
               ),
-              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement('input', { type: 'text', className: 'form-control', id: 'postal_code', name: 'postal_code', maxLength: '10',
-                value: this.state.formFields.postal_code, onChange: this.onFormFieldChange.bind(this, "postal_code") })
-            )
-          ),
-          __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-            __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["g" /* Modal */].Footer,
-            null,
-            __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-              __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["a" /* Button */],
-              { onClick: this.closeModal },
-              "Cancel"
+              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                'div',
+                { className: 'form-group' },
+                __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                  'label',
+                  { htmlFor: 'postal_code' },
+                  'Zip/Postal Code'
+                ),
+                __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement('input', { type: 'text', className: 'form-control', id: 'postal_code', name: 'postal_code', maxLength: '10',
+                  value: this.state.formFields.postal_code, onChange: this.onFormFieldChange.bind(this, "postal_code") })
+              )
             ),
             __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-              __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["a" /* Button */],
-              { disabled: !this.state.formFields.email || !this.state.formFields.postal_code, onClick: this.handleSubmit },
-              'Submit'
+              __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["g" /* Modal */].Footer,
+              null,
+              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["a" /* Button */],
+                { onClick: this.closeModal },
+                "Cancel"
+              ),
+              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+                __WEBPACK_IMPORTED_MODULE_1_react_bootstrap__["a" /* Button */],
+                { disabled: !this.state.formFields.email || !this.state.formFields.postal_code, type: 'submit', onClick: this.handleSubmit },
+                'Submit'
+              )
             )
           )
         )


### PR DESCRIPTION
Wraps the email signup alert modal in a React-controlled form element which allows for form submit on keypress instead of just clicking Submit.

To test,
Go to the Find Projects page and click "Sign up for Alerts"
 -  Fill out the form partially and press Enter. Form should _not_ submit.
 -  Fill out the form completely and press Enter. Form _should_ submit.


