### PR TITLE
Handle empty file content when replacing single file pt.2

### DIFF
--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -286,10 +286,11 @@ class ProjectFile(models.Model):
         else:
             existing_file = ProjectFile.objects.filter(file_user=owner.id, file_category=file_category.value).first()
 
-        if is_json_field_empty(file_json) and existing_file:
+        is_empty_field = is_json_field_empty(file_json)
+        if is_empty_field and existing_file:
             # Remove existing file
             existing_file.delete()
-        else:
+        elif not is_empty_field:
             if not existing_file:
                 # Add new file
                 thumbnail = ProjectFile.from_json(owner, file_category, file_json)


### PR DESCRIPTION
We weren't handling the case when a user didn't submit a resume when saving their profile changes, which led to an Error 500 page.

The first iteration of the fix missed a scenario where we were creating a new file.