### PR TITLE
Add Html Email Framework

### DIFF
--- a/democracylab/emails.py
+++ b/democracylab/emails.py
@@ -47,6 +47,8 @@ class HtmlEmailTemplate:
             sections_text = ''.join(self.sections)
             self.hydrated_template = Template(HtmlEmailTemplate.base_template.render({"content": sections_text}))
         email_msg.content_subtype = "html"
+        # For some reason xml markup characters in the template (<,>) get converted to entity codes (&lt; and &rt;)
+        # We unescape to convert the markup characters back
         email_msg.body = unescape(self.hydrated_template.render(Context(context or {})))
         return email_msg
 

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -66,6 +66,7 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
             os.path.join(PROJECT_ROOT, 'democracylab/templates'),
+            os.path.join(PROJECT_ROOT, 'democracylab/templates/emails'),
             os.path.join(PROJECT_ROOT, 'civictechprojects/templates')
         ],
         'APP_DIRS': True,

--- a/democracylab/templates/emails/html_email_button.html
+++ b/democracylab/templates/emails/html_email_button.html
@@ -1,4 +1,9 @@
-<!-- BUTTON -->
+<!-- HTML Button template for DemocracyLab emails -->
+<!--
+Template Arguments
+ url: Button link url
+ text: Button text
+ -->
 <!-- Set button background color at TD, link/text color at A and TD, font family ("sans-serif" or "Georgia, serif") at TD. For verification codes add "letter-spacing: 5px;".  -->
 <tr>
     <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;

--- a/democracylab/templates/emails/html_email_button.html
+++ b/democracylab/templates/emails/html_email_button.html
@@ -9,17 +9,15 @@ Template Arguments
     <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;
 			padding-top: 25px;
 			padding-bottom: 5px;" class="button">
-        <a href="https://github.com/konsav/email-templates/" target="_blank" style="text-decoration: underline;">
-            <table border="0" cellpadding="0" cellspacing="0" align="center" style="max-width: 360px; min-width: 120px; border-collapse: collapse; border-spacing: 0; padding: 0;">
-                <tr>
-                    <td align="center" valign="middle" style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
-                                                                                                                                                                                           bgcolor="#f4a73c">
-                        <a target="_blank" style="text-decoration: underline; color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;" href="{{url}}">
-                            {{text}}
-                        </a>
-                    </td>
-                </tr>
-            </table>
-        </a>
+        <table border="0" cellpadding="0" cellspacing="0" align="center" style="max-width: 360px; min-width: 120px; border-collapse: collapse; border-spacing: 0; padding: 0;">
+            <tr>
+                <td align="center" valign="middle" style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
+                                                                                                                                                                                       bgcolor="#f4a73c">
+                    <a target="_blank" style="text-decoration: underline; color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;" href="{{url}}">
+                        {{text}}
+                    </a>
+                </td>
+            </tr>
+        </table>
     </td>
 </tr>

--- a/democracylab/templates/emails/html_email_button.html
+++ b/democracylab/templates/emails/html_email_button.html
@@ -1,0 +1,20 @@
+<!-- BUTTON -->
+<!-- Set button background color at TD, link/text color at A and TD, font family ("sans-serif" or "Georgia, serif") at TD. For verification codes add "letter-spacing: 5px;".  -->
+<tr>
+    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;
+			padding-top: 25px;
+			padding-bottom: 5px;" class="button">
+        <a href="https://github.com/konsav/email-templates/" target="_blank" style="text-decoration: underline;">
+            <table border="0" cellpadding="0" cellspacing="0" align="center" style="max-width: 360px; min-width: 120px; border-collapse: collapse; border-spacing: 0; padding: 0;">
+                <tr>
+                    <td align="center" valign="middle" style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
+                                                                                                                                                                                           bgcolor="#f4a73c">
+                        <a target="_blank" style="text-decoration: underline; color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;" href="{{url}}">
+                            {{text}}
+                        </a>
+                    </td>
+                </tr>
+            </table>
+        </a>
+    </td>
+</tr>

