### PR TITLE
Bug Fix:  Prerender urls matching sitemap by substring rather than exactly

### DIFF
--- a/common/helpers/caching.py
+++ b/common/helpers/caching.py
@@ -25,7 +25,7 @@ def is_prerenderable_request(request):
     if not request_should_be_ignored(request):
         # Only prerender urls that are listed in the sitemap
         for url in all_sitemap_paths:
-            if url in full_path:
+            if url == full_path:
                 return True
     else:
         return False

--- a/common/helpers/caching.py
+++ b/common/helpers/caching.py
@@ -21,14 +21,17 @@ def update_cached_url(url):
 
 
 def is_prerenderable_request(request):
-    full_path = request.get_full_path()
     if not request_should_be_ignored(request):
         # Only prerender urls that are listed in the sitemap
-        for url in all_sitemap_paths:
-            if url == full_path:
-                return True
+        return is_sitemap_url(request.get_full_path())
     else:
         return False
+
+
+def is_sitemap_url(url):
+    for sitemap_url in all_sitemap_paths:
+        if sitemap_url == url:
+            return True
 
 
 class DebugUserAgentMiddleware(SelectedBackend):

--- a/common/tests/test_helpers.py
+++ b/common/tests/test_helpers.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from common.helpers.caching import is_sitemap_url
+from civictechprojects.sitemaps import all_sitemap_paths
+
+
+class CommonHelperTests(TestCase):
+
+    def test_prerender_urls(self):
+        urls = all_sitemap_paths
+        for url in urls:
+            self.assertTrue(is_sitemap_url(url), 'Should be able to prerender ' + url)
+
+    def test_do_not_prerender_urls(self):
+        urls = [
+            '/projects/signup/',
+            '/index/?section=FindProjects&sortField=project_name'
+        ]
+        for url in urls:
+            self.assertFalse(is_sitemap_url(url), 'Should not be able to prerender ' + url)
+
+


### PR DESCRIPTION
The way we were detecting whether prospective urls matched what was in the sitemap, and therefore should be prerendered, made it so that urls only had to match by substring, which led to many false positives.  This corrects the issue, and adds unit tests to test the changes with valid and invalid urls.

