### PR TITLE
Peter/filter flash

### DIFF
--- a/common/components/componentsBySection/FindProjects/Filters/ProjectFilterDataContainer.jsx
+++ b/common/components/componentsBySection/FindProjects/Filters/ProjectFilterDataContainer.jsx
@@ -57,7 +57,6 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
         sortedTags: sorted
       });
     });
-    this._selectOption = this._selectOption.bind(this);
   }
 
   static getStores(): $ReadOnlyArray<FluxReduceStore> {
@@ -109,7 +108,6 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
               data={_.sortBy(this.state.sortedTags[key], (tag) => tag.display_name.toUpperCase())}
               hasSubcategories={_.every(this.state.sortedTags[key], 'subcategory')}
               selectedTags={Object.keys(this.state.selectedTags)}
-              selectOption={this._selectOption}
             />
           );
         return (
@@ -118,25 +116,6 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
             </div>
         )
     }
-
-    _selectOption(tag: TagDefinition): void {
-      var tagInState = _.has(this.state.selectedTags, tag.tag_name);
-      //if tag is NOT currently in state, add it, otherwise remove
-      if(!tagInState) {
-        ProjectSearchDispatcher.dispatch({
-          type: 'ADD_TAG',
-          tag: tag.tag_name,
-        });
-        metrics.logSearchFilterByTagEvent(tag);
-      } else {
-        ProjectSearchDispatcher.dispatch({
-          type: 'REMOVE_TAG',
-          tag: tag,
-        });
-      }
-
-
-  }
 }
 
 

--- a/common/components/componentsBySection/FindProjects/Filters/ProjectFilterDataContainer.jsx
+++ b/common/components/componentsBySection/FindProjects/Filters/ProjectFilterDataContainer.jsx
@@ -122,8 +122,11 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
     }
 
     _checkEnabled(tag: TagDefinition): boolean {
-      //return true if tag is in this.state.selectedTags, else implicitly false
-      return _.has(this.state.selectedTags, tag.tag_name)
+      if (this.state.selectedTags[tag.tag_name]) {
+         return true
+       } else {
+         return false
+       }
     }
 
     _selectOption(tag: TagDefinition): void {

--- a/common/components/componentsBySection/FindProjects/Filters/ProjectFilterDataContainer.jsx
+++ b/common/components/componentsBySection/FindProjects/Filters/ProjectFilterDataContainer.jsx
@@ -57,7 +57,6 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
         sortedTags: sorted
       });
     });
-    this._checkEnabled = this._checkEnabled.bind(this);
     this._selectOption = this._selectOption.bind(this);
   }
 
@@ -70,7 +69,6 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
       selectedTags:_.mapKeys(ProjectSearchStore.getTags().toArray(), (tag: TagDefinition) => tag.tag_name)
     };
   }
-
 
   render(): React$Node {
     //should render a number of <RenderFilterCategory> child components
@@ -110,7 +108,7 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
               category={key}
               data={_.sortBy(this.state.sortedTags[key], (tag) => tag.display_name.toUpperCase())}
               hasSubcategories={_.every(this.state.sortedTags[key], 'subcategory')}
-              checkEnabled={this._checkEnabled}
+              selectedTags={this.state.selectedTags}
               selectOption={this._selectOption}
             />
           );
@@ -119,14 +117,6 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
                 {displayFilters}
             </div>
         )
