### PR TITLE
Log missing environment variables errors on startup

### DIFF
--- a/common/apps.py
+++ b/common/apps.py
@@ -15,4 +15,7 @@ class CommonConfig(AppConfig):
     def display_missing_environment_variables(self):
         for key, value in settings.ENVIRONMENT_VARIABLE_WARNINGS.items():
             if not hasattr(settings, key):
-                print(value['message'])
+                if value['error']:
+                    raise EnvironmentError(value['message'])
+                else:
+                    print(value['message'])

--- a/common/apps.py
+++ b/common/apps.py
@@ -15,7 +15,7 @@ class CommonConfig(AppConfig):
     def display_missing_environment_variables(self):
         missing_required_variables = []
         for key, value in settings.ENVIRONMENT_VARIABLE_WARNINGS.items():
-            if not hasattr(settings, key):
+            if not (hasattr(settings, key) and len(getattr(settings, key)) > 0):
                 if value['error']:
                     missing_required_variables.append(key)
                 print(key + ' not set: ' + value['message'])

--- a/common/apps.py
+++ b/common/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 from common.helpers.db import db_is_initialized
 
 
@@ -6,6 +7,12 @@ class CommonConfig(AppConfig):
     name = 'common'
 
     def ready(self):
+        self.display_missing_environment_variables()
         from common.helpers.tags import import_tags_from_csv
         if db_is_initialized():
             import_tags_from_csv()
+
+    def display_missing_environment_variables(self):
+        for key, value in settings.ENVIRONMENT_VARIABLE_WARNINGS.items():
+            if not hasattr(settings, key):
+                print(value['message'])

--- a/common/apps.py
+++ b/common/apps.py
@@ -13,9 +13,11 @@ class CommonConfig(AppConfig):
             import_tags_from_csv()
 
     def display_missing_environment_variables(self):
+        missing_required_variables = []
         for key, value in settings.ENVIRONMENT_VARIABLE_WARNINGS.items():
             if not hasattr(settings, key):
                 if value['error']:
-                    raise EnvironmentError(value['message'])
-                else:
-                    print(value['message'])
+                    missing_required_variables.append(key)
+                print(value['message'])
+        if len(missing_required_variables) > 0:
+            raise EnvironmentError('Required environment variables missing: ' + ','.join(missing_required_variables))

--- a/common/apps.py
+++ b/common/apps.py
@@ -18,6 +18,6 @@ class CommonConfig(AppConfig):
             if not hasattr(settings, key):
                 if value['error']:
                     missing_required_variables.append(key)
-                print(value['message'])
+                print(key + ' not set: ' + value['message'])
         if len(missing_required_variables) > 0:
             raise EnvironmentError('Required environment variables missing: ' + ','.join(missing_required_variables))

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -192,10 +192,38 @@ GOOGLE_PROPERTY_ID = os.environ.get('GOOGLE_PROPERTY_ID', '')
 STATIC_CDN_URL = os.environ.get('STATIC_CDN_URL', '')
 
 ENVIRONMENT_VARIABLE_WARNINGS = {
-    'STATIC_CDN_URL': {
+    'PRESS_LINKS': {
         'error': True,
-        'message': 'STATIC_CDN_URL not set; static images will not be shown.'
+        'message': 'PRESS_LINKS not set: Press page articles will not be shown.'
     },
+    'PROTOCOL_DOMAIN': {
+        'error': True,
+        'message': 'PROTOCOL_DOMAIN not set: backend link generation will not work.'
+    },
+    'DLAB_PROJECT_ID': {
+        'error': True,
+        'message': 'DLAB_PROJECT_ID not set: About Us page will not display correctly.'
+    },
+    'STATIC_CDN_URL': {
+        'error': False,
+        'message': 'STATIC_CDN_URL not set: static images will not be shown.'
+    },
+    'PROJECT_DESCRIPTION_EXAMPLE_URL': {
+        'error': False,
+        'message': 'PROJECT_DESCRIPTION_EXAMPLE_URL not set: url example for project description will not be shown.'
+    },
+    'POSITION_DESCRIPTION_EXAMPLE_URL': {
+        'error': False,
+        'message': 'POSITION_DESCRIPTION_EXAMPLE_URL not set: url example for position description will not be shown.'
+    },
+    'S3_BUCKET': {
+        'error': False,
+        'message': 'S3_BUCKET not set; saving images and files will not work.'
+    },
+    'PAYPAL_ENDPOINT': {
+        'error': False,
+        'message': 'PAYPAL_ENDPOINT not set; donation will not work.'
+    }
 }
 
 # TODO: Set to True in productions

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -194,35 +194,35 @@ STATIC_CDN_URL = os.environ.get('STATIC_CDN_URL', '')
 ENVIRONMENT_VARIABLE_WARNINGS = {
     'PRESS_LINKS': {
         'error': True,
-        'message': 'PRESS_LINKS not set: Press page articles will not be shown.'
+        'message': 'Press page articles will not be shown.'
     },
     'PROTOCOL_DOMAIN': {
         'error': True,
-        'message': 'PROTOCOL_DOMAIN not set: backend link generation will not work.'
+        'message': 'Backend link generation will not work.'
     },
     'DLAB_PROJECT_ID': {
         'error': True,
-        'message': 'DLAB_PROJECT_ID not set: About Us page will not display correctly.'
+        'message': 'About Us page will not display correctly.'
     },
-    'STATIC_CDN_URL': {
+    'STATIC_CDN_URLX': {
         'error': False,
-        'message': 'STATIC_CDN_URL not set: static images will not be shown.'
+        'message': 'Static images will not be shown.'
     },
     'PROJECT_DESCRIPTION_EXAMPLE_URL': {
         'error': False,
-        'message': 'PROJECT_DESCRIPTION_EXAMPLE_URL not set: url example for project description will not be shown.'
+        'message': 'Example url for project description will not be shown.'
     },
     'POSITION_DESCRIPTION_EXAMPLE_URL': {
         'error': False,
-        'message': 'POSITION_DESCRIPTION_EXAMPLE_URL not set: url example for position description will not be shown.'
+        'message': 'Example url for position description will not be shown.'
     },
     'S3_BUCKET': {
         'error': False,
-        'message': 'S3_BUCKET not set; saving images and files will not work.'
+        'message': 'Saving images and files will not work.'
     },
     'PAYPAL_ENDPOINT': {
         'error': False,
-        'message': 'PAYPAL_ENDPOINT not set; donation will not work.'
+        'message': 'Donations will not work.'
     }
 }
 

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -204,7 +204,7 @@ ENVIRONMENT_VARIABLE_WARNINGS = {
         'error': True,
         'message': 'About Us page will not display correctly.'
     },
-    'STATIC_CDN_URLX': {
+    'STATIC_CDN_URL': {
         'error': False,
         'message': 'Static images will not be shown.'
     },

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -191,7 +191,12 @@ GOOGLE_PROPERTY_ID = os.environ.get('GOOGLE_PROPERTY_ID', '')
 
 STATIC_CDN_URL = os.environ.get('STATIC_CDN_URL', '')
 
-# TODO: Call out missing required environment variables
+ENVIRONMENT_VARIABLE_WARNINGS = {
+    'STATIC_CDN_URL': {
+        'error': True,
+        'message': 'STATIC_CDN_URL not set; static images will not be shown.'
+    },
+}
 
 # TODO: Set to True in productions
 # SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
When new environment variables are added to DemocracyLab, not all of the developers are necessarily aware they need to add them to their development environments.  Now, any missing environment variables will be logged to the console upon startup.  In addition, for environment variables that are critical to basic operation of the site, if they are missing the server will abort the startup process.