### PR TITLE
fix crowding issue with long titles in About Us page

### DIFF
--- a/civictechprojects/static/css/partials/_AboutUs.scss
+++ b/civictechprojects/static/css/partials/_AboutUs.scss
@@ -110,6 +110,7 @@
   flex-basis: 50%; /* default 2 wide, will raise at wider breakpoints */
   margin-bottom: 25px;
   text-align: center;
+  padding: 0 5px;
 }
 .about-us-team-card p {
   font-size: 18px;
@@ -253,6 +254,7 @@
   }
   .about-us-team-card {
     flex-basis: 33%;
+    padding: 0 10px;
   }
 }
 
@@ -275,6 +277,7 @@
 @include media-breakpoint-up(xl) {
   .about-us-team-card {
     flex-basis: 25%;
+    padding: 0 20px;
   }
 }
 @include media-breakpoint-up(xxl) {


### PR DESCRIPTION
If two (or more) people on the about us page have long titles, the text gets crowded up against each other a lot. This adds some separation at each breakpoint to ensure the text will have some space between.