### PR TITLE
Readme and Contributor Guide Update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for contributing to DemocracyLab! We're glad you want to help us make our platform even better.
 
-When contributing to this repository, please make sure you have followed the [https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#](Contributor Guide). If you have any questions, please reach out to us on Slack.
+When contributing to this repository, please make sure you have followed the [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#). If you have any questions, please reach out to us on Slack.
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Thanks for contributing to DemocracyLab! We're glad you want to help us make our platform even better.
+
+When contributing to this repository, please make sure you have followed the [https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#](Contributor Guide). If you have any questions, please reach out to us on Slack.
+
+## Pull Request Process
+
+1. Please make sure your PR includes the bundle.js created as part of the `npm run build` process. This file is required for changes to be deployed.
+2. When your pull request is submitted, another developer from the team will review it. All pull requests must be reviewed and approved prior to merging. If any changes are requested, those will be made through the Github review system.  
+3. ???

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,106 @@
 # Contributing
 
-Thanks for contributing to DemocracyLab! We're glad you want to help us make our platform even better.
+Thanks for your interest in contributing to DemocracyLab! We're glad you want to help us make our platform even better, and we want to make that process as easy as possible.
 
-When contributing to this repository, please make sure you have followed the [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#). If you have any questions, please reach out to us on Slack.
+## What do I need first?
+
+Make sure you've followed our [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#) to get the DemocracyLab developer environment set up correctly.
+
+## Where's the best place to ask a question?
+
+Our [Slack](https://join.slack.com/t/democracylab-org/shared_invite/enQtMjQyNDMxOTY2NjA4LTU3MTYyM2EwYTRmMDYwNzUyNjg4YTk1NjEyZTg0ZjgxNzYwY2E5ODIyMTNjZGZkOTI5NTAyZTMwNTNiMWRiZTA). While you can submit an issue through Github, response time will be slower than asking in Slack. Depending on what your question is, try one of these channels:
+  - `#design` for anything related to the overall site design, UI, or user experience
+  - `#developers` for anything related to the function of the site or a given component, as well as technical assistance on contributing
+  - `#general` for anything else
+
 
 ## Pull Request Process
 
-1. Please make sure your PR includes the bundle.js created as part of the `npm run build` process. This file is required for changes to be deployed.
-2. When your pull request is submitted, another developer from the team will review it. All pull requests must be reviewed and approved prior to merging. If any changes are requested, those will be made through the Github review system.  
-3. ???
+1. Create a branch with `git checkout -b branchname` where the name is something descriptive about the issue your branch will fix, then make and test your changes if possible.
+2. Merge the latest version of master, to make sure your branch is up to date:
+  ```
+  git checkout master
+  git pull origin master
+  git checkout _<feature branch>_
+  git merge master
+  ```
+3. Resolve any merge conflicts if they exist, then test to make sure your feature branch still works correctly. Please make sure your PR includes the `bundle.js` file (it's required for deployment) and then `git push origin _<_feature branch>_`
+4. On Github, create a pull request from your feature branch. Make sure to summarize your changes you made, and if there's anything specific you want reviewed or tested, note that in the PR.
+5. Post in Slack (in `#developers`) that your PR is ready for review! All pull requests must be reviewed and approved prior to merging. If any changes are requested, those will be made through the Github review system.  
+6. When approved, your branch will be merged into master and you're done! Thanks for contributing! :)
+
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [hello@democracylab.org](hello@democracylab.org). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to DemocracyLab! We're glad you want to
 
 ## What do I need first?
 
-Make sure you've followed our [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#) to get the DemocracyLab developer environment set up correctly.
+Make sure you've followed our [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#) to get the DemocracyLab developer environment set up correctly. This guide will also tell you our process for creating and submitting a feature branch on Github.
 
 ## Where's the best place to ask a question?
 
@@ -16,8 +16,8 @@ Our [Slack](https://join.slack.com/t/democracylab-org/shared_invite/enQtMjQyNDMx
 
 ## Pull Request Process
 
-1. Create a branch with `git checkout -b branchname` where the name is something descriptive about the issue your branch will fix, then make and test your changes if possible.
-2. Merge the latest version of master, to make sure your branch is up to date:
+1. Create a branch with `git checkout -b branchname` where the name is something descriptive about the issue your branch will fix, then make your changes and test them to make sure they work.
+2. When you're ready to submit, merge the latest version of master, to make sure your branch is up to date:
   ```
   git checkout master
   git pull origin master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,13 @@ Our [Slack](https://join.slack.com/t/democracylab-org/shared_invite/enQtMjQyNDMx
 
 1. Create a branch with `git checkout -b branchname` where the name is something descriptive about the issue your branch will fix, then make your changes and test them to make sure they work.
 2. When you're ready to submit, merge the latest version of master, to make sure your branch is up to date:
-  ```
-  git checkout master
-  git pull origin master
-  git checkout _<feature branch>_
-  git merge master
-  ```
-3. Resolve any merge conflicts if they exist, then test to make sure your feature branch still works correctly. Please make sure your PR includes the `bundle.js` file (it's required for deployment) and then `git push origin _<_feature branch>_`
+    ```
+    git checkout master
+    git pull origin master
+    git checkout <feature branch>
+    git merge master
+    ```
+3. Resolve any merge conflicts if they exist, then test to make sure your feature branch still works correctly. Please make sure your PR includes the `bundle.js` file (it's required for deployment) and then `git push origin <feature branch>`
 4. On Github, create a pull request from your feature branch. Make sure to summarize your changes you made, and if there's anything specific you want reviewed or tested, note that in the PR.
 5. Post in Slack (in `#developers`) that your PR is ready for review! All pull requests must be reviewed and approved prior to merging. If any changes are requested, those will be made through the Github review system.  
 6. When approved, your branch will be merged into master and you're done! Thanks for contributing! :)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
 # CivicTechExchange
 
-.
+Welcome to DemocracyLab! DemocracyLab is creating an online hub for civic innovation that that will engage stakeholders by using marketplace dynamics to allocate effort, resources, and attention. The result will be an increase in participation, collaboration and transparency within the civic tech movement, and the evolution of new civic innovations capable of addressing society’s significant challenges.
+
+Our platform connects skilled volunteers with technology-for-good projects, resulting in better civic technologies, more active citizens, and more efficient institutions.
+
+
+## Getting Started
+
+DemocracyLab uses [https://www.volunteermatch.org/search/org1097749.jsp](VolunteerMatch) to list contributor positions we're specifically looking for, but we'd be glad to talk to you no matter what your skillset is. [mailto:hello@democracylab.org](Say hello)!
+
+DemocracyLab's [https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#](Contributor Guide) will get you up and running with a copy of our project for development and testing purposes. We encourage any contributors to follow the links in our Contributor Guide to join our Slack and take a look at our Trello board. Come talk to your fellow volunteers, get any help you need, and see what we're working on!
+
+## Built With
+
+* [React](https://reactjs.org) - Frontend framework
+* [Django](https://djangoproject.com) - Backend server
+* [Heroku](https://heroku.com) - Deployed host
+
+## Contributing
+
+Please read the Getting Started section of this README and our  [CONTRIBUTING.md](https://github.com/DemocracyLab/CivicTechExchange/blob/master/CONTRIBUTING.md) for details on the process for submitting pull requests to us.
+
+
+## Authors
+
+???
+
+## License
+
+???
+
+
+## Acknowledgments
+
+* **Billie Thompson** - *README and CONTRIBUTING templates* - [PurpleBooth](https://github.com/PurpleBooth)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Our platform connects skilled volunteers with technology-for-good projects, resu
 
 ## Getting Started
 
-DemocracyLab uses [VolunteerMatch](https://www.volunteermatch.org/search/org1097749.jsp) to list contributor positions we're specifically looking for, but we'd be glad to talk to you no matter what your skillset is. [Say hello](mailto:hello@democracylab.org)!
+First, [join our Slack](https://join.slack.com/t/democracylab-org/shared_invite/enQtMjQyNDMxOTY2NjA4LTU3MTYyM2EwYTRmMDYwNzUyNjg4YTk1NjEyZTg0ZjgxNzYwY2E5ODIyMTNjZGZkOTI5NTAyZTMwNTNiMWRiZTA)! We communicate and coordinate our work there. For developers, reach out in the `#developers` channel to @marlon-keating, engineering lead, and let us know you want to contribute. We'll get back to you as soon as we can.
 
-DemocracyLab's [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/) will get you up and running with a copy of our project for development and testing purposes. We encourage any contributors to follow the links in our Contributor Guide to join our Slack and take a look at our Trello board. Come talk to your fellow volunteers, get any help you need, and see what we're working on!
+Next, follow DemocracyLab's [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/). This guide will get you up and running with a copy of our project for development and testing purposes as quickly as possible. If you have questions, just put them in Slack and we'll get them sorted out.
 
 ## Built With
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# CivicTechExchange
+# Civic Tech Exchange
 
 Welcome to DemocracyLab! DemocracyLab is creating an online hub for civic innovation that that will engage stakeholders by using marketplace dynamics to allocate effort, resources, and attention. The result will be an increase in participation, collaboration and transparency within the civic tech movement, and the evolution of new civic innovations capable of addressing society’s significant challenges.
 
 Our platform connects skilled volunteers with technology-for-good projects, resulting in better civic technologies, more active citizens, and more efficient institutions.
-
 
 ## Getting Started
 
@@ -13,22 +12,13 @@ Next, follow DemocracyLab's [Contributor Guide](https://docs.google.com/document
 
 ## Built With
 
-* [React](https://reactjs.org) - Frontend framework
-* [Django](https://djangoproject.com) - Backend server
-* [Heroku](https://heroku.com) - Deployed host
+* [React](https://reactjs.org)
+* [Flux](https://facebook.github.io/flux/)
+* [Django](https://djangoproject.com)
 
 ## Contributing
 
-Please read the Getting Started section of this README and our  [CONTRIBUTING.md](https://github.com/DemocracyLab/CivicTechExchange/blob/master/CONTRIBUTING.md) for details on the process for submitting pull requests to us.
-
-
-## Authors
-
-???
-
-## License
-
-???
+Please read the Getting Started section of this README and our  [Contributing Guide](https://github.com/DemocracyLab/CivicTechExchange/blob/master/CONTRIBUTING.md) for details on the process for submitting pull requests to us.
 
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Our platform connects skilled volunteers with technology-for-good projects, resu
 
 ## Getting Started
 
-DemocracyLab uses [VolunteerMatch](https://www.volunteermatch.org/search/org1097749.jsp) to list contributor positions we're specifically looking for, but we'd be glad to talk to you no matter what your skillset is. [mailto:hello@democracylab.org](Say hello)!
+DemocracyLab uses [VolunteerMatch](https://www.volunteermatch.org/search/org1097749.jsp) to list contributor positions we're specifically looking for, but we'd be glad to talk to you no matter what your skillset is. [Say hello](mailto:hello@democracylab.org)!
 
 DemocracyLab's [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/) will get you up and running with a copy of our project for development and testing purposes. We encourage any contributors to follow the links in our Contributor Guide to join our Slack and take a look at our Trello board. Come talk to your fellow volunteers, get any help you need, and see what we're working on!
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Our platform connects skilled volunteers with technology-for-good projects, resu
 
 ## Getting Started
 
-DemocracyLab uses [https://www.volunteermatch.org/search/org1097749.jsp](VolunteerMatch) to list contributor positions we're specifically looking for, but we'd be glad to talk to you no matter what your skillset is. [mailto:hello@democracylab.org](Say hello)!
+DemocracyLab uses [VolunteerMatch](https://www.volunteermatch.org/search/org1097749.jsp) to list contributor positions we're specifically looking for, but we'd be glad to talk to you no matter what your skillset is. [mailto:hello@democracylab.org](Say hello)!
 
-DemocracyLab's [https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/edit#](Contributor Guide) will get you up and running with a copy of our project for development and testing purposes. We encourage any contributors to follow the links in our Contributor Guide to join our Slack and take a look at our Trello board. Come talk to your fellow volunteers, get any help you need, and see what we're working on!
+DemocracyLab's [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/) will get you up and running with a copy of our project for development and testing purposes. We encourage any contributors to follow the links in our Contributor Guide to join our Slack and take a look at our Trello board. Come talk to your fellow volunteers, get any help you need, and see what we're working on!
 
 ## Built With
 


### PR DESCRIPTION
This branch updates our readme and adds a contributor guide, resolving #73 for anyone who finds our project through Github instead of something like VolunteerMatch.

The goals we agreed on were to keep the readme fairly short and designed to get any potential developers into Slack and direct them to the Contributor Guide as quickly as possible. Please review/make any changes for clarity required.

The CONTRIBUTING.md is a more technical document on the Github PR process, which is in part a restatement of the contribution sections of the existing Contributor Guide on google docs. I don't know how much we should restate there vs direct people to the google doc, please review that also.

I also added a Code of Conduct to the contributor guide on Github (my template for this document had one) which should be approved by the project leads; I think it's a good idea to have one but I don't want to just unilaterally add it. 