-    }
-
-    _checkEnabled(tag: TagDefinition): boolean {
-      if (this.state.selectedTags[tag.tag_name]) {
-         return true
-       } else {
-         return false
-       }
     }
 
     _selectOption(tag: TagDefinition): void {

--- a/common/components/componentsBySection/FindProjects/Filters/ProjectFilterDataContainer.jsx
+++ b/common/components/componentsBySection/FindProjects/Filters/ProjectFilterDataContainer.jsx
@@ -108,7 +108,7 @@ class ProjectFilterDataContainer extends React.Component<Props, State> {
               category={key}
               data={_.sortBy(this.state.sortedTags[key], (tag) => tag.display_name.toUpperCase())}
               hasSubcategories={_.every(this.state.sortedTags[key], 'subcategory')}
-              selectedTags={this.state.selectedTags}
+              selectedTags={Object.keys(this.state.selectedTags)}
               selectOption={this._selectOption}
             />
           );

--- a/common/components/componentsBySection/FindProjects/Filters/RenderFilterCategory.jsx
+++ b/common/components/componentsBySection/FindProjects/Filters/RenderFilterCategory.jsx
@@ -16,7 +16,7 @@ const classCategoryCollapsed = 'ProjectFilterContainer-category ProjectFilterCon
 const classSubcategoryExpanded = 'ProjectFilterContainer-subcategory ProjectFilterContainer-expanded';
 const classSubcategoryCollapsed = 'ProjectFilterContainer-subcategory ProjectFilterContainer-collapsed';
 
-class RenderFilterCategory<T> extends React.Component<Props<T>, State> {
+class RenderFilterCategory<T> extends React.PureComponent<Props<T>, State> {
   constructor(props: Props): void {
     super(props)
     // This constructor creates state keys based on category or subcategory - each state key/value will indicate whether or not a given (sub)category is expanded (true) or collapsed (false)
@@ -106,9 +106,9 @@ class RenderFilterCategory<T> extends React.Component<Props<T>, State> {
     let sortedTags = Object.values(data).map(tag => {
       const key:string = tag.category + '-' + tag.tag_name;
       return  (<li key={key} className="ProjectFilterContainer-list-item">
-                <input type="checkbox" id={key} checked={this.props.selectedTags[tag.tag_name] || false} onChange={() => this.props.selectOption(tag)}></input>
+                <input type="checkbox" id={key} checked={this.props.selectedTags.includes(tag.tag_name)} onChange={() => this.props.selectOption(tag)}></input>
                 <label htmlFor={key}>
-                  <span className="ProjectFilterContainer-list-item-name">{tag.display_name}</span> <span className="ProjectFilterContainer-list-item-count">{this.props.selectedTags[tag.tag_name] ? <i className={GlyphStyles.Check}></i> : tag.num_times}</span>
+                  <span className="ProjectFilterContainer-list-item-name">{tag.display_name}</span> <span className="ProjectFilterContainer-list-item-count">{this.props.selectedTags.includes(tag.tag_name) ? <i className={GlyphStyles.Check}></i> : tag.num_times}</span>
                 </label>
               </li>)
       });

--- a/common/components/componentsBySection/FindProjects/Filters/RenderFilterCategory.jsx
+++ b/common/components/componentsBySection/FindProjects/Filters/RenderFilterCategory.jsx
@@ -42,7 +42,8 @@ class RenderFilterCategory<T> extends React.PureComponent<Props<T>, State> {
     const tdata = this.props.data
     for (var i = 0; i < tdata.length; i++) {
       var kname = tdata[i].tag_name;
-      tagNames[kname] = false
+      //set true or false initially using selectedTags prop (this handles querystring saved filter sets)
+      tagNames[kname] = this.props.selectedTags.includes(kname)
     }
     //merge these two objects before creating state
     let combined = _.merge(collector, tagNames)

--- a/common/components/componentsBySection/FindProjects/Filters/RenderFilterCategory.jsx
+++ b/common/components/componentsBySection/FindProjects/Filters/RenderFilterCategory.jsx
@@ -16,7 +16,7 @@ const classCategoryCollapsed = 'ProjectFilterContainer-category ProjectFilterCon
 const classSubcategoryExpanded = 'ProjectFilterContainer-subcategory ProjectFilterContainer-expanded';
 const classSubcategoryCollapsed = 'ProjectFilterContainer-subcategory ProjectFilterContainer-collapsed';
 
-class RenderFilterCategory<T> extends React.PureComponent<Props<T>, State> {
+class RenderFilterCategory<T> extends React.Component<Props<T>, State> {
   constructor(props: Props): void {
     super(props)
     // This constructor creates state keys based on category or subcategory - each state key/value will indicate whether or not a given (sub)category is expanded (true) or collapsed (false)
@@ -40,8 +40,6 @@ class RenderFilterCategory<T> extends React.PureComponent<Props<T>, State> {
 
     this._handleChange = this._handleChange.bind(this);
   }
-
-
 
   //handle expand/collapse
   _handleChange(name, event) {
@@ -108,9 +106,9 @@ class RenderFilterCategory<T> extends React.PureComponent<Props<T>, State> {
     let sortedTags = Object.values(data).map(tag => {
       const key:string = tag.category + '-' + tag.tag_name;
       return  (<li key={key} className="ProjectFilterContainer-list-item">
-                <input type="checkbox" id={key} checked={this.props.checkEnabled(tag)} onChange={() => this.props.selectOption(tag)}></input>
+                <input type="checkbox" id={key} checked={this.props.selectedTags[tag.tag_name] || false} onChange={() => this.props.selectOption(tag)}></input>
                 <label htmlFor={key}>
-                  <span className="ProjectFilterContainer-list-item-name">{tag.display_name}</span> <span className="ProjectFilterContainer-list-item-count">{this.props.checkEnabled(tag) ? <i className={GlyphStyles.Check}></i> : tag.num_times}</span>
+                  <span className="ProjectFilterContainer-list-item-name">{tag.display_name}</span> <span className="ProjectFilterContainer-list-item-count">{this.props.selectedTags[tag.tag_name] ? <i className={GlyphStyles.Check}></i> : tag.num_times}</span>
                 </label>
               </li>)
       });

--- a/common/components/componentsBySection/FindProjects/Filters/RenderFilterCategory.jsx
+++ b/common/components/componentsBySection/FindProjects/Filters/RenderFilterCategory.jsx
@@ -27,16 +27,25 @@ class RenderFilterCategory<T> extends React.PureComponent<Props<T>, State> {
     let c = Object.keys(_.groupBy(this.props.data, 'category')) || [] ;
     let s = Object.keys(_.groupBy(this.props.data, 'subcategory')) || [];
     let cs = _.concat(c, s);
-    //cs is now an array of each key we want to use for expand/collapse tracking
-
+    //cs is now an array of each key we want to use for expand/collapse category state
     //make an object and push in each key from cs, set all values to false
     const collector = {}
     for (var key in cs) {
       let val = cs[key]
       collector[val] = false;
     }
-    //set initial state once collector is populated
-    this.state = collector || {}
+    //now create an object for individual filter selected/unselected state
+    const tagNames = {}
+    const tdata = this.props.data
+    for (var i = 0; i < tdata.length; i++) {
+      var kname = tdata[i].tag_name;
+      tagNames[kname] = false
+    }
+    //merge these two objects before creating state
+    let combined = _.merge(collector, tagNames)
+
+    //set initial state
+    this.state = combined || {}
 
     this._handleChange = this._handleChange.bind(this);
   }


### PR DESCRIPTION
trello item: https://trello.com/c/wQ7mhDRU/316-find-projects-clicking-filter-makes-other-selected-filters-flash-white-for-a-second-while-new-search-results-load

From what I've been able to determine the filter components, due to how they held state, were re-rendering from scratch every time something changed, causing the blink. Specifically, because the state object which held checked/unchecked data didn't know or care about the categories of filter, neither did the rerender; some console.logs demonstrated the isChecked function would fire on every filter item if any of them changed; that's a lot of needless re-render.

To mitigate this, I moved state-control for the individual filter items into the child `<RenderFilterCategory />` component instead of the parent `<ProjectFilterDataContainer />` component. Each child component handles pushing to and from the flux store's selectedTags object (which is our 'source of truth') 

Or that's the intent. There are two outstanding issues, both of which I think are caused by me not using that source of truth properly. Clicking a filter will add and clicking it again will remove, but the Clear Filters button and clicking the X on each selected filter pill does not work. 

On the upside, in my testing the filter flashing is totally gone. And I was just expecting to minimize it, not remove it. so if I can get this to listen to changes from the Reset Search button and clicking the X inside a filter pill...