--- a/democracylab/templates/emails/html_email_frame.html
+++ b/democracylab/templates/emails/html_email_frame.html
@@ -1,3 +1,5 @@
+<!-- HTML base email template for all DemocracyLab emails -->
+
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
@@ -31,9 +33,6 @@
         }
 
     </style>
-
-    <!-- MESSAGE SUBJECT -->
-    <title>You're making a difference at {{project_name}}</title>
 
 </head>
 

--- a/democracylab/templates/emails/html_email_frame.html
+++ b/democracylab/templates/emails/html_email_frame.html
@@ -1,0 +1,134 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0;">
+    <meta name="format-detection" content="telephone=no"/>
+
+    <!-- Responsive Mobile-First Email Template by Konstantin Savchenko, 2015.
+    https://github.com/konsav/email-templates/  -->
+
+    <style>
+        /* Reset styles */
+        body { margin: 0; padding: 0; min-width: 100%; width: 100% !important; height: 100% !important;}
+        body, table, td, div, p, a { -webkit-font-smoothing: antialiased; text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; line-height: 100%; }
+        table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; border-spacing: 0; }
+        img { border: 0; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }
+        #outlook a { padding: 0; }
+        .ReadMsgBody { width: 100%; } .ExternalClass { width: 100%; }
+        .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div { line-height: 100%; }
+
+        /* Rounded corners for advanced mail clients only */
+        @media all and (min-width: 560px) {
+            .container { border-radius: 8px; -webkit-border-radius: 8px; -moz-border-radius: 8px; -khtml-border-radius: 8px;}
+        }
+
+        /* Set color for auto links (addresses, dates, etc.) */
+        a, a:hover {
+            color: #127DB3;
+        }
+        .footer a, .footer a:hover {
+            color: #999999;
+        }
+
+    </style>
+
+    <!-- MESSAGE SUBJECT -->
+    <title>You're making a difference at {{project_name}}</title>
+
+</head>
+
+<!-- BODY -->
+<!-- Set message background color (twice) and text color (twice) -->
+<body topmargin="0" rightmargin="0" bottommargin="0" leftmargin="0" marginwidth="0" marginheight="0" width="100%" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; height: 100%; -webkit-font-smoothing: antialiased; text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; line-height: 100%;
+	background-color: #f6f7f8;
+	color: #000000;"
+      bgcolor="#f6f7f8"
+      text="#000000">
+
+<!-- SECTION / BACKGROUND -->
+<!-- Set message background color one again -->
+<table width="100%" align="center" border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%;" class="background"><tr><td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0;"
+                                                                                                                                                                                                   bgcolor="#f6f7f8">
+
+    <!-- WRAPPER -->
+    <!-- Set wrapper width (twice) -->
+    <table border="0" cellpadding="0" cellspacing="0" align="center"
+           width="560" style="border-collapse: collapse; border-spacing: 0; padding: 0; width: inherit;
+	max-width: 560px;" class="wrapper">
+
+        <tr>
+            <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;
+			padding-top: 20px;
+			padding-bottom: 20px;">
+
+                <!-- PREHEADER -->
+                <!-- Set text color to background color -->
+                <div style="display: none; visibility: hidden; overflow: hidden; opacity: 0; font-size: 1px; line-height: 1px; height: 0; max-height: 0; max-width: 0;
+			color: #f6f7f8;" class="preheader">
+                </div>
+
+                <!-- LOGO -->
+                <!-- Image text color should be opposite to background color. Set your url, image src, alt and title. Alt text should fit the image size. Real image size should be x2. -->
+                <a target="_blank" style="text-decoration: none;"
+                   href="https://www.democracylab.org"><img border="0" vspace="0" hspace="0"	src="https://d1agxr2dqkgkuy.cloudfront.net/img/dl_logo.png"
+                                                            width="100" height="30"
+                                                            alt="Logo" title="Logo" style="
+				color: #000000;
+				font-size: 10px; margin: 0; padding: 0; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; border: none; display: block;" /></a>
+
+            </td>
+        </tr>
+
+        <!-- End of WRAPPER -->
+    </table>
+
+    <!-- WRAPPER / CONTAINER -->
+    <!-- Set container background color -->
+    <table border="0" cellpadding="0" cellspacing="0" align="center"
+           bgcolor="#FFFFFF"
+           width="560" style="border-collapse: collapse; border-spacing: 0; padding: 0; width: inherit;
+	max-width: 560px;" class="container">
+        {{content}}
+
+        <tr>
+            <td valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 17px; font-weight: 400; line-height: 160%;
+			padding-top: 25px; padding-bottom: 25px;
+			color: #000000;
+			font-family: sans-serif;" class="paragraph">
+                Best regards, <br>
+                The DemocracyLab Team
+            </td>
+        </tr>
+    </table>
+
+    <!-- WRAPPER -->
+    <!-- Set wrapper width (twice) -->
+    <table border="0" cellpadding="0" cellspacing="0" align="center"
+           width="560" style="border-collapse: collapse; border-spacing: 0; padding: 0; width: inherit;
+	max-width: 560px;" class="wrapper">
+
+
+        </td>
+        </tr>
+
+        <!-- FOOTER -->
+        <!-- Set text color and font family ("sans-serif" or "Georgia, serif"). Duplicate all text styles in links, including line-height -->
+        <tr>
+            <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 13px; font-weight: 400; line-height: 150%;
+			padding-top: 20px;
+			padding-bottom: 20px;
+			color: #999999;
+			font-family: sans-serif;" class="footer">
+
+                Copyright &copy; 2019 DemocracyLab. All Rights Reserved.
+            </td>
+        </tr>
+
+        <!-- End of WRAPPER -->
+    </table>
+
+    <!-- End of SECTION / BACKGROUND -->
+</td></tr></table>
+
+</body>
+</html>

