### PR TITLE
Remove empty filters and filter categories from DOM

### DIFF
--- a/civictechprojects/helpers/projects.py
+++ b/civictechprojects/helpers/projects.py
@@ -1,20 +1,25 @@
-from civictechprojects.models import ProjectPosition
+from civictechprojects.models import Project, ProjectPosition
 from common.helpers.dictionaries import merge_dicts
 from collections import Counter
+from pprint import pprint
 
-
-# Gets a breakdown of all issue/technology/position tags used in the given list of projects
-def projects_tag_counts(projects):
-    # Get list of all tags used
+def projects_tag_counts():
+    projects = Project.objects.all()
     issues, technologies, stage, organization, positions = [], [], [], [], []
-    for project in projects:
-        issues += project.project_issue_area.slugs()
-        technologies += project.project_technologies.slugs()
-        stage += project.project_stage.slugs()
-        organization += project.project_organization.slugs()
+    if projects:
+        for project in projects:
+            issues += project.project_issue_area.slugs()
+            technologies += project.project_technologies.slugs()
+            stage += project.project_stage.slugs()
+            organization += project.project_organization.slugs()
 
-        project_positions = ProjectPosition.objects.filter(position_project=project.id)
-        positions += map(lambda position: position.position_role.slugs()[0], project_positions)
+            project_positions = ProjectPosition.objects.filter(position_project=project.id)
+            positions += map(lambda position: position.position_role.slugs()[0], project_positions)
+            # Get the counts of all the tags used
+            
+        return merge_dicts(Counter(issues), Counter(technologies), Counter(stage), Counter(organization), Counter(positions))
 
-    # Get the counts of all the tags used
-    return merge_dicts(Counter(issues), Counter(technologies), Counter(stage), Counter(organization), Counter(positions))
+
+            # sc = Counter(k['tag_name'] for k in projects if k.get('tag_name'))
+            # sc = Counter(projects)
+            # return sc

--- a/civictechprojects/helpers/projects.py
+++ b/civictechprojects/helpers/projects.py
@@ -6,16 +6,15 @@ from collections import Counter
 # Gets a breakdown of all issue/technology/position tags used in the given list of projects
 def projects_tag_counts(projects):
     # Get list of all tags used
-    # TODO: Add project stage and communities
-    issues, technologies, positions = [], [], []
+    issues, technologies, stage, organization, positions = [], [], [], [], []
     for project in projects:
         issues += project.project_issue_area.slugs()
         technologies += project.project_technologies.slugs()
         stage += project.project_stage.slugs()
-        community += project.project_community.slugs()
+        organization += project.project_organization.slugs()
 
         project_positions = ProjectPosition.objects.filter(position_project=project.id)
         positions += map(lambda position: position.position_role.slugs()[0], project_positions)
 
     # Get the counts of all the tags used
-    return merge_dicts(Counter(issues), Counter(technologies), Counter(stage), Counter(community), Counter(positions))
+    return merge_dicts(Counter(issues), Counter(technologies), Counter(stage), Counter(organization), Counter(positions))

--- a/civictechprojects/helpers/projects.py
+++ b/civictechprojects/helpers/projects.py
@@ -1,7 +1,6 @@
 from civictechprojects.models import Project, ProjectPosition
 from common.helpers.dictionaries import merge_dicts
 from collections import Counter
-from pprint import pprint
 
 def projects_tag_counts():
     projects = Project.objects.all()
@@ -15,11 +14,5 @@ def projects_tag_counts():
 
             project_positions = ProjectPosition.objects.filter(position_project=project.id)
             positions += map(lambda position: position.position_role.slugs()[0], project_positions)
-            # Get the counts of all the tags used
-            
+
         return merge_dicts(Counter(issues), Counter(technologies), Counter(stage), Counter(organization), Counter(positions))
-
-
-            # sc = Counter(k['tag_name'] for k in projects if k.get('tag_name'))
-            # sc = Counter(projects)
-            # return sc

