### PR TITLE
 2/21/2020 Release Bugfixes

### DIFF
--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -35,6 +35,7 @@
     grid-column: 1/5;
     grid-row: 3;
     margin-left: 0.5rem;
+    word-break: break-word; // prevent long project titles from breaking flow
   }
   .ProjectCard-subinfo {
     grid-column: 3/5;

--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -35,7 +35,6 @@
     grid-column: 1/5;
     grid-row: 3;
     margin-left: 0.5rem;
-    word-break: break-word; // prevent long project titles from breaking flow
   }
   .ProjectCard-subinfo {
     grid-column: 3/5;

--- a/civictechprojects/static/css/partials/_ProjectCard.scss
+++ b/civictechprojects/static/css/partials/_ProjectCard.scss
@@ -56,6 +56,7 @@
   margin-right: 0.375rem;
 }
 .ProjectCard-title {
+  overflow-wrap: break-word; // prevent long project titles from breaking flow
   grid-column: 3 / 5;
   grid-row: 1 / 2;
 }

--- a/civictechprojects/static/css/partials/_ProjectCard.scss
+++ b/civictechprojects/static/css/partials/_ProjectCard.scss
@@ -56,7 +56,6 @@
   margin-right: 0.375rem;
 }
 .ProjectCard-title {
-  word-break: break-all; // prevent long project titles from breaking flow
   grid-column: 3 / 5;
   grid-row: 1 / 2;
 }

--- a/common/components/common/notification/NotificationModal.jsx
+++ b/common/components/common/notification/NotificationModal.jsx
@@ -38,8 +38,8 @@ class NotificationModal extends React.PureComponent<Props, State> {
   render(): React$Node {
     return (
       <div>
-          <Modal show={this.state.showModal} size="lg">
-              <Modal.Header style={{whiteSpace: "pre-wrap"}}>
+          <Modal show={this.state.showModal} size="lg" onHide={this.closeModal.bind(this)}>
+              <Modal.Header style={{whiteSpace: "pre-wrap"}} closeButton>
                   <Modal.Title>{this.props.headerText}</Modal.Title>
               </Modal.Header>
               <Modal.Body style={{whiteSpace: "pre-wrap"}}>

--- a/common/components/controllers/SignUpController.jsx
+++ b/common/components/controllers/SignUpController.jsx
@@ -24,7 +24,6 @@ type State = {|
   password2: string,
   validations: $ReadOnlyArray<Validator>,
   termsOpen: boolean,
-  didReadTerms: boolean,
   didCheckTerms: boolean,
   isValid: boolean
 |}
@@ -48,7 +47,6 @@ class SignUpController extends React.Component<Props, State> {
       password1: '',
       password2: '',
       termsOpen: false,
-      didReadTerms: false,
       didCheckTerms: false,
       isValid: false,
       validations: [
@@ -168,15 +166,13 @@ class SignUpController extends React.Component<Props, State> {
             <input
               name="read"
               type="checkbox"
-              disabled={!this.state.didReadTerms}
-              title={!this.state.didReadTerms && "Please read terms before clicking"}
               onChange={e => this.setState({didCheckTerms: !this.state.didCheckTerms})}
             />
             <span> I have read and accepted the <PseudoLink text="Terms of Volunteering" onClick={e => this.setState({termsOpen: true})}/> </span>
             
           </div>
           
-          <TermsModal showModal={this.state.termsOpen} onSelection={() => this.setState({termsOpen: false, didReadTerms: true})}/>
+          <TermsModal showModal={this.state.termsOpen} onSelection={() => this.setState({termsOpen: false})}/>
 
           {/* TODO: Replace with visible forms, or modify backend. */}
           <input name="postal_code" value="123456" type="hidden" />


### PR DESCRIPTION
Fixes:

  - Sign up: Users are not required to open terms modal before checking agreement box
  - Terms modal: Close button in the upper right is re-enabled and clicking outside the modal dismisses it
  - Project Cards (Home page, Find Projects page): Text no longer breaks on any character to fill line space, instead it breaks on word breaks if at all possible