### PR TITLE
Create Project: Highlight PUBLISH button

### DIFF
--- a/common/components/controllers/CreateProjectController.jsx
+++ b/common/components/controllers/CreateProjectController.jsx
@@ -71,7 +71,7 @@ class CreateProjectController extends React.PureComponent<{||},State> {
           formComponent: ProjectPositionsForm
         }, {
           header: "Ready to publish your project?",
-          subHeader: "Congratulations!  You have successfully created a tech-for-good project.",
+          subHeader: "Please review your project's details and click \"PUBLISH\" below when you're ready.",
           onSubmit: this.onSubmit,
           onSubmitSuccess: this.onFinalSubmitSuccess,
           formComponent: ProjectPreviewForm

--- a/common/components/forms/FormWorkflow.jsx
+++ b/common/components/forms/FormWorkflow.jsx
@@ -142,7 +142,7 @@ class FormWorkflow<T> extends React.PureComponent<Props<T>,State<T>> {
             <h1>{currentStep.header}</h1>
             <h2>{currentStep.subHeader}</h2>
             <StepIndicatorBars
-              stepCount={this.props.steps.length}
+              stepCount={this.props.steps.length + 1}
               currentlySelected={this.state.currentStep}
             />
           </div>


### PR DESCRIPTION
Made a couple changes in order to highlight to users that they need to click PUBLISH on the last page of the Create Project workflow.
- Changed message to indicate the user needs to click PUBLISH after previewing project profile page
- Added additional step bar so user doesn't wrongly conclude they're finished before clicking PUBLISH