--- a/civictechprojects/helpers/projects.py
+++ b/civictechprojects/helpers/projects.py
@@ -6,13 +6,16 @@ from collections import Counter
 # Gets a breakdown of all issue/technology/position tags used in the given list of projects
 def projects_tag_counts(projects):
     # Get list of all tags used
+    # TODO: Add project stage and communities
     issues, technologies, positions = [], [], []
     for project in projects:
         issues += project.project_issue_area.slugs()
         technologies += project.project_technologies.slugs()
+        stage += project.project_stage.slugs()
+        community += project.project_community.slugs()
 
         project_positions = ProjectPosition.objects.filter(position_project=project.id)
         positions += map(lambda position: position.position_role.slugs()[0], project_positions)
 
     # Get the counts of all the tags used
-    return merge_dicts(Counter(issues), Counter(technologies), Counter(positions))
+    return merge_dicts(Counter(issues), Counter(technologies), Counter(stage), Counter(community), Counter(positions))

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -27,20 +27,20 @@ def tags(request):
     if 'category' in query_terms:
         category = query_terms.get('category')[0]
         queryset = get_tags_by_category(category)
-        tags = queryset.annotate(num_times=Count('category'))
-    else:
         activetagdict = projects_tag_counts()
-        queryset = Tag.objects.all()
         querydict = {tag.tag_name:tag for tag in queryset}
         resultdict = {}
 
         for slug in querydict.keys():
-            resultdict[slug] = activetagdict[slug] if slug in activetagdict else 0
-    
-        tags = queryset.annotate(num_times=Count('category'))
+            resultdict[slug] = Tag.hydrate_tag_model(querydict[slug])
+            resultdict[slug]['num_times'] = activetagdict[slug] if slug in activetagdict else 0
+        tags = resultdict
+    else:
+        queryset = Tag.objects.all()
+        tags = list(queryset.values())
     return HttpResponse(
         json.dumps(
-            list(tags.values())
+            tags
         )
     )
 

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -30,8 +30,8 @@ def tags(request):
         queryset = get_tags_by_category(category)
         tags = queryset.annotate(num_times=Count('category'))
     else:
-        queryset = Tag.objects
         #TOFIX as above, not correct but unblocks front end
