### PR TITLE
Peter/update hero

### DIFF
--- a/civictechprojects/static/css/_vars.scss
+++ b/civictechprojects/static/css/_vars.scss
@@ -20,6 +20,7 @@ $color-background-dark: #222629; //nav bar, footer
 $color-background-info: #add8e6; // info messages
 $color-background-success: #a3ffa6; // success messages
 $color-background-error: #ffcfcf; //error messages
+$color-opacity-layer: #231f20; //  overlay opacity
 
 //Dimensions
 $header-height: 50px; //Height of site header

--- a/civictechprojects/static/css/partials/_SplashScreen.scss
+++ b/civictechprojects/static/css/partials/_SplashScreen.scss
@@ -1,5 +1,5 @@
 .SplashScreen-root {
-  background-color: $color-text-grey;
+  background-color: $color-opacity-layer;
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
@@ -61,6 +61,15 @@
 .SplashScreen-mission p {
   margin: 0 auto;
   font-weight: 500;
+}
+.SplashScreen-opacity-layer {
+  background-blend-mode: multiply;
+}
+.SplashScreen-opacity50 {
+  background: rgba($color-opacity-layer, 0.5)
+}
+.SplashScreen-opacity20 {
+  background: rgba($color-opacity-layer, 0.2)
 }
 @include media-breakpoint-up(md) {
   .SplashScreen-mission p {

--- a/civictechprojects/static/css/partials/_SplashScreen.scss
+++ b/civictechprojects/static/css/partials/_SplashScreen.scss
@@ -66,10 +66,10 @@
   background-blend-mode: multiply;
 }
 .SplashScreen-opacity50 {
-  background: rgba($color-opacity-layer, 0.5)
+  background-color: rgba($color-opacity-layer, 0.5)
 }
 .SplashScreen-opacity20 {
-  background: rgba($color-opacity-layer, 0.2)
+  background-color: rgba($color-opacity-layer, 0.2)
 }
 @include media-breakpoint-up(md) {
   .SplashScreen-mission p {

--- a/common/components/componentsBySection/FindProjects/SplashScreen.jsx
+++ b/common/components/componentsBySection/FindProjects/SplashScreen.jsx
@@ -10,14 +10,26 @@ type Props = {|
   onClickFindProjects: () => void
 |};
 
+const heroImages: $ReadOnlyArray<string> = [
+  "CodeForGood_072719_MSReactor-003.jpg",
+  "CodeForGood_072719_MSReactor-074.jpg",
+  "CodeForGood_072719_MSReactor-020.jpg",
+  "CodeForGood_072719_MSReactor-064.jpg"
+]
+
 class SplashScreen extends React.PureComponent<Props> {
   _onClickFindProjects(): void {
     this.props.onClickFindProjects();
   }
 
+  _heroRandomizer(): void {
+    let imgIndex = Math.floor(Math.random() * Math.floor(heroImages.length));
+    return cdn.image(heroImages[imgIndex])
+  }
+
   render(): React$Node {
     return (
-      <div className="SplashScreen-root" style={{backgroundImage: 'url(' + cdn.image("dl_splash.jpg")+ ')' }}>
+      <div className="SplashScreen-root SplashScreen-opacity-layer SplashScreen-opacity50" style={{backgroundImage: 'url(' + this._heroRandomizer() + ')' }}>
         <div className="SplashScreen-content">
           <h1>We connect skilled volunteers and tech-for-good projects</h1>
           <div className="SplashScreen-section">
@@ -29,7 +41,7 @@ class SplashScreen extends React.PureComponent<Props> {
             </Button>
           </div>
         </div>
-        <div className="SplashScreen-mission">
+        <div className="SplashScreen-mission SplashScreen-opacity-layer SplashScreen-opacity70">
           <p>DemocracyLab is a nonprofit organization.</p>
           <p>Our mission is to empower people who use technology to advance the public good.</p>
         </div>

--- a/common/components/componentsBySection/FindProjects/SplashScreen.jsx
+++ b/common/components/componentsBySection/FindProjects/SplashScreen.jsx
@@ -41,7 +41,7 @@ class SplashScreen extends React.PureComponent<Props> {
             </Button>
           </div>
         </div>
-        <div className="SplashScreen-mission SplashScreen-opacity-layer SplashScreen-opacity70">
+        <div className="SplashScreen-mission SplashScreen-opacity-layer SplashScreen-opacity20">
           <p>DemocracyLab is a nonprofit organization.</p>
           <p>Our mission is to empower people who use technology to advance the public good.</p>
         </div>


### PR DESCRIPTION
Updates splash screen to randomly select one of our hero images on pageload, adds CSS opacity layers for readability without having to manually edit each image.

Adding more images to the rotation is as simple as uploading them to the CDN and updating the `heroImages` array with their filenames.

Still to do: 
- [x] deploy to a test environment
- [ ] decide if the images work in all the aspect ratios we have
- [ ] check opacity values w/ team, see if we want to change them. the prototype operated differently from the end product here, so we may want to adjust.