### PR TITLE
change import for mdi-material-ui to reduce bundle.js size

### DIFF
--- a/common/components/componentsBySection/FindProjects/ProjectDetails.jsx
+++ b/common/components/componentsBySection/FindProjects/ProjectDetails.jsx
@@ -1,7 +1,12 @@
 // @flow
 import React from 'react';
 import Divider from '@material-ui/core/Divider';
-import {Earth, MapMarker, Clock, Domain, ChartBar, Key} from 'mdi-material-ui';
+import Earth from 'mdi-material-ui/Earth';
+import MapMarker from 'mdi-material-ui/MapMarker';
+import Clock from 'mdi-material-ui/Clock';
+import Domain from 'mdi-material-ui/Domain';
+import ChartBar from 'mdi-material-ui/ChartBar';
+import Key from 'mdi-material-ui/Key';
 import Moment from 'react-moment';
 import urlHelper from '../../utils/url.js'
 


### PR DESCRIPTION
This changes how we import `mdi-material-ui` to not import every single icon in the entire MDI package, but only the ones we use. 

I followed the "Without tree-shaking" import style documented here: https://www.npmjs.com/package/mdi-material-ui

This caused a reduction in bundle.js filesize of nearly 50%. 

Other import statements in our codebase act similarly to how MDI was imported - this is solving a symptom and not root cause - but my analysis of our webpack output shows MDI as the single biggest contributor to bundle filesize, so it's worth doing until we fix it in a more comprehensive fashion.