### PR TITLE
Only send two reminder emails and make it configurable

### DIFF
--- a/common/management/commands/emailreminders.py
+++ b/common/management/commands/emailreminders.py
@@ -3,10 +3,6 @@ from django.utils import timezone
 from django.conf import settings
 from democracylab.emails import send_volunteer_application_email
 
-# TODO: Make this configurable
-# This array specifies how many days we should space our reminder emails.  In this case, the first reminder comes after
-# two days, and then repeats every seven days
-
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
@@ -21,9 +17,9 @@ class Command(BaseCommand):
 
 
 def time_for_reminder(volunteer):
-    reminder_interval_days = settings.APPLICATION_REMINDER_PERIODS or [2, 7]
+    reminder_interval_days = settings.APPLICATION_REMINDER_PERIODS or [2, 7, -1]
 
     time_of_application_or_reminder = volunteer.last_reminder_date or volunteer.application_date
     days_since_last_reminder = (timezone.now() - time_of_application_or_reminder).days
     days_to_next_reminder = reminder_interval_days[min(volunteer.reminder_count, len(reminder_interval_days) - 1)]
-    return days_since_last_reminder >= days_to_next_reminder
+    return (days_to_next_reminder > 0) and (days_since_last_reminder >= days_to_next_reminder)

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -30,8 +30,10 @@ export POSITION_DESCRIPTION_EXAMPLE_URL='https://docs.google.com/document/d/142N
 # If True, emails won't be sent to their recipients, but to the ADMIN_EMAIL address (with metadata for debugging)
 export FAKE_EMAILS=True
 
-export AWS_ACCESS_KEY_ID=AKIAIU6OWKO72U5V3TUA
-export AWS_SECRET_ACCESS_KEY=+Ez0xciQwssORjrRcLKqAPt4BitmfuPjidAFa92m
+# This array specifies how many days we should space our reminder emails.  In this case, the first reminder comes after
+# two days, the second after seven days, and none after that
+export APPLICATION_REMINDER_PERIODS='[2,7,-1]'
+
 export S3_BUCKET=democracylab-marlok
 export EMAIL_HOST_PASSWORD=betterDemocracyViaTechnology
 


### PR DESCRIPTION
We want to be able to stop sending volunteer application reminders after two emails.  To facilitate that, this change adds a configuration option to terminate the APPLICATION_REMINDER_PERIODS configuration with a '-1', which will prevent from sending any reminder emails after that point..

Our new configuration is [2,7,-1], which configures our system to send reminders once after 2 days, once after 7 days, and no more.