### PR TITLE
20191205 fixes

### DIFF
--- a/civictechprojects/sitemaps.py
+++ b/civictechprojects/sitemaps.py
@@ -11,14 +11,21 @@ class SectionSitemap(Sitemap):
     priority = 0.5
     # TODO: Update this date for each release
     lastmod = settings.SITE_LAST_UPDATED
-    sections = [FrontEndSection.AboutUs, FrontEndSection.FindProjects, FrontEndSection.PartnerWithUs, FrontEndSection.Donate,
-                FrontEndSection.Press, FrontEndSection.ContactUs]
+    pages = [
+        str(FrontEndSection.AboutUs.value),
+        str(FrontEndSection.FindProjects.value),
+        str(FrontEndSection.FindProjects.value) + '&showSplash=1',
+        str(FrontEndSection.PartnerWithUs.value),
+        str(FrontEndSection.Donate.value),
+        str(FrontEndSection.Press.value),
+        str(FrontEndSection.ContactUs.value)
+    ]
 
     def items(self):
-        return self.sections
+        return self.pages
 
-    def location(self, section):
-        return '/index/?section=' + str(section.value)
+    def location(self, page):
+        return '/index/?section=' + page
 
 
 class ProjectSitemap(Sitemap):

--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -169,9 +169,7 @@
 }
 
 .AboutProjects-details {
-    #project-details {
-      white-space: pre-wrap;
-    }
+    white-space: pre-wrap;
 }
 
 .AboutProjects-skills-container {

--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -215,7 +215,8 @@
 }
 .AboutProjects-jumplink {
   /* anchor tag is moved "higher up" than its content to account for Bootstrap fixed nav bar */
-  top: -$header-height;
+  /* TODO: Make the component use the React prop from MainHeader and then remove this rule, so it can account for the alert message */
+  top: -60px;
 }
 .AboutProjects-positions-available {
   padding: 25px 10px; /*as with description-details consider maxwidth */

--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -168,7 +168,7 @@
       }
 }
 
-.AboutProjects-details {
+.AboutProjects-details-description {
     white-space: pre-wrap;
 }
 

--- a/civictechprojects/static/css/partials/_CreateProjectForm.scss
+++ b/civictechprojects/static/css/partials/_CreateProjectForm.scss
@@ -20,7 +20,7 @@
 }
 
 .create-project-saved-emblem {
-    margin-right: 1rem;
+    margin: auto 1rem auto auto;
     font-weight: bold;
     color: $color-orange;
 }

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -313,7 +313,11 @@ def clean_nonexistent_tags(tags, tag_dict):
 
 
 def projects_by_keyword(keyword):
-    return Project.objects.filter(Q(project_description__icontains=keyword) | Q(project_name__icontains=keyword))
+    return Project.objects.filter(Q(project_name__icontains=keyword)
+                                  | Q(project_short_description__icontains=keyword)
+                                  | Q(project_description__icontains=keyword)
+                                  | Q(project_description_solution__icontains=keyword)
+                                  | Q(project_description_actions__icontains=keyword))
 
 
 def projects_by_sortField(project_list, sortField):

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -228,7 +228,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
               {project.project_description}
               {!_.isEmpty(project.project_description_solution) &&
                 <React.Fragment>
-                  <div>
+                  <div className="AboutProjects-details-description">
                     <br></br>
                     {project.project_description_solution}
                   </div>

--- a/common/components/common/projects/ProjectVolunteerRenewModal.jsx
+++ b/common/components/common/projects/ProjectVolunteerRenewModal.jsx
@@ -137,7 +137,6 @@ class ProjectVolunteerRenewModal extends React.PureComponent<Props, State> {
       options={volunteerPeriodsInDays}
       value={this.state.daysToVolunteerForOption}
       onChange={this.handleVolunteerPeriodSelection.bind(this)}
-      className="form-control"
       simpleValue={true}
       isClearable={false}
       isMulti={false}


### PR DESCRIPTION
Fixes for our December 5 (ish) 2019 release

- [x] Project Profile: Newlines in Problem/Solution/Actions aren't displayed
- [x] My Projects: Volunteer Renewal position selection is outside container box 
- [x] Sitemaps.xml: Was not displaying Find Projects splash page
- [x] Find Projects: Searching by keyword was not searching through short description, solutions, or actions field
- [x] [Firefox] Project Profile: Blank url shows empty space
- [x] Create Projects: Saved icon now shows up in center of screen rather than right next to 'Next' button
- [x] **partial** fixes for: Clicking 'Details'  and 'Skills Needed' links on Project Profile page scrolls page slightly too low (under the floating header)