### PR TITLE
Backend to return only necessary fields when listing projects

### DIFF
--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -88,6 +88,30 @@ class Project(models.Model):
 
         return project
 
+    def hydrate_to_tile_json(self):
+        files = ProjectFile.objects.filter(file_project=self.id)
+        thumbnail_files = list(files.filter(file_category=FileCategory.THUMBNAIL.value))
+        positions = ProjectPosition.objects.filter(position_project=self.id)
+
+        project = {
+            'project_id': self.id,
+            'project_name': self.project_name,
+            'project_creator': self.project_creator.id,
+            'project_claimed': not self.project_creator.is_admin_contributor(),
+            'project_description': self.project_description,
+            'project_url': self.project_url,
+            'project_location': self.project_location,
+            'project_issue_area': Tag.hydrate_to_json(self.id, list(self.project_issue_area.all().values())),
+            'project_stage': Tag.hydrate_to_json(self.id, list(self.project_stage.all().values())),
+            'project_positions': list(map(lambda position: position.to_json(), positions)),
+            'project_date_modified': self.project_date_modified.__str__()
+        }
+
+        if len(thumbnail_files) > 0:
+            project['project_thumbnail'] = thumbnail_files[0].to_json()
+
+        return project
+
 
 class ProjectLink(models.Model):
     # TODO: Add ForeignKey pointing to Contributor, see https://stackoverflow.com/a/20935513/6326903

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -157,7 +157,7 @@ def add_alert(request):
 def my_projects(request):
     projects = Project.objects.filter(project_creator_id=request.user.id)
     return HttpResponse(json.dumps([
-        project.hydrate_to_json() for project in projects
+        project.hydrate_to_tile_json() for project in projects
     ]))
 
 
@@ -239,7 +239,7 @@ def projects_by_roles(tags):
 
 def projects_with_filter_counts(projects):
     return {
-        'projects': [project.hydrate_to_json() for project in projects],
+        'projects': [project.hydrate_to_tile_json() for project in projects],
         'tags': list(Tag.objects.values())
     }
 


### PR DESCRIPTION
Currently when listing projects, the backend returns data that isn't displayed by the project tiles, wasting processing time and bandwidth.  This forks the project hydration code to only hydrate the necessary fields for listing projects on the Find Projects and My Projects pages.