### PR TITLE
Don't use fixed aspect ratio for project and user images

### DIFF
--- a/common/components/common/upload/ImageCropUploadButton.jsx
+++ b/common/components/common/upload/ImageCropUploadButton.jsx
@@ -12,7 +12,7 @@ type Props = {|
   cropButtonText: string,
   acceptedFileTypes: string,
   iconClass: string,
-  aspect: number
+  aspect: ?number
 |};
 
 type State = {|
@@ -23,17 +23,21 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
 
   constructor(props): void {
     super(props);
-    const aspect = props.aspect || 1 / 1;
+    let cropSettings = props.aspect
+      ? {aspect:props.aspect}
+      : {
+        unit:"%",
+        x:5,
+        y:5,
+        width:90,
+        height:90
+      };
     this.state = {
       s3Key: "",
       src: null,
       isCropping: false,
       croppedImageUrl: '',
-      crop: {
-        unit:"%",
-        width:30,
-        aspect: aspect
-      }
+      crop: cropSettings
     };
   }
 

--- a/common/components/forms/ImageCropUploadFormElement.jsx
+++ b/common/components/forms/ImageCropUploadFormElement.jsx
@@ -46,11 +46,13 @@ class ImageCropUploadFormElement extends React.PureComponent<Props,State> {
   }
 
   render(): React$Node {
-    const aspect = this.props.aspect || 1 / 1;
     const previewImage = this.props.currentImage ? this.props.currentImage.publicUrl : '';
     return (
       <div>
-        <ImageCropUploadButton currentImage={previewImage} aspect={aspect} buttonText={this.props.buttonText || "Upload Image"} onFileUpload={this._handleFileSelection.bind(this)}/>
+        <ImageCropUploadButton currentImage={previewImage}
+                               aspect={this.props.aspect}
+                               buttonText={this.props.buttonText || "Upload Image"}
+                               onFileUpload={this._handleFileSelection.bind(this)}/>
         <input type="hidden" ref="hiddenFormField" name={this.props.form_id} id={this.props.form_id} />
       </div>
     );


### PR DESCRIPTION
Currently users are locked to a 1:1 aspect ratio when uploading project and user profile images.  This is causing issues for people, so we're changing it to not be locked to 1:1 for those images.