### PR TITLE
update slack links in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Make sure you've followed our [Contributor Guide](https://docs.google.com/docume
 
 ## Where's the best place to ask a question?
 
-Our [Slack](https://join.slack.com/t/democracylab-org/shared_invite/enQtMjQyNDMxOTY2NjA4LTU3MTYyM2EwYTRmMDYwNzUyNjg4YTk1NjEyZTg0ZjgxNzYwY2E5ODIyMTNjZGZkOTI5NTAyZTMwNTNiMWRiZTA). While you can submit an issue through Github, response time will be slower than asking in Slack. Depending on what your question is, try one of these channels:
+Our [Slack](https://join.slack.com/t/democracylab-org/shared_invite/enQtMjY3OTQ1NDI2NzU1LTQzNDBkYTVjNmY1MTU3ZDNjMjI5YzRkNjY0MTRjZDc1ZTZlYTlhODlmMjhjM2QyOGE4ZTRmNjljMTIwMzc3NTA). While you can submit an issue through Github, response time will be slower than asking in Slack. Depending on what your question is, try one of these channels:
   - `#design` for anything related to the overall site design, UI, or user experience
   - `#developers` for anything related to the function of the site or a given component, as well as technical assistance on contributing
   - `#general` for anything else

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Our platform connects skilled volunteers with technology-for-good projects, resu
 
 ## Getting Started
 
-First, [join our Slack](https://join.slack.com/t/democracylab-org/shared_invite/enQtMjQyNDMxOTY2NjA4LTU3MTYyM2EwYTRmMDYwNzUyNjg4YTk1NjEyZTg0ZjgxNzYwY2E5ODIyMTNjZGZkOTI5NTAyZTMwNTNiMWRiZTA)! We communicate and coordinate our work there. For developers, reach out in the `#developers` channel to @marlon-keating, engineering lead, and let us know you want to contribute. We'll get back to you as soon as we can.
+First, [join our Slack](https://join.slack.com/t/democracylab-org/shared_invite/enQtMjY3OTQ1NDI2NzU1LTQzNDBkYTVjNmY1MTU3ZDNjMjI5YzRkNjY0MTRjZDc1ZTZlYTlhODlmMjhjM2QyOGE4ZTRmNjljMTIwMzc3NTA)! We communicate and coordinate our work there. For developers, reach out in the `#developers` channel to @marlon-keating, engineering lead, and let us know you want to contribute. We'll get back to you as soon as we can.
 
 Next, follow DemocracyLab's [Contributor Guide](https://docs.google.com/document/d/1OLQPFFJ8oz_BxpuxRxKKdZ2brmlUkVN3ICTdbA_axxY/). This guide will get you up and running with a copy of our project for development and testing purposes as quickly as possible. If you have questions, just put them in Slack and we'll get them sorted out.
 


### PR DESCRIPTION
Updates our README and CONTRIBUTING documents to have the same Slack invite link as our website, addressing #316 (thanks for letting us know about it!)

It's difficult for me to test since I'm a member of the slack already but the link seems to function so ... probably good?

