### PR TITLE
OAuth: Add user:email scope to github

### DIFF
--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -76,7 +76,7 @@ if SOCIAL_APPS_environ is not None:
 
 SOCIALACCOUNT_PROVIDERS = {
     'github': {
-        'SCOPE': ['read:user']
+        'SCOPE': ['read:user', 'user:email']
     },
     'google': {
         'SCOPE': ['profile', 'email'],


### PR DESCRIPTION
We need to request user:email permissions for github users, as some users have a private email and we won't get it from their public profile