### PR TITLE
Docker: Fix build command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,4 +20,7 @@
 !requirements.txt
 
 # Config
+!webpack.common.js
+!webpack.dev.js
+!webpack.prod.js
 !docker_environment_init.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   web:
     build: .
     command: bash -c 'source ./docker_environment_init.sh || true &&
-                      npm run buildfast &&
+                      npm run dev &&
                       python manage.py runserver 0.0.0.0:8000'
     ports:
       - "8000:8000"


### PR DESCRIPTION
Fixing some issues with the docker setup.

- The build command was the outdated 'buildfast'
- Webpack config files weren't being copied into the working directory