### PR TITLE
Configure separate email accounts for support and volunteering

### DIFF
--- a/democracylab/emails.py
+++ b/democracylab/emails.py
@@ -67,7 +67,9 @@ def send_volunteer_application_email(volunteer_relation, is_reminder=False):
 
 
 def send_email(email_msg):
+    # TODO: Pass in email account we want to use
     if not settings.FAKE_EMAILS:
+        email_msg.connection = settings.EMAIL_SUPPORT_ACCT
         email_msg.send()
     else:
         test_email_subject = 'TEST EMAIL: ' + email_msg.subject
@@ -84,3 +86,6 @@ def send_email(email_msg):
             to=[settings.ADMIN_EMAIL]
         )
         test_email_msg.send()
+
+
+

--- a/democracylab/emails.py
+++ b/democracylab/emails.py
@@ -34,10 +34,10 @@ def send_password_reset_email(contributor):
     print(reset_url)
     # Send email with token
     email_msg = EmailMessage(
-        'DemocracyLab Password Reset',
-        'Click here to change your password: ' + reset_url,
-        settings.EMAIL_SUPPORT_ACCT['from_name'],
-        [contributor.email]
+        subject='DemocracyLab Password Reset',
+        body='Click here to change your password: ' + reset_url,
+        from_email=settings.EMAIL_SUPPORT_ACCT['from_name'],
+        to=[contributor.email]
     )
     send_email(email_msg, settings.EMAIL_SUPPORT_ACCT)
 
@@ -45,16 +45,16 @@ def send_password_reset_email(contributor):
 def send_project_creation_notification(project):
     project_url = settings.PROTOCOL_DOMAIN + '/index/?section=AboutProject&id=' + str(project.id)
     email_msg = EmailMessage(
-        'New DemocracyLab Project: ' + project.project_name,
-        '{first_name} {last_name}({email}) has created the project "{project_name}": \n {project_url}'.format(
+        subject='New DemocracyLab Project: ' + project.project_name,
+        body='{first_name} {last_name}({email}) has created the project "{project_name}": \n {project_url}'.format(
             first_name=project.project_creator.first_name,
             last_name=project.project_creator.last_name,
             email=project.project_creator.email,
             project_name=project.project_name,
             project_url=project_url
         ),
-        settings.DEFAULT_FROM_EMAIL,
-        [settings.ADMIN_EMAIL]
+        from_email=settings.EMAIL_SUPPORT_ACCT['from_name'],
+        to=[settings.ADMIN_EMAIL]
     )
     send_email(email_msg, settings.EMAIL_SUPPORT_ACCT)
 
@@ -105,8 +105,9 @@ def send_volunteer_application_email(volunteer_relation, is_reminder=False):
 
 
 def send_email(email_msg, email_acct=None):
+    connection = email_acct['connection'] if email_acct else settings.EMAIL_SUPPORT_ACCT['connection']
     if not settings.FAKE_EMAILS:
-        email_msg.connection = email_acct['connection'] if email_acct else settings.EMAIL_SUPPORT_ACCT['connection']
+        email_msg.connection = connection
         email_msg.send()
     else:
         test_email_subject = 'TEST EMAIL: ' + email_msg.subject
@@ -119,9 +120,9 @@ def send_email(email_msg, email_acct=None):
         test_email_msg = EmailMessage(
             subject=test_email_subject,
             body=test_email_body,
-            from_email=settings.EMAIL_HOST_USER,
             to=[settings.ADMIN_EMAIL]
         )
+        test_email_msg.connection = connection
         test_email_msg.send()
 
 

--- a/democracylab/emails.py
+++ b/democracylab/emails.py
@@ -17,7 +17,7 @@ def send_verification_email(contributor):
     email_msg = EmailMessage(
         'Welcome to DemocracyLab',
         'Click here to confirm your email address (or paste into your browser): ' + verification_url,
-        settings.EMAIL_HOST_USER,
+        settings.EMAIL_SUPPORT_ACCT['from_name'],
         [contributor.email]
     )
     send_email(email_msg, settings.EMAIL_SUPPORT_ACCT)
@@ -36,7 +36,7 @@ def send_password_reset_email(contributor):
     email_msg = EmailMessage(
         'DemocracyLab Password Reset',
         'Click here to change your password: ' + reset_url,
-        settings.EMAIL_HOST_USER,
+        settings.EMAIL_SUPPORT_ACCT['from_name'],
         [contributor.email]
     )
     send_email(email_msg, settings.EMAIL_SUPPORT_ACCT)
@@ -65,7 +65,7 @@ def send_to_project_owners(project, sender, subject, body):
     email_msg = EmailMessage(
         subject=subject,
         body=body,
-        from_email=settings.EMAIL_HOST_USER,
+        from_email=settings.EMAIL_VOLUNTEER_ACCT['from_name'],
         to=[project.project_creator.email] + co_owner_emails,
         reply_to=[sender.email]
     )
@@ -78,7 +78,7 @@ def send_to_project_volunteer(volunteer_relation, subject, body):
     email_msg = EmailMessage(
         subject=subject,
         body=body,
-        from_email=settings.EMAIL_HOST_USER,
+        from_email=settings.EMAIL_VOLUNTEER_ACCT['from_name'],
         to=[volunteer_relation.volunteer.email],
         reply_to=[volunteer_relation.project.project_creator.email] + co_owner_emails,
     )
@@ -106,7 +106,7 @@ def send_volunteer_application_email(volunteer_relation, is_reminder=False):
 
 def send_email(email_msg, email_acct=None):
     if not settings.FAKE_EMAILS:
-        email_msg.connection = email_acct or settings.EMAIL_SUPPORT_ACCT
+        email_msg.connection = email_acct['connection'] if email_acct else settings.EMAIL_SUPPORT_ACCT['connection']
         email_msg.send()
     else:
         test_email_subject = 'TEST EMAIL: ' + email_msg.subject
@@ -123,6 +123,5 @@ def send_email(email_msg, email_acct=None):
             to=[settings.ADMIN_EMAIL]
         )
         test_email_msg.send()
