### PR TITLE
Peter/partner fix

### DIFF
--- a/common/components/controllers/PartnerWithUsController.jsx
+++ b/common/components/controllers/PartnerWithUsController.jsx
@@ -39,7 +39,6 @@ class PartnerWithUsController extends React.Component<{||}> {
           {this._renderPlatformSponsorshipSection()}
         </div>
         {this._renderPartnersSection()}
-      }
       </div>
       </React.Fragment>
     );

--- a/common/components/controllers/PartnerWithUsController.jsx
+++ b/common/components/controllers/PartnerWithUsController.jsx
@@ -38,14 +38,8 @@ class PartnerWithUsController extends React.Component<{||}> {
           {this._renderEventSponsorshipSection()}
           {this._renderPlatformSponsorshipSection()}
         </div>
-        <div className="PartnerWithUsController-partners col-12">
-          <h2>Our Partnerships</h2>
-          {this._renderSponsors("Visionary")}
-          {this._renderSponsors("Sustaining")}
-          {this._renderSponsors("Advancing")}
-          {this._renderSponsors("Supporting")}
-        </div>
-
+        {this._renderPartnersSection()}
+      }
       </div>
       </React.Fragment>
     );
@@ -71,6 +65,22 @@ class PartnerWithUsController extends React.Component<{||}> {
         </p>
       </div>
     );
+  }
+
+  _renderPartnersSection(): React$Node {
+    const sponsors: $ReadOnlyArray<SponsorMetadata> = Sponsors.list();
+    // check if we have any sponsors at all before rendering anthing
+    if (sponsors.length > 0) {
+      return (
+        <div className="PartnerWithUsController-partners col-12">
+          <h2>Our Partnerships</h2>
+          {this._renderSponsors("Visionary")}
+          {this._renderSponsors("Sustaining")}
+          {this._renderSponsors("Advancing")}
+          {this._renderSponsors("Supporting")}
+        </div>
+      )
+    }
   }
 
   _renderPlatformSponsorshipSection(): React$Node {

--- a/common/components/utils/Sponsors.js
+++ b/common/components/utils/Sponsors.js
@@ -16,6 +16,8 @@ class Sponsors {
       const sponsorMetadata:string = window.SPONSORS_METADATA;
       if(!_.isEmpty(sponsorMetadata)) {
         return JSON.parse(_.unescape(sponsorMetadata));
+      } else {
+        return [];
       }
     } catch(ex) {
       console.error("Failed to parse sponsor metadata. ", ex);


### PR DESCRIPTION
Adds a conditional rendering check to the entire Our Partnerships section on the Partner With Us page so that in the event we have no sponsor data, it won't render an empty header.

There's also a small change to our Sponsors utility to return an empty array if the input couldn't be parsed. I ran into an issue where if I set `SPONSORS_METADATA=""` I got an undefined error attempting to access it (e.g. `const sponsors = Sponsors.list()`) which caused the page load to fail. Now it returns an empty array and the page loads and the conditionals work regardless of metadata state.

Theoretically, it will still render if the SPONSORS_METADATA field has an array of objects but none of them are formatted correctly (so they're rejected by the "Sustaining," "Advancing," etc categories but pass the length > 0 test) but I think that's pretty low risk since we control what goes in there.