### PR TITLE
Remove email entry from Subscribe to our newsletter section

### DIFF
--- a/common/components/common/integrations/NewsletterSignup.jsx
+++ b/common/components/common/integrations/NewsletterSignup.jsx
@@ -20,14 +20,6 @@ render() {
           <div className="mc-field-group SocialFooter-signupcontainer">
             <label htmlFor="mce-EMAIL" />
             <input
-              type="email"
-              defaultValue=""
-              placeholder="Enter your email address"
-              name="EMAIL"
-              className="required email"
-              id="mce-EMAIL"
-            />
-            <input
               type="submit"
               value="Subscribe"
               name="subscribe"


### PR DESCRIPTION
MailChimp required a first name, last name, and email for anyone subscribing.  Our old email entry only required an email address, and when the user was redirected to MailChimp to finish signing up, the page showed an error since the first name and last name fields weren't filled out.  By removing the email field entirely, users now have to enter it on MailChimp's side, but they won't see any errors.