-
 
 

--- a/democracylab/emails.py
+++ b/democracylab/emails.py
@@ -17,7 +17,7 @@ def send_verification_email(contributor):
     email_msg = EmailMessage(
         'Welcome to DemocracyLab',
         'Click here to confirm your email address (or paste into your browser): ' + verification_url,
-        settings.EMAIL_SUPPORT_ACCT['from_name'],
+        _get_account_from_email(settings.EMAIL_SUPPORT_ACCT),
         [contributor.email]
     )
     send_email(email_msg, settings.EMAIL_SUPPORT_ACCT)
@@ -36,7 +36,7 @@ def send_password_reset_email(contributor):
     email_msg = EmailMessage(
         subject='DemocracyLab Password Reset',
         body='Click here to change your password: ' + reset_url,
-        from_email=settings.EMAIL_SUPPORT_ACCT['from_name'],
+        from_email=_get_account_from_email(settings.EMAIL_SUPPORT_ACCT),
         to=[contributor.email]
     )
     send_email(email_msg, settings.EMAIL_SUPPORT_ACCT)
@@ -53,7 +53,7 @@ def send_project_creation_notification(project):
             project_name=project.project_name,
             project_url=project_url
         ),
-        from_email=settings.EMAIL_SUPPORT_ACCT['from_name'],
+        from_email=_get_account_from_email(settings.EMAIL_SUPPORT_ACCT),
         to=[settings.ADMIN_EMAIL]
     )
     send_email(email_msg, settings.EMAIL_SUPPORT_ACCT)
@@ -65,7 +65,7 @@ def send_to_project_owners(project, sender, subject, body):
     email_msg = EmailMessage(
         subject=subject,
         body=body,
-        from_email=settings.EMAIL_VOLUNTEER_ACCT['from_name'],
+        from_email=_get_account_from_email(settings.EMAIL_VOLUNTEER_ACCT),
         to=[project.project_creator.email] + co_owner_emails,
         reply_to=[sender.email]
     )
@@ -105,9 +105,8 @@ def send_volunteer_application_email(volunteer_relation, is_reminder=False):
 
 
 def send_email(email_msg, email_acct=None):
