### PR TITLE
Project Profile: Edit Project button should go to Create Project page for unpublished projects

### DIFF
--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -113,6 +113,7 @@ class Project(Archived):
             'project_name': self.project_name,
             'project_creator': self.project_creator.id,
             'project_claimed': not self.project_creator.is_admin_contributor(),
+            'project_approved': self.is_searchable,
             'project_description': self.project_description,
             'project_description_solution': self.project_description_solution,
             'project_description_actions': self.project_description_actions,

--- a/common/components/common/projects/ContactProjectButton.jsx
+++ b/common/components/common/projects/ContactProjectButton.jsx
@@ -87,13 +87,14 @@ class ContactProjectButton extends React.PureComponent<Props, State> {
 
   _renderEditProjectButton(): React$Node {
     const id = {'id':this.props.project.project_id};
+    const section: string = this.props.project.project_approved ? Section.EditProject : Section.CreateProject;
     return (
         <Button
           className="AboutProject-button btn btn-theme clear-button-appearance"
           type="button"
           disabled={this.state.buttonDisabled}
           title={this.state.buttonTitle}
-          href={url.section(Section.EditProject, id)}
+          href={url.section(section, id)}
         >
           Edit Project
         </Button>

--- a/common/components/utils/ProjectAPIUtils.js
+++ b/common/components/utils/ProjectAPIUtils.js
@@ -75,6 +75,7 @@ export type ProjectDetailsAPIData = {|
   +project_short_description: string,
   +project_creator: number,
   +project_claimed: boolean,
+  +project_approved: boolean,
   +project_url: string,
   +project_organization: $ReadOnlyArray<TagDefinition>,
   +project_organization_type: $ReadOnlyArray<TagDefinition>,


### PR DESCRIPTION
When a project has not been published, the Edit Project button shown on its profile page should go to the Create Project page, rather than the Edit Project page.