### PR TITLE
Make sure user is logged in before firing VolunteerClickedReviewCommitmentsInEmail event

### DIFF
--- a/common/components/controllers/MyProjectsController.jsx
+++ b/common/components/controllers/MyProjectsController.jsx
@@ -52,7 +52,7 @@ class MyProjectsController extends React.Component<{||}, State> {
   componentWillMount(): void {
     UniversalDispatcher.dispatch({type: 'INIT'});
     const args = url.arguments(window.location.href);
-    if ("from" in args && args.from === "renewal_notification_email") {
+    if ("from" in args && args.from === "renewal_notification_email" && CurrentUser.isLoggedIn()) {
       metrics.logVolunteerClickReviewCommitmentsInEmail(CurrentUser.userID());
     }
   }


### PR DESCRIPTION
We fire a VolunteerClickedReviewCommitmentsInEmail event when a volunteer clicks on the Review Commitments button in the email alerting them their volunteering period with a project is coming to an end.  However, if the user isn't logged in, the event will fire without recording their userId, and then if they DO log in at that point, it will proceed to fire the event again (though this time with the userId).

What we want in this instance is for the event to not fire the first time when they're not logged in.