### PR TITLE
Add Error page with custom message for OAuth signup failure

### DIFF
--- a/civictechprojects/urls.py
+++ b/civictechprojects/urls.py
@@ -16,10 +16,15 @@ Including another URLconf
 from django.conf.urls import url
 from django.views.generic import TemplateView
 from django.contrib.sitemaps.views import sitemap
+from common.helpers.error_handlers import handle500
 from .sitemaps import ProjectSitemap, SectionSitemap
 
 
 from . import views
+
+# Set custom error handler
+handler500 = handle500
+
 urlpatterns = [
 
     url(

--- a/common/components/controllers/ErrorController.jsx
+++ b/common/components/controllers/ErrorController.jsx
@@ -14,7 +14,9 @@ type State = {|
 
 const ErrorMessagesByType: Dictionary<(ErrorArgs) => string> = {
   MissingOAuthFieldError: (errorArgs: ErrorArgs) => {
-    return "Sign up failed, as your account is missing the following fields: " + decodeURI(errorArgs.missing_fields);
+    const missingFields: string = decodeURI(errorArgs.missing_fields);
+    return `Sign up failed, as your account is missing the following fields: ${missingFields}. ` +
+      `Please update your ${errorArgs.provider} profile with this information or use another method to sign up for DemocracyLab. Thank you!`;
   }
 };
 

--- a/common/components/controllers/ErrorController.jsx
+++ b/common/components/controllers/ErrorController.jsx
@@ -1,0 +1,46 @@
+// @flow
+
+import React from 'react';
+import type {Dictionary} from "../types/Generics.jsx";
+import urlHelper from "../utils/url.js";
+
+type ErrorArgs = {|
+  errorType: string
+|}
+
+type State = {|
+  errorArgs: ErrorArgs
+|};
+
+const ErrorMessagesByType: Dictionary<(ErrorArgs) => string> = {
+  MissingOAuthFieldError: (errorArgs: ErrorArgs) => {
+    return "Sign up failed, as your account is missing the following fields: " + decodeURI(errorArgs.missing_fields);
+  }
+};
+
+function getErrorMessage(errorArgs: ErrorArgs): string {
+  if(errorArgs.errorType in ErrorMessagesByType) {
+    return ErrorMessagesByType[errorArgs.errorType](errorArgs);
+  } else {
+    return "Error";
+  }
+}
+
+class ErrorController extends React.Component<{||}, State> {
+  constructor(): void {
+    super();
+    this.state = {
+      errorArgs: urlHelper.getSectionArgs().args
+    };
+  }
+
+  render(): React$Node {
+    return (
+      <div> 
+        {getErrorMessage(this.state.errorArgs)}
+      </div>
+    );
+  }
+}
+
+export default ErrorController;

--- a/common/components/controllers/SectionController.jsx
+++ b/common/components/controllers/SectionController.jsx
@@ -33,6 +33,7 @@ import CreateEventController from './CreateEventController.jsx';
 import MyGroupsController from './MyGroupsController.jsx';
 import LiveEventController from "./LiveEventController.jsx";
 import AboutEventController from "./AboutEventController.jsx";
+import ErrorController from "./ErrorController.jsx";
 
 type State = {|
   section: SectionType,
@@ -110,6 +111,8 @@ class SectionController extends React.Component<{||}, State> {
         return <AboutEventController/>;
       case Section.LiveEvent:
         return <LiveEventController />;
+      case Section.Error:
+        return <ErrorController />;
       default:
         return <div>Section not yet implemented: {this.state.section}</div>
     }

--- a/common/components/enums/Section.js
+++ b/common/components/enums/Section.js
@@ -26,7 +26,8 @@ const Section = {
   CreateGroup: 'CreateGroup',
   CreateEvent: 'CreateEvent',
   AboutEvent: 'AboutEvent',
-  LiveEvent: 'LiveEvent'
+  LiveEvent: 'LiveEvent',
+  Error: 'Error'
 };
 
 export type SectionType = $Keys<typeof Section>;

--- a/common/helpers/constants.py
+++ b/common/helpers/constants.py
@@ -35,3 +35,4 @@ class FrontEndSection(Enum):
     EditProfile = 'EditProfile'
     ThankYou = 'ThankYou'
     EmailVerified = 'EmailVerified'
+    Error = 'Error'

--- a/common/helpers/error_handlers.py
+++ b/common/helpers/error_handlers.py
@@ -1,0 +1,31 @@
+import sys
+from django.shortcuts import redirect
+from common.helpers.constants import FrontEndSection
+from common.helpers.dictionaries import merge_dicts
+from common.helpers.front_end import section_url
+
+
+class ReportableError(Exception):
+    """Exception raised that needs to be logged and sent to a front end error page
+
+    Attributes:
+        message -- explanation of the error to be reported in the logs
+        front_end_args -- arguments to be surfaced on the front end error page
+    """
+
+    def __init__(self, message, front_end_args):
+        self.message = message
+        self.front_end_args = front_end_args or {}
+
+
+def handle500(request):
+    exception_type, exception, traceback = sys.exc_info()
+    if isinstance(exception, ReportableError):
+        # Log message
+        print("Error(500): " + exception.message)
+        error_args = merge_dicts(exception.front_end_args, {'errorType': type(exception).__name__})
+        # Redirect to Error page
+        return redirect(section_url(FrontEndSection.Error, error_args))
+    else:
+        return redirect(section_url(FrontEndSection.Error))
+

--- a/democracylab/urls.py
+++ b/democracylab/urls.py
@@ -17,8 +17,12 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.views.generic.base import RedirectView
+from common.helpers.error_handlers import handle500
 
 from . import views
+
+# Set custom error handler
+handler500 = handle500
 
 urlpatterns = [
     url(r'^accounts/', include('oauth2.providers.github.urls')),

--- a/oauth2/adapter.py
+++ b/oauth2/adapter.py
@@ -17,12 +17,12 @@ class MissingOAuthFieldError(ReportableError):
     """Exception raised when required fields are not returned from OAuth
 
     Attributes:
-        missing_fields -- list of missing field names
+        missing_fields -- description of missing fields
         message -- explanation of the error to be reported in the logs
     """
 
     def __init__(self, message, provider, missing_fields):
-        super().__init__(message, {'provider': provider, 'missing_fields': ', '.join(missing_fields)})
+        super().__init__(message, {'provider': provider, 'missing_fields': missing_fields})
 
 
 class SocialAccountAdapter(DefaultSocialAccountAdapter):
@@ -58,10 +58,10 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         last_name = data.get('last_name')
 
         if full_name is None and first_name is None:
-            missing_fields = ['name', 'first_name']
+            missing_fields = ['name', 'first_name', 'last_name']
             msg = 'Social login Failed for {provider}.  Missing fields: {fields}'\
                 .format(provider=provider.name, fields=missing_fields)
-            raise MissingOAuthFieldError(msg, provider.name, missing_fields)
+            raise MissingOAuthFieldError(msg, provider.name, "Full Name")
 
         sociallogin.user.first_name = first_name or full_name.split()[0]
         sociallogin.user.last_name = last_name or ' '.join(full_name.split()[1:])

--- a/oauth2/adapter.py
+++ b/oauth2/adapter.py
@@ -21,8 +21,8 @@ class MissingOAuthFieldError(ReportableError):
         message -- explanation of the error to be reported in the logs
     """
 
-    def __init__(self, message, missing_fields):
-        super().__init__(message, {'missing_fields': ', '.join(missing_fields)})
+    def __init__(self, message, provider, missing_fields):
+        super().__init__(message, {'provider': provider, 'missing_fields': ', '.join(missing_fields)})
 
 
 class SocialAccountAdapter(DefaultSocialAccountAdapter):
@@ -57,13 +57,11 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         first_name = data.get('first_name')
         last_name = data.get('last_name')
 
-        # print('Social Login: ' + [full_name, first_name, last_name].join(','))
-
         if full_name is None and first_name is None:
             missing_fields = ['name', 'first_name']
             msg = 'Social login Failed for {provider}.  Missing fields: {fields}'\
                 .format(provider=provider.name, fields=missing_fields)
-            raise MissingOAuthFieldError(msg, missing_fields)
+            raise MissingOAuthFieldError(msg, provider.name, missing_fields)
 
         sociallogin.user.first_name = first_name or full_name.split()[0]
         sociallogin.user.last_name = last_name or ' '.join(full_name.split()[1:])


### PR DESCRIPTION
## Summary ##
Some users are failing to sign up with OAuth because their profile does not have all the fields we require (email, first, and last name).  We want to alert the user to this problem.

## Front-end ##
- Basic Error page that reads specific errors from the back-end

## Back-end ##
- Custom exception class ReportableError, structured for publishing error details to logs and to the front-end
- Custom error 500 handler that intercepts ReportableErrors, logs them, and redirects to Front-end error page

## Notes ##
- The custom error page will only be triggered if DJANGO_DEBUG=False.  If Debug is true, Django will output a comprehensive debug page that is useful for debugging but a security risk in Production.