### PR TITLE
Bug Fix: Handle existing project locations that aren't in the new list

### DIFF
--- a/common/components/common/projects/EditProjectForm.jsx
+++ b/common/components/common/projects/EditProjectForm.jsx
@@ -201,15 +201,19 @@ class EditProjectForm extends React.PureComponent<Props,State> {
   }
 
   _renderLocationDropdown(): React$Node{
+    const presetLocations: $ReadOnlyArray<string> = [
+      "Seattle, WA",
+      "Redmond, WA",
+      "Kirkland, WA",
+      "Bellevue, WA",
+      Locations.OTHER
+    ];
+    
     return <div className="form-group">
       <label htmlFor="project_location">Project Location</label>
       <select name="project_location" id="project_location" className="form-control" value={this.state.formFields.project_location} onChange={this.onFormFieldChange.bind(this, "project_location")}>
-        {!this.state.formFields.project_location ? <option value=""></option> : null}
-        <option value="Redmond, WA">Redmond, WA</option>
-        <option value="Kirkland, WA">Kirkland, WA</option>
-        <option value="Bellevue, WA">Bellevue, WA</option>
-        <option value="Seattle, WA">Seattle, WA</option>
-        <option value={Locations.OTHER}>{Locations.OTHER}</option>
+        {!_.includes(presetLocations, this.state.formFields.project_location) ? <option value={this.state.formFields.project_location}>{this.state.formFields.project_location}</option> : null}
+        {presetLocations.map(location => <option key={location} value={location}>{location}</option>)}
       </select>
     </div>;
   }

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -34170,6 +34170,8 @@ var EditProjectForm = function (_React$PureComponent) {
   }, {
     key: '_renderLocationDropdown',
     value: function _renderLocationDropdown() {
+      var presetLocations = ["Seattle, WA", "Redmond, WA", "Kirkland, WA", "Bellevue, WA", __WEBPACK_IMPORTED_MODULE_13__constants_ProjectConstants__["a" /* Locations */].OTHER];
+
       return __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
         'div',
         { className: 'form-group' },
@@ -34181,32 +34183,18 @@ var EditProjectForm = function (_React$PureComponent) {
         __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
           'select',
           { name: 'project_location', id: 'project_location', className: 'form-control', value: this.state.formFields.project_location, onChange: this.onFormFieldChange.bind(this, "project_location") },
-          !this.state.formFields.project_location ? __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement('option', { value: '' }) : null,
-          __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+          !__WEBPACK_IMPORTED_MODULE_12_lodash___default.a.includes(presetLocations, this.state.formFields.project_location) ? __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
             'option',
-            { value: 'Redmond, WA' },
-            'Redmond, WA'
-          ),
-          __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-            'option',
-            { value: 'Kirkland, WA' },
-            'Kirkland, WA'
-          ),
-          __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-            'option',
-            { value: 'Bellevue, WA' },
-            'Bellevue, WA'
-          ),
-          __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-            'option',
-            { value: 'Seattle, WA' },
-            'Seattle, WA'
-          ),
-          __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
-            'option',
-            { value: __WEBPACK_IMPORTED_MODULE_13__constants_ProjectConstants__["a" /* Locations */].OTHER },
-            __WEBPACK_IMPORTED_MODULE_13__constants_ProjectConstants__["a" /* Locations */].OTHER
-          )
+            { value: this.state.formFields.project_location },
+            this.state.formFields.project_location
+          ) : null,
+          presetLocations.map(function (location) {
+            return __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(
+              'option',
+              { key: location, value: location },
+              location
+            );
+          })
         )
       );
     }


### PR DESCRIPTION
For projects that had entered in a project location that wasn't in our list during the time it was a free-form field, the new experience would have them automatically selecting 'Redmond, WA' when they went to edit their project, with no means to revert to their original value.

Eventually we want to migrate away from any non-standard values, but until we either do it ourselves manually or come up with a workable conversion scheme let's not force them to change it.