### PR TITLE
Only use prerendered pages that are exposed in our sitemap

### DIFF
--- a/civictechprojects/sitemaps.py
+++ b/civictechprojects/sitemaps.py
@@ -2,7 +2,6 @@ from common.helpers.constants import FrontEndSection
 from django.conf import settings
 from django.contrib.sitemaps import Sitemap
 from .models import Project
-from datetime import date
 
 
 class SectionSitemap(Sitemap):
@@ -41,3 +40,15 @@ class ProjectSitemap(Sitemap):
 
     def lastmod(self, project):
         return project.project_date_modified
+
+
+def get_all_sitemap_paths():
+    sitemap_paths = []
+    for sitemap_class in [SectionSitemap, ProjectSitemap]:
+        sitemap_instance = sitemap_class()
+        sitemap_paths = sitemap_paths + list(map(lambda item: sitemap_instance.location(item), sitemap_instance.items()))
+
+    return sitemap_paths
+
+
+all_sitemap_paths = get_all_sitemap_paths()

--- a/common/helpers/caching.py
+++ b/common/helpers/caching.py
@@ -26,7 +26,6 @@ def is_prerenderable_request(request):
         # Only prerender urls that are listed in the sitemap
         for url in all_sitemap_paths:
             if url in full_path:
-                print('Can prerender ' + full_path)
                 return True
     else:
         return False
@@ -45,7 +44,7 @@ class DebugUserAgentMiddleware(SelectedBackend):
             return
 
         if not is_prerenderable_request(request):
-            print('Prerender: do not prerender ' + request.path)
+            print('Prerender: do not prerender ' + request.get_full_path())
             return
 
         if "HTTP_USER_AGENT" not in request.META:
@@ -56,6 +55,7 @@ class DebugUserAgentMiddleware(SelectedBackend):
             print('Prerender: User agent "{agent}" not in list'.format(agent=request.META["HTTP_USER_AGENT"]))
             return
 
+        print('Prerender: Retrieving prerendered ' + request.get_full_path())
         url = self.backend.build_absolute_uri(request)
         try:
             return self.backend.get_response_for_url(url)

--- a/common/helpers/caching.py
+++ b/common/helpers/caching.py
@@ -1,12 +1,12 @@
+from civictechprojects.sitemaps import all_sitemap_paths
 from common.helpers.constants import FrontEndSection
 from common.helpers.front_end import section_url
 from django_seo_js import settings
-from django_seo_js.helpers import update_cache_for_url
+from django_seo_js.helpers import update_cache_for_url, request_should_be_ignored
 from django_seo_js.backends import SEOBackendBase, SelectedBackend
 from django_seo_js.backends.base import RequestsBasedBackend
 
 import re
-from django_seo_js.helpers import request_should_be_ignored
 import logging
 logger = logging.getLogger(__name__)
 
@@ -18,6 +18,18 @@ def update_cached_project_url(project_id):
 # Update url cached with our 3rd party prerender service
 def update_cached_url(url):
     update_cache_for_url(url)
+
+
+def is_prerenderable_request(request):
+    full_path = request.get_full_path()
+    if not request_should_be_ignored(request):
+        # Only prerender urls that are listed in the sitemap
+        for url in all_sitemap_paths:
+            if url in full_path:
+                print('Can prerender ' + full_path)
+                return True
+    else:
+        return False
 
 
 class DebugUserAgentMiddleware(SelectedBackend):
@@ -32,8 +44,8 @@ class DebugUserAgentMiddleware(SelectedBackend):
             print('Prerender: settings.ENABLED False')
             return
 
-        if request_should_be_ignored(request):
-            print('Prerender: request_should_be_ignored')
+        if not is_prerenderable_request(request):
+            print('Prerender: do not prerender ' + request.path)
             return
 
         if "HTTP_USER_AGENT" not in request.META:


### PR DESCRIPTION
We are currently trying to use prerendered versions of pages that do not get cached by the prerender service.  With this change, we will only attempt to fetch prerendered versions of pages if they are part of our sitemap.