### PR TITLE
Add error logging for exceptions

### DIFF
--- a/democracylab/logging.py
+++ b/democracylab/logging.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import traceback
 
@@ -18,14 +19,13 @@ sensitive_fields = ['password', 'password1', 'password2']
 
 
 def censor_sensitive_fields(fields_dict):
+    fields_copy = copy.deepcopy(fields_dict)
     for field in sensitive_fields:
-        if field in fields_dict:
-            censored_length = len(fields_dict[field][0])
-            print(fields_dict[field])
-            print(censored_length)
-            fields_dict[field][0] = '*' * censored_length
+        if field in fields_copy:
+            censored_length = len(fields_copy[field][0])
+            fields_copy[field][0] = '*' * censored_length
 
-    return fields_dict
+    return fields_copy
 
 
 class CustomErrorHandler(logging.Handler):

--- a/democracylab/logging.py
+++ b/democracylab/logging.py
@@ -1,0 +1,35 @@
+import logging
+import traceback
+
+
+def dump(obj):
+    for attr in dir(obj):
+        print("obj.%s = %r" % (attr, getattr(obj, attr)))
+
+
+def dump_request_summary(request):
+    user = request.user.username if request.user.is_authenticated() else ''
+    url = request.path
+    method = request.method
+    body = censor_sensitive_fields(dict(getattr(request, method)))
+    return '({user}) {method} {url} {body}'.format(user=user, url=url, method=method, body=body)
+
+sensitive_fields = ['password', 'password1', 'password2']
+
+
+def censor_sensitive_fields(fields_dict):
+    for field in sensitive_fields:
+        if field in fields_dict:
+            censored_length = len(fields_dict[field][0])
+            print(fields_dict[field])
+            print(censored_length)
+            fields_dict[field][0] = '*' * censored_length
+
+    return fields_dict
+
+
+class CustomErrorHandler(logging.Handler):
+    def emit(self, record):
+        exception_info = traceback.format_exc()
+        request_info = dump_request_summary(record.request)
+        print('ERROR: {exception_info} REQUEST: {request_info}'.format(exception_info=exception_info, request_info=request_info))

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 import os
 import dj_database_url
 from distutils.util import strtobool
+# from .logging import CustomErrorHandler
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -166,3 +167,26 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'staticfiles')
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'handlers': {
+        'custom_error_handler': {
+            'class': 'democracylab.logging.CustomErrorHandler'
+        }
+    },
+    'loggers': {
+        # Override global logger
+        '': {
+            'handlers': ['custom_error_handler'],
+            'level': 'ERROR',
+            'propagate': True
+        },
+    },
+}

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 import os
 import dj_database_url
 from distutils.util import strtobool
-# from .logging import CustomErrorHandler
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/democracylab/views.py
+++ b/democracylab/views.py
@@ -30,9 +30,6 @@ def signup(request):
         form = DemocracyLabUserCreationForm(request.POST)
         if form.is_valid():
             email = form.cleaned_data.get('email')
-            # TODO: Remove this test line
-            if email == 'crash@me.plz':
-                x = 1/0
             raw_password = form.cleaned_data.get('password1')
             # TODO: Form validation
             contributor = Contributor(

--- a/democracylab/views.py
+++ b/democracylab/views.py
@@ -30,6 +30,9 @@ def signup(request):
         form = DemocracyLabUserCreationForm(request.POST)
         if form.is_valid():
             email = form.cleaned_data.get('email')
+            # TODO: Remove this test line
+            if email == 'crash@me.plz':
+                x = 1/0
             raw_password = form.cleaned_data.get('password1')
             # TODO: Form validation
             contributor = Contributor(


### PR DESCRIPTION
We're not currently recording all the information necessary to debug exceptions that happen in production.  We will now log stack traces and arguments for any requests where exceptions happen.