+        queryset = Tag.objects
         tags = queryset.annotate(num_times=Count('category'))
     return HttpResponse(
         json.dumps(

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -18,8 +18,6 @@ from .forms import ProjectCreationForm
 from democracylab.models import Contributor, get_request_contributor
 from common.models.tags import Tag
 
-from pprint import pprint
-
 def tags(request):
     url_parts = request.GET.urlencode()
     query_terms = urlparse.parse_qs(

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -26,12 +26,20 @@ def tags(request):
         url_parts, keep_blank_values=0, strict_parsing=0)
     if 'category' in query_terms:
         category = query_terms.get('category')[0]
-        #TOFIX this returns 1 every time because it's counting the wrong thing. It needs to count projects and annotate tags, not count tags/annotate tags.
         queryset = get_tags_by_category(category)
         tags = queryset.annotate(num_times=Count('category'))
     else:
-        #TOFIX as above, not correct but unblocks front end
-        queryset = Tag.objects
+        activetagdict = projects_tag_counts()
+        queryset = Tag.objects.all()
+        querydict = {tag.tag_name:tag for tag in queryset}
+        resultdict = {}
+
+        for slug in querydict.keys():
+            resultdict[slug] = activetagdict[slug] or '0'
+        pprint(resultdict)
+
+        #use resultdict value to populate num_times in tagset
+
         tags = queryset.annotate(num_times=Count('category'))
     return HttpResponse(
         json.dumps(
@@ -51,7 +59,6 @@ def to_rows(items, width):
             rows.append([])
             row_number += 1
     return rows
-
 
 def to_tag_map(tags):
     tag_map = ((tag.tag_name, tag.display_name) for tag in tags)

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -35,11 +35,8 @@ def tags(request):
         resultdict = {}
 
         for slug in querydict.keys():
-            resultdict[slug] = activetagdict[slug] or '0'
-        pprint(resultdict)
-
-        #use resultdict value to populate num_times in tagset
-
+            resultdict[slug] = activetagdict[slug] if slug in activetagdict else 0
+    
         tags = queryset.annotate(num_times=Count('category'))
     return HttpResponse(
         json.dumps(

--- a/common/components/common/selection/SelectorCollapsible.jsx
+++ b/common/components/common/selection/SelectorCollapsible.jsx
@@ -65,10 +65,17 @@ class SelectorCollapsible<T> extends React.PureComponent<Props<T>, State> {
 
   initializeOptions(props: Props) {
     if(!_.isEmpty(props.options)) {
-      if(props.optionCategory && _.some(props.options, props.optionCategory)) {
-        return {optionCategoryTree:_.groupBy(props.options, props.optionCategory)};
+
+      let filteredOptions = Object.keys(props.options).filter(function(key) {
+        return props.options[key]['num_times'] > 0;
+      }).map(function(key) {
+        return props.options[key]
+      });
+
+      if(props.optionCategory && _.some(filteredOptions, props.optionCategory)) {
+        return {optionCategoryTree:_.groupBy(filteredOptions, props.optionCategory)};
       } else {
-        return {optionFlatList: props.options};
+        return {optionFlatList: filteredOptions};
       }
     }
   }
@@ -116,13 +123,13 @@ class SelectorCollapsible<T> extends React.PureComponent<Props<T>, State> {
 
     return sortedOptions.map( (option, i) => {
       const classes = "CollapsibleMenuItem"
-      if (option.num_times > 0) { return <label
+      // to filter just entries and not category headers, use  if (option.num_times > 0) { return ... }
+      return <label
         key={i}
         className={classes}
         ><input type="checkbox" checked={this.props.optionEnabled(option)} onChange={() => this.selectOption(option)}></input>
         {this.props.optionDisplay(option)} ({option.num_times})
       </label>
-    }
     });
   }
 

--- a/common/components/common/selection/SelectorCollapsible.jsx
+++ b/common/components/common/selection/SelectorCollapsible.jsx
@@ -116,12 +116,13 @@ class SelectorCollapsible<T> extends React.PureComponent<Props<T>, State> {
 
     return sortedOptions.map( (option, i) => {
       const classes = "CollapsibleMenuItem"
-      return <label
+      if (option.num_times > 0) { return <label
         key={i}
         className={classes}
         ><input type="checkbox" checked={this.props.optionEnabled(option)} onChange={() => this.selectOption(option)}></input>
-        {this.props.optionDisplay(option)} ({option.num_times}) //not sure if I want to handle conditional render here or in TagSelectorCollapsible. if here, chain .filter() on map or use react conditional if options.num_times > 0
+        {this.props.optionDisplay(option)} ({option.num_times})
       </label>
+    }
     });
   }
 

--- a/common/components/common/selection/SelectorCollapsible.jsx
+++ b/common/components/common/selection/SelectorCollapsible.jsx
@@ -120,7 +120,7 @@ class SelectorCollapsible<T> extends React.PureComponent<Props<T>, State> {
         key={i}
         className={classes}
         ><input type="checkbox" checked={this.props.optionEnabled(option)} onChange={() => this.selectOption(option)}></input>
-        {this.props.optionDisplay(option)}
+        {this.props.optionDisplay(option)} ({option.num_times}) //not sure if I want to handle conditional render here or in TagSelectorCollapsible. if here, chain .filter() on map or use react conditional if options.num_times > 0
       </label>
     });
   }

--- a/common/components/common/tags/TagSelectorCollapsible.jsx
+++ b/common/components/common/tags/TagSelectorCollapsible.jsx
@@ -80,7 +80,7 @@ class TagSelectorCollapsible extends React.Component<Props, State> {
           ? (
             <SelectorCollapsible
               title={this.props.title}
-              options={this.state.tags}
+              options={this.state.tags} //maybe pull out options.num_times directly and pass as prop?
               optionCategory={this.state.hasSubcategories && (tag => tag.subcategory)}
               optionDisplay={tag => this._displayTag(tag)}
               optionEnabled={tag => this._tagEnabled(tag)}

--- a/common/models/tags.py
+++ b/common/models/tags.py
@@ -30,15 +30,19 @@ class Tag(models.Model):
         # TODO: Remove project id from this if we don't end up using it
         tags = map(lambda tag_slug: Tag.get_by_name(tag_slug['slug']), tag_entries)
         existing_tags = filter(lambda tag: tag is not None, tags)
-        hydrated_tags = list(map(lambda tag: {
+        hydrated_tags = list(map(hydrate_tag_model, existing_tags))
+        return hydrated_tags
+
+    @staticmethod
+    def hydrate_tag_model():
+         tag = {
             'id': project_id,
             'display_name': tag.display_name,
             'tag_name': tag.tag_name,
             'caption': tag.caption,
             'category': tag.category,
             'subcategory': tag.subcategory,
-            'parent': tag.parent}, existing_tags))
-        return hydrated_tags
+            'parent': tag.parent}
 
     @staticmethod
     def merge_tags_field(tags_field, tag_entries):

--- a/common/models/tags.py
+++ b/common/models/tags.py
@@ -30,13 +30,12 @@ class Tag(models.Model):
         # TODO: Remove project id from this if we don't end up using it
         tags = map(lambda tag_slug: Tag.get_by_name(tag_slug['slug']), tag_entries)
         existing_tags = filter(lambda tag: tag is not None, tags)
-        hydrated_tags = list(map(hydrate_tag_model, existing_tags))
+        hydrated_tags = list(map(lambda tag: Tag.hydrate_tag_model(tag), existing_tags))
         return hydrated_tags
 
     @staticmethod
-    def hydrate_tag_model():
-         tag = {
-            'id': project_id,
+    def hydrate_tag_model(tag):
+        return {
             'display_name': tag.display_name,
             'tag_name': tag.tag_name,
             'caption': tag.caption,

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -78975,10 +78975,17 @@ var SelectorCollapsible = function (_React$PureComponent) {
     key: 'initializeOptions',
     value: function initializeOptions(props) {
       if (!__WEBPACK_IMPORTED_MODULE_2_lodash___default.a.isEmpty(props.options)) {
-        if (props.optionCategory && __WEBPACK_IMPORTED_MODULE_2_lodash___default.a.some(props.options, props.optionCategory)) {
-          return { optionCategoryTree: __WEBPACK_IMPORTED_MODULE_2_lodash___default.a.groupBy(props.options, props.optionCategory) };
+
+        var filteredOptions = Object.keys(props.options).filter(function (key) {
+          return props.options[key]['num_times'] > 0;
+        }).map(function (key) {
+          return props.options[key];
+        });
+
+        if (props.optionCategory && __WEBPACK_IMPORTED_MODULE_2_lodash___default.a.some(filteredOptions, props.optionCategory)) {
+          return { optionCategoryTree: __WEBPACK_IMPORTED_MODULE_2_lodash___default.a.groupBy(filteredOptions, props.optionCategory) };
         } else {
-          return { optionFlatList: props.options };
+          return { optionFlatList: filteredOptions };
         }
       }
     }
@@ -79043,22 +79050,21 @@ var SelectorCollapsible = function (_React$PureComponent) {
 
       return sortedOptions.map(function (option, i) {
         var classes = "CollapsibleMenuItem";
-        if (option.num_times > 0) {
-          return __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement(
-            'label',
-            {
-              key: i,
-              className: classes
-            },
-            __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement('input', { type: 'checkbox', checked: _this3.props.optionEnabled(option), onChange: function onChange() {
-                return _this3.selectOption(option);
-              } }),
-            _this3.props.optionDisplay(option),
-            ' (',
-            option.num_times,
-            ')'
-          );
-        }
+        // to filter just entries and not category headers, use  if (option.num_times > 0) { return ... }
+        return __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement(
+          'label',
+          {
+            key: i,
+            className: classes
+          },
+          __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement('input', { type: 'checkbox', checked: _this3.props.optionEnabled(option), onChange: function onChange() {
+              return _this3.selectOption(option);
+            } }),
+          _this3.props.optionDisplay(option),
+          ' (',
+          option.num_times,
+          ')'
+        );
       });
     }
   }, {

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -39192,13 +39192,6 @@ var LogInController = function (_React$Component) {
               disabled: !this.state.username || !this.state.password,
               type: 'submit' },
             'Sign In'
-          ),
-          __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement(
-            'div',
-            {
-              name: 'error',
-              type: 'text' },
-            this.state.messages
           )
         )
       );
@@ -79059,7 +79052,10 @@ var SelectorCollapsible = function (_React$PureComponent) {
           __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement('input', { type: 'checkbox', checked: _this3.props.optionEnabled(option), onChange: function onChange() {
               return _this3.selectOption(option);
             } }),
-          _this3.props.optionDisplay(option)
+          _this3.props.optionDisplay(option),
+          ' (',
+          option.num_times,
+          ')'
         );
       });
     }

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -78863,8 +78863,8 @@ var TagSelectorCollapsible = function (_React$Component) {
         null,
         this.state.tags ? __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(__WEBPACK_IMPORTED_MODULE_3__selection_SelectorCollapsible_jsx__["a" /* default */], {
           title: this.props.title,
-          options: this.state.tags,
-          optionCategory: this.state.hasSubcategories && function (tag) {
+          options: this.state.tags //maybe pull out options.num_times directly and pass as prop?
+          , optionCategory: this.state.hasSubcategories && function (tag) {
             return tag.subcategory;
           },
           optionDisplay: function optionDisplay(tag) {
@@ -79043,20 +79043,22 @@ var SelectorCollapsible = function (_React$PureComponent) {
 
       return sortedOptions.map(function (option, i) {
         var classes = "CollapsibleMenuItem";
-        return __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement(
-          'label',
-          {
-            key: i,
-            className: classes
-          },
-          __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement('input', { type: 'checkbox', checked: _this3.props.optionEnabled(option), onChange: function onChange() {
-              return _this3.selectOption(option);
-            } }),
-          _this3.props.optionDisplay(option),
-          ' (',
-          option.num_times,
-          ')'
-        );
+        if (option.num_times > 0) {
+          return __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement(
+            'label',
+            {
+              key: i,
+              className: classes
+            },
+            __WEBPACK_IMPORTED_MODULE_1_react___default.a.createElement('input', { type: 'checkbox', checked: _this3.props.optionEnabled(option), onChange: function onChange() {
+                return _this3.selectOption(option);
+              } }),
+            _this3.props.optionDisplay(option),
+            ' (',
+            option.num_times,
+            ')'
+          );
+        }
       });
     }
   }, {


### PR DESCRIPTION
This PR is composed of two major parts. The first, in views.py and helpers/projects.py, uses the tag model and the projects model to create a new `num_times` value passed to the front end with every API request for a category of tags. This num_times value represents the number of projects which have that tag, i.e. how many projects will display to the user if a given filter is checked.

On the front end, num_times is used in two ways. Simplest is that this value is shown to the user: If Python is tagged in 5 projects, the Python filter will read `Python (5)`. 

It is also used to remove empty filters from the filter component entirely. Some previous commits in this branch removed empty filters fairly late in the process of generating the filters so empty categories would show up where I didn't want them - they were initialized before I removed empty filters. By changing where I remove empty filters to the very start of SelectorCollapsible's `initializeOptions` function this problem is avoided.

To test: 
load Find Projects page and expand all filter categories. All categories shown should have at least one entry in them. All entries shown should have a parenthetical number of >=1. If an entry reads 5, selecting that filter should return 5 projects.

Adding or removing a project's tags should result in numbers updating and filters appearing/disappearing as appropriate.

*Known Issue:*
Filtering via a saved querystring, i.e. pasting localhost:8000/index/?section=FindProjects&issues=public-safety into your browser and submitting, does not work. I get an exception error in console from the flux project store. Any ideas on that?