--- a/democracylab/templates/emails/html_email_header.html
+++ b/democracylab/templates/emails/html_email_header.html
@@ -1,4 +1,8 @@
-<!-- HEADER -->
+<!-- HTML Header template for DemocracyLab emails -->
+<!--
+Template Arguments
+ text: Header text
+ -->
 <!-- Set text color and font family ("sans-serif" or "Georgia, serif") -->
 <tr>
     <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 24px; font-weight: bold; line-height: 130%;

--- a/democracylab/templates/emails/html_email_header.html
+++ b/democracylab/templates/emails/html_email_header.html
@@ -1,0 +1,10 @@
+<!-- HEADER -->
+<!-- Set text color and font family ("sans-serif" or "Georgia, serif") -->
+<tr>
+    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 24px; font-weight: bold; line-height: 130%;
+			padding-top: 25px;
+			color: #f4a73c;
+			font-family: sans-serif;" class="header">
+        {{text}}
+    </td>
+</tr>

--- a/democracylab/templates/emails/html_email_paragraph.html
+++ b/democracylab/templates/emails/html_email_paragraph.html
@@ -1,4 +1,8 @@
-<!-- PARAGRAPH -->
+<!-- HTML Paragraph template for DemocracyLab emails -->
+<!--
+Template Arguments
+ text: Paragraph text
+ -->
 <!-- Set text color and font family ("sans-serif" or "Georgia, serif"). Duplicate all text styles in links, including line-height -->
 <tr>
     <td valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 17px; font-weight: 400; line-height: 160%;

--- a/democracylab/templates/emails/html_email_paragraph.html
+++ b/democracylab/templates/emails/html_email_paragraph.html
@@ -1,0 +1,10 @@
+<!-- PARAGRAPH -->
+<!-- Set text color and font family ("sans-serif" or "Georgia, serif"). Duplicate all text styles in links, including line-height -->
+<tr>
+    <td valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 17px; font-weight: 400; line-height: 160%;
+			padding-top: 25px;
+			color: #000000;
+			font-family: sans-serif;" class="paragraph">
+        {{text}}
+    </td>
+</tr>


### PR DESCRIPTION
Up till now we've only sent plain text emails, but for some features going forward we're looking to move to richer, html-based emails.  This change adds a framework for that, as well as changing the email address verification emails to use the framework.