### PR TITLE
updated psycopg2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ djangorestframework==3.6.4
 docutils==0.14
 gunicorn==19.6.0
 jmespath==0.9.3
-psycopg2==2.7.3.2
+psycopg2==2.7.7
 python-dateutil==2.6.1
 pytz==2017.3
 rcssmin==1.0.6


### PR DESCRIPTION
Updated psycopg2 version to a more recent version(2.7.7) to assist with setting up environments on Windows.