### PR TITLE
Add Volunteering terms to Sign Up page

### DIFF
--- a/civictechprojects/static/css/partials/_SignUpController.scss
+++ b/civictechprojects/static/css/partials/_SignUpController.scss
@@ -3,3 +3,11 @@
   margin-top: 100px;
   width: 100%;
 }
+
+.LogInController-root input + span{
+  padding-left: 10px;
+}
+
+.Terms-body li{
+  padding-bottom: 5px;
+}

--- a/common/components/chrome/PseudoLink.jsx
+++ b/common/components/chrome/PseudoLink.jsx
@@ -1,0 +1,26 @@
+// @flow
+
+import React from 'react';
+
+type Props = {|
+  +text: string,
+  +onClick: () => void
+|};
+
+class PseudoLink extends React.PureComponent<Props> {
+  
+  onClick(e): void {
+    // Prevent any page navigation
+    e.preventDefault();
+    this.props.onClick();
+  }
+  
+  render(): React$Node{
+    // TODO: Implement with styled text instead of anchor
+    return (
+      <a href="#" onClick={this.onClick.bind(this)} >{this.props.text}</a>
+    );
+  }
+}
+
+export default PseudoLink;

--- a/common/components/common/confirmation/TermsModal.jsx
+++ b/common/components/common/confirmation/TermsModal.jsx
@@ -36,18 +36,20 @@ class TermsModal extends React.PureComponent<Props, State> {
   render(): React$Node {
     return (
       <NotificationModal headerText="Terms of Volunteering" buttonText="Close and Continue" showModal={this.state.showModal} onClickButton={this.confirm.bind(this)}>
-        <ul>
-          <li>I am volunteering solely for my personal purposes or pleasure, including for civic, charitable, or humanitarian reasons.</li>
-          <li>I am freely donating my volunteer services and have no expectation of receiving and have not been promised compensation or benefits in exchange for any assistance I provide to project owners.</li>
-          <li>I am donating my volunteer services to the owner of a tech-for-good project, not to DemocracyLab itself, and any associated liability is entirely with that project owner.</li>
-          <li>I release and forever discharge and hold harmless DemocracyLab from any and all liability, claims, and demands related to my volunteering for third-party project owners, use of the DemocracyLab website, and attendance at DemocracyLab events. </li>
-          <li>I understand that if I am responsible for injuries or property damage to project owners or others while acting outside the scope of volunteer assignments, that I may be held personally liable by the injured party.</li>
-          <li>I will perform the project tasks on a temporary, fully-independent basis without significant and ongoing control of work schedules and conditions by the project owner.</li>
-          <li>I am not volunteering for an organization with which I am employed nor am I expecting to receive a job offer from a project owner.</li>
-          <li>I will not perform the type of work an employee would typically perform for a project owner’s customers or clients nor will I supervise employees of a project owner. I will use my own tools and equipment and will not seek reimbursement for any purchases of materials or supplies.</li>
-          <li>I grant DemocracyLab permission to use all photographs, images, video, or audio recordings of me in connection with my attendance at DemocracyLab events or volunteering for project owners.</li>
-          <li>I am at least 18 years old and possess the authority to bind myself to this agreement.</li>
-        </ul>
+        <div className="Terms-body">
+          <ul>
+            <li>I am volunteering solely for my personal purposes or pleasure, including for civic, charitable, or humanitarian reasons.</li>
+            <li>I am freely donating my volunteer services and have no expectation of receiving and have not been promised compensation or benefits in exchange for any assistance I provide to project owners.</li>
+            <li>I am donating my volunteer services to the owner of a tech-for-good project, not to DemocracyLab itself, and any associated liability is entirely with that project owner.</li>
+            <li>I release and forever discharge and hold harmless DemocracyLab from any and all liability, claims, and demands related to my volunteering for third-party project owners, use of the DemocracyLab website, and attendance at DemocracyLab events. </li>
+            <li>I understand that if I am responsible for injuries or property damage to project owners or others while acting outside the scope of volunteer assignments, that I may be held personally liable by the injured party.</li>
+            <li>I will perform the project tasks on a temporary, fully-independent basis without significant and ongoing control of work schedules and conditions by the project owner.</li>
+            <li>I am not volunteering for an organization with which I am employed nor am I expecting to receive a job offer from a project owner.</li>
+            <li>I will not perform the type of work an employee would typically perform for a project owner’s customers or clients nor will I supervise employees of a project owner. I will use my own tools and equipment and will not seek reimbursement for any purchases of materials or supplies.</li>
+            <li>I grant DemocracyLab permission to use all photographs, images, video, or audio recordings of me in connection with my attendance at DemocracyLab events or volunteering for project owners.</li>
+            <li>I am at least 18 years old and possess the authority to bind myself to this agreement.</li>
+          </ul>
+        </div>
       </NotificationModal>
     );
   }

--- a/common/components/common/confirmation/TermsModal.jsx
+++ b/common/components/common/confirmation/TermsModal.jsx
@@ -1,0 +1,56 @@
+// @flow
+
+import React from 'react';
+import NotificationModal from "../notification/NotificationModal.jsx";
+
+type Props = {|
+  showModal: boolean,
+  onSelection: () => void
+|};
+type State = {|
+  showModal: boolean,
+|};
+
+/**
+ * Modal for getting yes/no confirmation
+ */
+class TermsModal extends React.PureComponent<Props, State> {
+  constructor(props: Props): void {
+    super(props);
+    this.state = {
+      showModal: false
+    }
+  }
+
+  componentWillReceiveProps(nextProps: Props): void {
+    this.setState({ showModal: nextProps.showModal });
+  }
+
+  confirm(): void {
+    this.props.onSelection();
+    this.setState({
+      showModal: false
+    });
+  }
+
+  render(): React$Node {
+    return (
+      <NotificationModal headerText="Terms of Volunteering" buttonText="Close and Continue" showModal={this.state.showModal} onClickButton={this.confirm.bind(this)}>
+        <ul>
+          <li>I am volunteering solely for my personal purposes or pleasure, including for civic, charitable, or humanitarian reasons.</li>
+          <li>I am freely donating my volunteer services and have no expectation of receiving and have not been promised compensation or benefits in exchange for any assistance I provide to project owners.</li>
+          <li>I am donating my volunteer services to the owner of a tech-for-good project, not to DemocracyLab itself, and any associated liability is entirely with that project owner.</li>
+          <li>I release and forever discharge and hold harmless DemocracyLab from any and all liability, claims, and demands related to my volunteering for third-party project owners, use of the DemocracyLab website, and attendance at DemocracyLab events. </li>
+          <li>I understand that if I am responsible for injuries or property damage to project owners or others while acting outside the scope of volunteer assignments, that I may be held personally liable by the injured party.</li>
+          <li>I will perform the project tasks on a temporary, fully-independent basis without significant and ongoing control of work schedules and conditions by the project owner.</li>
+          <li>I am not volunteering for an organization with which I am employed nor am I expecting to receive a job offer from a project owner.</li>
+          <li>I will not perform the type of work an employee would typically perform for a project owner’s customers or clients nor will I supervise employees of a project owner. I will use my own tools and equipment and will not seek reimbursement for any purchases of materials or supplies.</li>
+          <li>I grant DemocracyLab permission to use all photographs, images, video, or audio recordings of me in connection with my attendance at DemocracyLab events or volunteering for project owners.</li>
+          <li>I am at least 18 years old and possess the authority to bind myself to this agreement.</li>
+        </ul>
+      </NotificationModal>
+    );
+  }
+}
+
+export default TermsModal;

--- a/common/components/common/notification/NotificationModal.jsx
+++ b/common/components/common/notification/NotificationModal.jsx
@@ -39,7 +39,7 @@ class NotificationModal extends React.PureComponent<Props, State> {
     return (
       <div>
           <Modal show={this.state.showModal} size="lg">
-              <Modal.Header style={{whiteSpace: "pre-wrap"}} closeButton>
+              <Modal.Header style={{whiteSpace: "pre-wrap"}}>
                   <Modal.Title>{this.props.headerText}</Modal.Title>
               </Modal.Header>
               <Modal.Body style={{whiteSpace: "pre-wrap"}}>

--- a/common/components/common/notification/NotificationModal.jsx
+++ b/common/components/common/notification/NotificationModal.jsx
@@ -6,7 +6,7 @@ import Modal from 'react-bootstrap/Modal';
 
 type Props = {|
   showModal: boolean,
-  message: string,
+  message: ?string, // If message not included, use props.children instead
   buttonText: string,
   headerText: ?string,
   onClickButton: () => void
@@ -43,7 +43,7 @@ class NotificationModal extends React.PureComponent<Props, State> {
                   <Modal.Title>{this.props.headerText}</Modal.Title>
               </Modal.Header>
               <Modal.Body style={{whiteSpace: "pre-wrap"}}>
-                {this.props.message}
+                {this.props.message ? this.props.message : this.props.children}
               </Modal.Body>
               <Modal.Footer>
                   <Button variant="primary" onClick={this.closeModal.bind(this)}>{this.props.buttonText}</Button>

--- a/common/components/controllers/SignUpController.jsx
+++ b/common/components/controllers/SignUpController.jsx
@@ -8,7 +8,9 @@ import metrics from "../utils/metrics.js";
 import moment from 'moment';
 import _ from 'lodash';
 import Headers from "../common/Headers.jsx";
+import PseudoLink from "../chrome/PseudoLink.jsx";
 import SocialMediaSignupSection from "../common/integrations/SocialMediaSignupSection.jsx";
+import TermsModal from "../common/confirmation/TermsModal.jsx";
 
 type Props = {|
   +errors: {+[key: string]: $ReadOnlyArray<string>},
@@ -21,6 +23,9 @@ type State = {|
   password1: string,
   password2: string,
   validations: $ReadOnlyArray<Validator>,
+  termsOpen: boolean,
+  didReadTerms: boolean,
+  didCheckTerms: boolean,
   isValid: boolean
 |}
 
@@ -42,6 +47,9 @@ class SignUpController extends React.Component<Props, State> {
       email: '',
       password1: '',
       password2: '',
+      termsOpen: false,
+      didReadTerms: false,
+      didCheckTerms: false,
       isValid: false,
       validations: [
         {
@@ -72,6 +80,10 @@ class SignUpController extends React.Component<Props, State> {
           checkFunc: (state: State) => state.password1 === state.password2,
           errorMessage: "Passwords don't match"
         },
+        {
+          checkFunc: (state: State) => state.didCheckTerms,
+          errorMessage: "Check terms of service"
+        }
       ]
     };
   }
@@ -151,6 +163,19 @@ class SignUpController extends React.Component<Props, State> {
             />
           </div>
           <input name="password" value={this.state.password1} type="hidden" />
+          
+          <div>
+            <input
+              name="read"
+              type="checkbox"
+              disabled={!this.state.didReadTerms}
+              onChange={e => this.setState({didCheckTerms: !this.state.didCheckTerms})}
+            />
+            I have read and accepted the <PseudoLink text="terms of Volunteering" onClick={e => this.setState({termsOpen: true})}/>
+            
+          </div>
+          
+          <TermsModal showModal={this.state.termsOpen} onSelection={() => this.setState({termsOpen: false, didReadTerms: true})}/>
 
           {/* TODO: Replace with visible forms, or modify backend. */}
           <input name="postal_code" value="123456" type="hidden" />

--- a/common/components/controllers/SignUpController.jsx
+++ b/common/components/controllers/SignUpController.jsx
@@ -82,7 +82,7 @@ class SignUpController extends React.Component<Props, State> {
         },
         {
           checkFunc: (state: State) => state.didCheckTerms,
-          errorMessage: "Check terms of service"
+          errorMessage: "Agree to terms of service"
         }
       ]
     };
@@ -169,9 +169,10 @@ class SignUpController extends React.Component<Props, State> {
               name="read"
               type="checkbox"
               disabled={!this.state.didReadTerms}
+              title={!this.state.didReadTerms && "Please read terms before clicking"}
               onChange={e => this.setState({didCheckTerms: !this.state.didCheckTerms})}
             />
-            I have read and accepted the <PseudoLink text="terms of Volunteering" onClick={e => this.setState({termsOpen: true})}/>
+            <span> I have read and accepted the <PseudoLink text="Terms of Volunteering" onClick={e => this.setState({termsOpen: true})}/> </span>
             
           </div>
           

--- a/common/models/Tag_definitions.csv
+++ b/common/models/Tag_definitions.csv
@@ -258,3 +258,4 @@ for-profit,"For Profit Company (Corporation, LLC, Partership, Sole Propreitorshi
 informal,Informal (No Legal Entity Established),,Organization Type,,
 hacky-new-year-2019,Hacky New Year 2019,,Organization,,
 hacky-new-year-2020,Hacky New Year 2020,,Organization,,
+st-hack-tricks-day-2020,St. Hack-trick's Day 2020,,Organization,,


### PR DESCRIPTION
When new users come to sign up, they will now be asked to read and accept terms of service first.