### PR TITLE
Redirect old NationBuilder links

### DIFF
--- a/common/components/chrome/MainHeader.jsx
+++ b/common/components/chrome/MainHeader.jsx
@@ -44,7 +44,7 @@ class MainHeader extends React.PureComponent<{||}> {
         >
           <MenuItem href="mailto:hello@democracylab.org">Contact Us</MenuItem>
           <MenuItem divider />
-          <MenuItem href="/logout">Logout</MenuItem>
+          <MenuItem href="/logout/">Logout</MenuItem>
         </DropdownButton>
           )
       : (

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -84767,7 +84767,7 @@ var MainHeader = function (_React$PureComponent) {
         __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement(__WEBPACK_IMPORTED_MODULE_2_react_bootstrap__["f" /* MenuItem */], { divider: true }),
         __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement(
           __WEBPACK_IMPORTED_MODULE_2_react_bootstrap__["f" /* MenuItem */],
-          { href: '/logout' },
+          { href: '/logout/' },
           'Logout'
         )
       ) : __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement(

--- a/democracylab/urls.py
+++ b/democracylab/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
     url(r'^', include('civictechprojects.urls')),
     url(r'^$', RedirectView.as_view(url='/index/', permanent=True)),
     url(r'^admin/', admin.site.urls),
+    url(r'^platform$', RedirectView.as_view(url='http://connect.democracylab.org/platform/', permanent=True)),
     url(r'^.*$', RedirectView.as_view(url='/index/', permanent=True)),
     # url(
     #     r'check_email/(?P<user_email>.*)$',

--- a/democracylab/urls.py
+++ b/democracylab/urls.py
@@ -45,10 +45,10 @@ urlpatterns = [
         name="send_verification_email"
     ),
     url(r'^', include('civictechprojects.urls')),
-    url(r'^$', RedirectView.as_view(url='/index/', permanent=True)),
+    url(r'^$', RedirectView.as_view(url='/index/', permanent=False)),
     url(r'^admin/', admin.site.urls),
-    url(r'^platform$', RedirectView.as_view(url='http://connect.democracylab.org/platform/', permanent=True)),
-    url(r'^.*$', RedirectView.as_view(url='/index/', permanent=True)),
+    url(r'^platform$', RedirectView.as_view(url='http://connect.democracylab.org/platform/', permanent=False)),
+    url(r'^.*$', RedirectView.as_view(url='/index/', permanent=False)),
     # url(
     #     r'check_email/(?P<user_email>.*)$',
     #     views.check_email,

--- a/democracylab/urls.py
+++ b/democracylab/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
     url(r'^', include('civictechprojects.urls')),
     url(r'^$', RedirectView.as_view(url='/index/', permanent=True)),
     url(r'^admin/', admin.site.urls),
+    url(r'^.*$', RedirectView.as_view(url='/index/', permanent=True)),
     # url(
     #     r'check_email/(?P<user_email>.*)$',
     #     views.check_email,


### PR DESCRIPTION
Some people have saved links from the old NationBuilder site (when it was at democracylab.org), so we need to redirect those links to the new NationBuilder url.

Changes:
www.democracylab.org/platform redirects to NationBuilder
All other links will redirect to www.democracylab.org until further notice
All redirects are now non-permanent, to facilitate easier changes later.