-    connection = email_acct['connection'] if email_acct else settings.EMAIL_SUPPORT_ACCT['connection']
     if not settings.FAKE_EMAILS:
-        email_msg.connection = connection
+        email_msg.connection = email_acct['connection'] if email_acct is not None else settings.EMAIL_SUPPORT_ACCT['connection']
         email_msg.send()
     else:
         test_email_subject = 'TEST EMAIL: ' + email_msg.subject
@@ -122,7 +121,8 @@ def send_email(email_msg, email_acct=None):
             body=test_email_body,
             to=[settings.ADMIN_EMAIL]
         )
-        test_email_msg.connection = connection
         test_email_msg.send()
 
 
+def _get_account_from_email(email_acct):
+    return email_acct['from_name'] if email_acct is not None else 'DemocracyLab'

--- a/democracylab/models.py
+++ b/democracylab/models.py
@@ -1,10 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
-from django.core.mail import EmailMessage
-from django.contrib.auth.tokens import default_token_generator
-from common.helpers.constants import FrontEndSection
-from common.helpers.front_end import section_url
 from common.models.tags import Tag
 from taggit.managers import TaggableManager
 from taggit.models import TaggedItemBase
@@ -32,38 +28,6 @@ class Contributor(User):
 
     def full_name(self):
         return self.first_name + ' ' + self.last_name
-
-    def send_verification_email(self):
-        # Get token
-        user = Contributor.objects.get(id=self.id)
-        verification_token = default_token_generator.make_token(user)
-        verification_url = settings.PROTOCOL_DOMAIN + '/verify_user/' + str(self.id) + '/' + verification_token
-        # Send email with token
-        email_msg = EmailMessage(
-            'Welcome to DemocracyLab',
-            'Click here to confirm your email address (or paste into your browser): ' + verification_url,
-            settings.EMAIL_HOST_USER,
-            [self.email]
-        )
-        email_msg.send()
-
-    def send_password_reset_email(self):
-        # Get token
-        user = Contributor.objects.get(id=self.id)
-        reset_parameters = {
-            'userId': self.id,
-            'token': default_token_generator.make_token(user)
-        }
-        reset_url = section_url(FrontEndSection.ChangePassword, reset_parameters)
-        print(reset_url)
-        # Send email with token
-        email_msg = EmailMessage(
-            'DemocracyLab Password Reset',
-            'Click here to change your password: ' + reset_url,
-            settings.EMAIL_HOST_USER,
-            [self.email]
-        )
-        email_msg.send()
 
     def hydrate_to_json(self):
         links = civictechprojects.models.ProjectLink.objects.filter(link_user=self.id)

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -14,6 +14,7 @@ import os
 import ast
 import dj_database_url
 from distutils.util import strtobool
+from django.core.mail.backends.smtp import EmailBackend
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -131,6 +132,26 @@ REST_FRAMEWORK = {
     ],
     'PAGE_SIZE': 10
 }
