### PR TITLE
add placeholder 'http' to 'link to description' form field

### DIFF
--- a/common/components/forms/PositionEntryModal.jsx
+++ b/common/components/forms/PositionEntryModal.jsx
@@ -106,7 +106,7 @@ class PositionEntryModal extends React.PureComponent<Props,State> {
 
                 <div className="form-group">
                   <label htmlFor="link-position-description">Link to Description <span className="modal-hint"><a href="https://docs.google.com/document/d/142NH4uRblJP6XvKdmW4GiFwoOmVWY6BJfEjGrlSP3Uk/edit" rel="noopener noreferrer" target="_blank">(Example template)</a></span></label>
-                  <input type="text" className="form-control" id="link-position-description" maxLength="2075" value={this.state.positionInfo.descriptionUrl} onChange={this.onDescriptionChange.bind(this)}/>
+                  <input type="text" className="form-control" id="link-position-description" maxLength="2075" value={this.state.positionInfo.descriptionUrl} onChange={this.onDescriptionChange.bind(this)} placeholder="http://"/>
                 </div>
               </Modal.Body>
               <Modal.Footer>

--- a/common/static/js/bundle.js
+++ b/common/static/js/bundle.js
@@ -93855,7 +93855,7 @@ var PositionEntryModal = function (_React$PureComponent) {
                   )
                 )
               ),
-              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement('input', { type: 'text', className: 'form-control', id: 'link-position-description', maxLength: '2075', value: this.state.positionInfo.descriptionUrl, onChange: this.onDescriptionChange.bind(this) })
+              __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement('input', { type: 'text', className: 'form-control', id: 'link-position-description', maxLength: '2075', value: this.state.positionInfo.descriptionUrl, onChange: this.onDescriptionChange.bind(this), placeholder: 'http://' })
             )
           ),
           __WEBPACK_IMPORTED_MODULE_0_react___default.a.createElement(


### PR DESCRIPTION
I added a placeholder string to the form field.  Not sure if, instead, the spec is asking for the "http://" to be appended via javascript to the form field value: https://trello.com/c/Vo5mm42C/82-add-http-prefix-to-position-url-field