### PR TITLE
Sponsor Footer monitors page navigation and displays itself accordingly

### DIFF
--- a/common/components/chrome/MainFooter.jsx
+++ b/common/components/chrome/MainFooter.jsx
@@ -1,18 +1,36 @@
 // @flow
 
 import React from 'react';
+import {Container} from 'flux/utils';
 import url from "../utils/url.js";
 import Section from "../enums/Section.js";
 import Sponsors, {SponsorMetadata} from "../utils/Sponsors.js";
+import NavigationStore from "../stores/NavigationStore.js";
+import _ from 'lodash';
 
-class MainFooter extends React.PureComponent<{||}> {
+const sectionsToShowFooter: $ReadOnlyArray<string> = [
+  Section.FindProjects,
+  Section.AboutProject
+];
+
+class MainFooter extends React.Component<{||}> {
 
   constructor(): void {
     super();
   }
+  
+  static getStores(): $ReadOnlyArray<FluxReduceStore> {
+    return [NavigationStore];
+  }
+  
+  static calculateState(prevState: State): State {
+    return {
+      section: NavigationStore.getSection(),
+    };
+  }
 
-  render(): React$Node {
-    return (
+  render(): ?React$Node {
+    return this.state.section && (_.includes(sectionsToShowFooter, this.state.section)) && (
       <div className="MainFooter-footer container">
         <div className="MainFooter-item col-xs-12 col-md-6">
           <h2>Sponsors Make It Possible</h2>
@@ -43,4 +61,4 @@ class MainFooter extends React.PureComponent<{||}> {
     }
   }
 }
-export default MainFooter;
+export default Container.create(MainFooter);

--- a/common/components/controllers/MainController.jsx
+++ b/common/components/controllers/MainController.jsx
@@ -6,19 +6,12 @@ import UniversalDispatcher from '../stores/UniversalDispatcher.js';
 import React from 'react';
 import FlashMessage from '../chrome/FlashMessage.jsx';
 import MainFooter from "../chrome/MainFooter.jsx";
-import Section from "../enums/Section.js";
 import url from '../../components/utils/url.js'
-import _ from 'lodash';
 
 type State = {|
   headerHeight: number,
   currentSection: ?string
 |};
-
-const sectionsToShowFooter: $ReadOnlyArray<string> = [
-  Section.FindProjects,
-  Section.AboutProject
-];
 
 class MainController extends React.Component<{||}, State> {
   constructor() {
@@ -58,7 +51,7 @@ class MainController extends React.Component<{||}, State> {
       <MainHeader key='main_header' onMainHeaderHeightChange={this._mainHeaderHeightChange.bind(this)}/>,
       <FlashMessage key='flash_message'/>,
       <SectionController key='section_controller' headerHeight={this.state.headerHeight}/>,
-      this.state.currentSection && (_.includes(sectionsToShowFooter, this.state.currentSection)) ? <MainFooter/> : null
+      <MainFooter/>
     ];
   }
 }


### PR DESCRIPTION
The Sponsor footer is supposed to display itself on certain pages, but if a user initially navigates to a page with the footer, they will always see the footer on subsequent navigations.  Conversely, if they initially navigate to a page without the footer, they will never see the footer on subsequent navigations.