+
+
+def read_connection_config(config):
+    return config and EmailBackend(
+        host=config['host'],
+        port=int(config['port']),
+        username=config['username'],
+        password=config['password'],
+        use_tls=strtobool(config['use_tls']),
+        fail_silently=False,
+        use_ssl=strtobool(config['use_ssl']),
+        timeout=None,
+        ssl_keyfile=None,
+        ssl_certfile=None)
+
+EMAIL_SUPPORT_ACCT = read_connection_config(ast.literal_eval(os.environ.get('EMAIL_SUPPORT_ACCT', 'None')))
+EMAIL_VOLUNTEER_ACCT = read_connection_config(ast.literal_eval(os.environ.get('EMAIL_VOLUNTEER_ACCT', 'None')))
+
+# Default log to console in the absence of any account configurations
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 DEFAULT_FROM_EMAIL = 'democracylabreset@gmail.com'
 SERVER_EMAIL = 'democracylabreset@gmail.com'

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -156,13 +156,6 @@ EMAIL_VOLUNTEER_ACCT = read_connection_config(ast.literal_eval(os.environ.get('E
 # Default log to console in the absence of any account configurations
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-DEFAULT_FROM_EMAIL = 'democracylabreset@gmail.com'
-SERVER_EMAIL = 'democracylabreset@gmail.com'
-EMAIL_USE_TLS = True
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_PORT = 587
-EMAIL_HOST_USER = 'democracylabreset@gmail.com'
-EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
 PROTOCOL_DOMAIN = os.environ['PROTOCOL_DOMAIN']
 ADMIN_EMAIL = os.environ['ADMIN_EMAIL']
 FAKE_EMAILS = os.environ.get('FAKE_EMAILS', False) == 'True'

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -158,7 +158,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 PROTOCOL_DOMAIN = os.environ['PROTOCOL_DOMAIN']
 ADMIN_EMAIL = os.environ['ADMIN_EMAIL']
-FAKE_EMAILS = os.environ.get('FAKE_EMAILS', False) == 'True'
+FAKE_EMAILS = not EMAIL_SUPPORT_ACCT or not EMAIL_VOLUNTEER_ACCT or os.environ.get('FAKE_EMAILS', False) == 'True'
 
 APPLICATION_REMINDER_PERIODS = ast.literal_eval(os.environ.get('APPLICATION_REMINDER_PERIODS', 'None'))
 

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -135,17 +135,20 @@ REST_FRAMEWORK = {
 
 
 def read_connection_config(config):
-    return config and EmailBackend(
-        host=config['host'],
-        port=int(config['port']),
-        username=config['username'],
-        password=config['password'],
-        use_tls=strtobool(config['use_tls']),
-        fail_silently=False,
-        use_ssl=strtobool(config['use_ssl']),
-        timeout=None,
-        ssl_keyfile=None,
-        ssl_certfile=None)
+    return config and {
+        'from_name': '{name} <{email_address}>'.format(name=config['display_name'], email_address=config['username']),
+        'connection': EmailBackend(
+            host=config['host'],
+            port=int(config['port']),
+            username=config['username'],
+            password=config['password'],
+            use_tls=strtobool(config['use_tls']),
+            fail_silently=False,
+            use_ssl=strtobool(config['use_ssl']),
+            timeout=None,
+            ssl_keyfile=None,
+            ssl_certfile=None)
+    }
 
 EMAIL_SUPPORT_ACCT = read_connection_config(ast.literal_eval(os.environ.get('EMAIL_SUPPORT_ACCT', 'None')))
 EMAIL_VOLUNTEER_ACCT = read_connection_config(ast.literal_eval(os.environ.get('EMAIL_VOLUNTEER_ACCT', 'None')))

--- a/democracylab/urls.py
+++ b/democracylab/urls.py
@@ -41,8 +41,8 @@ urlpatterns = [
     ),
     url(
         r'^verify_user/$',
-        views.send_verification_email,
-        name="send_verification_email"
+        views.send_verification_email_request,
+        name="send_verification_email_request"
     ),
     url(r'^api/user/(?P<user_id>[0-9]+)/$', views.user_details, name='user_details'),
     url(r'^api/user/edit/(?P<user_id>[0-9]+)/$', views.user_edit, name='user_edit'),

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -34,6 +34,10 @@ export FAKE_EMAILS=True
 # two days, the second after seven days, and none after that
 export APPLICATION_REMINDER_PERIODS='[2,7,-1]'
 
+# Sample email account configuration
+# export EMAIL_SUPPORT_ACCT='{"host":"smtp.gmail.com","port":"587","display_name":"DemocracyLab Support","username":"support@democracylab.org","password":"SECRET","use_tls":"True","use_ssl":"False"}'
+# export EMAIL_VOLUNTEER_ACCT='{"host":"smtp.gmail.com","port":"587","display_name":"DemocracyLab Volunteering","username":"volunteer@democracylab.org","password":"SECRET","use_tls":"True","use_ssl":"False"}'
+
 export S3_BUCKET=democracylab-marlok
 export EMAIL_HOST_PASSWORD=betterDemocracyViaTechnology
 


### PR DESCRIPTION
Currently we only have one email account configured for all emails, but now we'd like to send from different email accounts for different purposes.  This change sets up two email accounts, one for support and another for volunteering/contacting projects.  When emails aren't configured, it falls back to logging emails on the console.