### PR TITLE
Add prerender toggle environment variable

### DIFF
--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -353,6 +353,7 @@ SEO_JS_PRERENDER_TOKEN = os.environ.get('SEO_JS_PRERENDER_TOKEN', '')
 SEO_JS_BACKEND = "common.helpers.caching.DebugPrerenderIO"
 SEO_JS_PRERENDER_URL = os.environ.get('SEO_JS_PRERENDER_URL', 'http://localhost:3000/')  # Note trailing slash.
 SEO_JS_PRERENDER_RECACHE_URL = SEO_JS_PRERENDER_URL + "recache"
+SEO_JS_ENABLED = os.environ.get('SEO_JS_ENABLED', False)
 
 # TODO: Put in environment variable
 SEO_JS_USER_AGENTS = (

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -95,3 +95,6 @@ export DL_PAGES_LAST_UPDATED='2019-12-05'
 
 # Disallow crawling for non-production environments
 export DISALLOW_CRAWLING=True
+
+# Turn on Prerender (hosted environments only)
+# export SEO_JS_ENABLED=True


### PR DESCRIPTION
Prerender is now turned off by default, and can be turned on by setting SEO_JS_ENABLED=True
