### PR TITLE
Bug Fix: Error 500 when submitting profile without resume

### DIFF
--- a/common/helpers/form_helpers.py
+++ b/common/helpers/form_helpers.py
@@ -1,0 +1,5 @@
+def is_json_field_empty(field_json):
+    if isinstance(field_json, dict):
+        return len(field_json.keys()) == 0
+    else:
+        return len(field_json) == 0


### PR DESCRIPTION
We weren't handling the case when a user didn't submit a resume when saving their profile changes, which led to an Error 500 page.