### PR TITLE
Cleared FlashMessage alert after navigation

### DIFF
--- a/common/components/chrome/FlashMessage.jsx
+++ b/common/components/chrome/FlashMessage.jsx
@@ -1,8 +1,32 @@
 // @flow
 
 import React from 'react';
+import { Container } from 'flux/utils';
+import NavigationStore from '../stores/NavigationStore';
+import Section from '../enums/Section.js';
 
-class FlashMessage extends React.PureComponent<{||}> {
+type State = {|
+  section: SectionType,
+|};
+
+class FlashMessage extends React.Component<{||}, State> {
+
+  static getStores(): $ReadOnlyArray<FluxReduceStore> {
+    return [NavigationStore];
+  }
+
+  static calculateState(prevState: State): State {    
+    return {
+      section: NavigationStore.getSection(),
+    };
+  }
+
+  componentWillUpdate(nextProps, nextState: State) {
+    if (nextState.section !== this.state.section) {
+      window.DLAB_MESSAGES = [];
+    }
+  }
+
   render(): React$Node {
     return (
       <div className="FlashMessage-root">
@@ -22,4 +46,4 @@ class FlashMessage extends React.PureComponent<{||}> {
   }
 }
 
-export default FlashMessage;
+export default Container.create(FlashMessage);


### PR DESCRIPTION
Issue: Flash message never got updated due to it being a pure component and thus no state changes were detected

Fix: 

- converted FlashMessage to a normal component
- added a state to store the navigation
- so the component will updates when user navigates (to a different route)
- clear the window message queue before re-rendering (updating) 
