### PR TITLE
About / Homepage splash image updates

### DIFF
--- a/civictechprojects/static/css/partials/_AboutUs.scss
+++ b/civictechprojects/static/css/partials/_AboutUs.scss
@@ -1,15 +1,15 @@
 .about-us-root h1, .about-us-root h2, .about-us-root h3 {
   font-weight: bold;
 }
-.about-us-mission, .about-us-vision {
-  align-items: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-  background-position: center;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  width: 100%;
+.about-us-mission .SplashScreen-content, .about-us-vision .SplashScreen-content {
+  margin: auto 0;
+  text-align: left;
+  h1, h2 {
+    font-size: 48px;
+  }
+  p {
+    font-size: 18px;
+  }
 }
 
 .about-us-mission, .about-us-vision {
@@ -171,6 +171,7 @@
   text-decoration: none;
 }
 /* selector to italicise Board Member titles; requires specific format in env key to work right. */
+/* TODO: refactor to handle this with classnames or similar, this is too fragile */
 .about-us-board-container .about-us-team-card-title div:nth-of-type(1) {
   font-style: italic;
 }

--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -42,7 +42,9 @@
   margin: 5px; /* override this on desktop */
 }
 .LandingController-root .SplashScreen-content {
-  margin: auto;
+  padding-bottom: 2rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 .LandingController-topsplash .SplashScreen-content h1 {
   font-size: 4rem;

--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -66,7 +66,7 @@
   white-space: pre-wrap;
 }
 /* midsplash isn't respecting margin rules because ??? */
-.LandingController-midsplash p, .LandingController-midsplash-btn {
+.LandingController-midsplash p, .LandingController-midsplash a {
   margin-left: auto;
   margin-right: auto;
 }

--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -46,6 +46,9 @@
   margin-left: auto;
   margin-right: auto;
 }
+.LandingController-root .SplashScreen-content h1 {
+  font-size: 2.5rem;
+}
 .LandingController-topsplash .SplashScreen-content h1 {
   font-size: 4rem;
 }

--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -64,6 +64,8 @@
 .LandingController-midsplash p {
   max-width: 500px;
   white-space: pre-wrap;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .LandingController-testimonial-container {
@@ -239,6 +241,9 @@
   }
   .RecentProjects-toggle:hover {
     color: $color-text-dark;
+  }
+  .LandingController-root .SplashScreen-content {
+    padding-bottom: 3rem;
   }
 
 }

--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -47,7 +47,7 @@
   margin-right: auto;
 }
 .LandingController-root .SplashScreen-content h1 {
-  font-size: 2.5rem;
+  font-size: 3rem;
 }
 .LandingController-topsplash .SplashScreen-content h1 {
   font-size: 4rem;
@@ -64,6 +64,9 @@
 .LandingController-midsplash p {
   max-width: 500px;
   white-space: pre-wrap;
+}
+/* midsplash isn't respecting margin rules because ??? */
+.LandingController-midsplash p, .LandingController-midsplash-btn {
   margin-left: auto;
   margin-right: auto;
 }

--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -51,6 +51,7 @@
 }
 .LandingController-topsplash .SplashScreen-content h1 {
   font-size: 4rem;
+  margin-bottom: 0;
 }
 .LandingController-topsplash p {
   font-size: 24px;

--- a/common/components/componentsBySection/FindProjects/SplashScreen.jsx
+++ b/common/components/componentsBySection/FindProjects/SplashScreen.jsx
@@ -20,13 +20,15 @@ type Props = {|
 export const HeroImage: { [key: string]: string } = {
   TopLanding: "CodeForGood_072719_MSReactor-064.jpg",
   MidLanding: "CodeForGood_072719_MSReactor-034.jpg",
-  BottomLanding: "CodeForGood_072719_MSReactor-003.jpg",
+  BottomLanding: "SplashImage-7178-1400.jpg",
+  AboutMission: "CodeForGood_072719_MSReactor-003.jpg",
 };
 
 const heroImages: $ReadOnlyArray<string> = [
   HeroImage.TopLanding,
   "CodeForGood_072719_MSReactor-074.jpg",
-  "CodeForGood_072719_MSReactor-020.jpg"
+  "CodeForGood_072719_MSReactor-020.jpg",
+  "SplashImage-7054-1400.jpg"
 ];
 
 class SplashScreen extends React.PureComponent<Props> {

--- a/common/components/componentsBySection/FindProjects/SplashScreen.jsx
+++ b/common/components/componentsBySection/FindProjects/SplashScreen.jsx
@@ -36,7 +36,7 @@ class SplashScreen extends React.PureComponent<Props> {
   }
 
   render(): React$Node {
-    const opacityValue = isNaN(this.props.opacity) ? 0.5 : this.props.opacity;
+    const opacityValue = _.isNumber(this.props.opacity) ? this.props.opacity : 0.5;
     const backgroundUrl: string = this.props.img ? cdn.image(this.props.img) : this._heroRandomizer();
     const cssClass = "SplashScreen-root SplashScreen-opacity-layer " + this.props.className
     return (

--- a/common/components/componentsBySection/FindProjects/SplashScreen.jsx
+++ b/common/components/componentsBySection/FindProjects/SplashScreen.jsx
@@ -27,8 +27,7 @@ export const HeroImage: { [key: string]: string } = {
 const heroImages: $ReadOnlyArray<string> = [
   HeroImage.TopLanding,
   "CodeForGood_072719_MSReactor-074.jpg",
-  "CodeForGood_072719_MSReactor-020.jpg",
-  "SplashImage-7054-1400.jpg"
+  "CodeForGood_072719_MSReactor-020.jpg"
 ];
 
 class SplashScreen extends React.PureComponent<Props> {

--- a/common/components/componentsBySection/FindProjects/SplashScreen.jsx
+++ b/common/components/componentsBySection/FindProjects/SplashScreen.jsx
@@ -13,6 +13,7 @@ type Props = {|
   bottomOverlayText: ?$ReadOnlyArray<string>,
   img: ?string,
   className: ?string,
+  opacity: ?number,
   onClickFindProjects: () => void
 |};
 
@@ -35,10 +36,11 @@ class SplashScreen extends React.PureComponent<Props> {
   }
 
   render(): React$Node {
+    const opacityValue = isNaN(this.props.opacity) ? 0.5 : this.props.opacity;
     const backgroundUrl: string = this.props.img ? cdn.image(this.props.img) : this._heroRandomizer();
-    const cssClass = "SplashScreen-root SplashScreen-opacity-layer SplashScreen-opacity50 " + this.props.className
+    const cssClass = "SplashScreen-root SplashScreen-opacity-layer " + this.props.className
     return (
-      <div className={cssClass} style={{backgroundImage: 'url(' + backgroundUrl + ')' }}>
+      <div className={cssClass} style={{backgroundImage: 'url(' + backgroundUrl + ')', backgroundColor: `rgba(0,0,0, ${opacityValue})`}}>
         <div className="SplashScreen-content">
           {this.props.header ? <h1>{this.props.header}</h1> : null}
           <div className="SplashScreen-section">

--- a/common/components/controllers/AboutUsController.jsx
+++ b/common/components/controllers/AboutUsController.jsx
@@ -100,7 +100,7 @@ class AboutUsController extends React.PureComponent<{||}, State> {
   _ourMission() {
     return (
       <div className="about-us-mission"
-      style={cdn.bgImage('OurMissionBGoverlay.jpg')}>
+      style={{ backgroundImage: `linear-gradient(to right, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(${cdn.image("CodeForGood_072719_MSReactor-003.jpg")})`}}>
         <div className="about-us-content container">
           <h1>Mission</h1>
           <p>Empower people who use technology to advance the public good.</p>

--- a/common/components/controllers/AboutUsController.jsx
+++ b/common/components/controllers/AboutUsController.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ProjectAPIUtils from '../utils/ProjectAPIUtils.js';
 import type {ProjectDetailsAPIData, TeamAPIData} from '../utils/ProjectAPIUtils.js';
 import cdn, {Images} from '../utils/cdn.js';
-import SplashScreen from '../componentsBySection/FindProjects/SplashScreen.jsx';
+import SplashScreen, {HeroImage} from '../componentsBySection/FindProjects/SplashScreen.jsx';
 import Headers from "../common/Headers.jsx";
 import BioModal from "../componentsBySection/AboutUs/BioModal.jsx";
 import BioThumbnail from "../componentsBySection/AboutUs/BioThumbnail.jsx";
@@ -103,7 +103,7 @@ class AboutUsController extends React.PureComponent<{||}, State> {
     const header: string = "Mission";
     const text: string = "Empower people who use technology to advance the public good.";
     return (
-      <SplashScreen className="about-us-mission about-us-content" header={header} text={text} img={"CodeForGood_072719_MSReactor-003.jpg"}>
+      <SplashScreen className="about-us-mission about-us-content" header={header} text={text} img={HeroImage.AboutMission}>
       </SplashScreen>
     )
   }

--- a/common/components/controllers/AboutUsController.jsx
+++ b/common/components/controllers/AboutUsController.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ProjectAPIUtils from '../utils/ProjectAPIUtils.js';
 import type {ProjectDetailsAPIData, TeamAPIData} from '../utils/ProjectAPIUtils.js';
 import cdn, {Images} from '../utils/cdn.js';
+import SplashScreen from '../componentsBySection/FindProjects/SplashScreen.jsx';
 import Headers from "../common/Headers.jsx";
 import BioModal from "../componentsBySection/AboutUs/BioModal.jsx";
 import BioThumbnail from "../componentsBySection/AboutUs/BioThumbnail.jsx";
@@ -97,26 +98,22 @@ class AboutUsController extends React.PureComponent<{||}, State> {
      });
   }
 
+
   _ourMission() {
+    const header: string = "Mission";
+    const text: string = "Empower people who use technology to advance the public good.";
     return (
-      <div className="about-us-mission"
-      style={{ backgroundImage: `linear-gradient(to right, rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(${cdn.image("CodeForGood_072719_MSReactor-003.jpg")})`}}>
-        <div className="about-us-content container">
-          <h1>Mission</h1>
-          <p>Empower people who use technology to advance the public good.</p>
-        </div>
-      </div>
+      <SplashScreen className="about-us-mission about-us-content" header={header} text={text} img={"CodeForGood_072719_MSReactor-003.jpg"}>
+      </SplashScreen>
     )
   }
   _ourVision() {
+    const header: string = "Vision";
+    const text: string = "Technology enables our collective intelligence to solve the most challenging social, economic, environmental and civic problems while empowering all members of our societies.";
+    const opacity: number = 0
     return (
-      <div className="about-us-vision"
-      style={cdn.bgImage('OurVisionBGoverlay.jpg')}>
-        <div className="about-us-content container">
-          <h2>Vision</h2>
-          <p>Technology enables our collective intelligence to solve the most challenging social, economic, environmental and civic problems while empowering all members of our societies.</p>
-        </div>
-      </div>
+      <SplashScreen className="about-us-vision about-us-content" header={header} text={text} img={"OurVisionBGoverlay.jpg"} opacity={opacity}>
+      </SplashScreen>
     )
   }
 

--- a/common/components/controllers/LandingController.jsx
+++ b/common/components/controllers/LandingController.jsx
@@ -165,7 +165,7 @@ class LandingController extends React.PureComponent<{||}> {
     const header: string = "What are you waiting for?";
 
     return (
-      <SplashScreen header={header} img={HeroImage.BottomLanding}>
+      <SplashScreen className="LandingController-bottom-splash" header={header} img={HeroImage.BottomLanding}>
         <Button variant="primary" className="LandingController-bottomsplash-btn" href={url.sectionOrLogIn(Section.FindProjects)}>Get Started</Button>
       </SplashScreen>
     );

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "buildtask:collectstatic": "python manage.py collectstatic --noinput -i *.scss",
     "test": "jest"
   },
+  "engines": {
+    "node": "13.7.x"
+  },
   "dependencies": {
     "@material-ui/core": "^3.5.1",
     "@material-ui/icons": "^3.0.1",


### PR DESCRIPTION
 - [x] updates image in top splash on About Us
 - [x] updates SplashScreen component to accept opacity value as prop (defaults to 0.5 / 50%), updates some About Us images to use the component instead of being hand built
 - [x] a lot of text and positioning changes on homepage from design team, most notably repositioning text to be in the bottom third (ish) of splash images instead of centered, text/alignment fixes
- [ ] mobile text sizes for splash images (still under discussion)

This branch also needs CDN drop-in replacements for image on Donate and ThankYou pages, but does not alter those pages directly. See #374 for those changes.