### PR TITLE
Remove keys to deprecated S3 bucket

### DIFF
--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -1,7 +1,7 @@
 # S3 bucket and credentials for uploading files
-export AWS_ACCESS_KEY_ID=AKIAIU6OWKO72U5V3TUA
-export AWS_SECRET_ACCESS_KEY=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
-export S3_BUCKET=democracylab-marlok
+#export AWS_ACCESS_KEY_ID=ASK
+#export AWS_SECRET_ACCESS_KEY=ASK
+#export S3_BUCKET=ASK
 
 # Password for account used to send email
 export EMAIL_HOST_PASSWORD=betterDemocracyViaTechnology


### PR DESCRIPTION
We exposed credentials for our S3 buckets in the example environment variables file some time back, which is a security risk (which could have allowed an attacker to delete files, or flood the bucket with junk). That key has been deprecated, but we're removing it from the file to indicate to people they need to ask for credentials privately.