### PR TITLE
Bug Fix: Project latitude/longitude reversed

### DIFF
--- a/civictechprojects/migrations/data_migrations/migrate_location.py
+++ b/civictechprojects/migrations/data_migrations/migrate_location.py
@@ -86,7 +86,7 @@ def migrate_locations_from_city_list(*args):
             project.project_country = data["country"]
             project.project_state = data["state"]
             project.project_city = data["city"]
-            project.project_location_coords = Point(data['latitude'], data['longitude'])
+            project.project_location_coords = Point(data['longitude'], data['latitude'])
             project.save()
 
 

--- a/civictechprojects/migrations/sql/reverse_project_lat_long.sql
+++ b/civictechprojects/migrations/sql/reverse_project_lat_long.sql
@@ -1,0 +1,6 @@
+-- Reverses project lat/long coordinates, as they were set in reversed order initially
+
+UPDATE
+    civictechprojects_project
+SET
+    project_location_coords = st_geometryfromtext('POINT('|| ST_Y(project_location_coords) ||' '|| ST_X(project_location_coords) ||')', 4326);

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -572,7 +572,7 @@ def projects_by_sortField(project_list, sortField):
 
 def projects_by_location(project_list, param):
     param_parts = param.split(',')
-    location = Point(float(param_parts[0]), float(param_parts[1]))
+    location = Point(float(param_parts[1]), float(param_parts[0]))
     radius = float(param_parts[2])
     project_list = project_list.filter(project_location_coords__distance_lte=(location, D(mi=radius)))
     return project_list

--- a/common/helpers/form_helpers.py
+++ b/common/helpers/form_helpers.py
@@ -32,7 +32,7 @@ def read_form_fields_point(model, form, point_field_name, lat_field_name, long_f
         lat = form.data.get(lat_field_name)
         long = form.data.get(long_field_name)
         if len(lat) > 0 and len(long) > 0:
-            setattr(model, point_field_name, Point(float(lat), float(long)))
+            setattr(model, point_field_name, Point(float(long), float(lat)))
 
 
 def merge_json_changes(model_class, model, form, field_name):


### PR DESCRIPTION
In the initial implementation, project coordinates were set with latitude and longitude in the wrong order.  This change fixes that bug, and includes a script for swapping the lat/long values already in the database.