### PR TITLE
Ignore #_=_ appended to url after facebook oauth callback

### DIFF
--- a/common/components/controllers/MainController.jsx
+++ b/common/components/controllers/MainController.jsx
@@ -28,7 +28,7 @@ class MainController extends React.Component<{||}, State> {
   }
 
   loadPage(): void {
-    const args = url.arguments(window.location.href);
+    const args = url.arguments(url.cleanDemocracyLabUrl());
     if (args.section) {
       UniversalDispatcher.dispatch({
         type: 'SET_SECTION',

--- a/common/components/utils/url.js
+++ b/common/components/utils/url.js
@@ -166,6 +166,12 @@ class urlHelper {
   static isEmptyStringOrValidUrl(url: string): boolean {
     return (_.isEmpty(url) || this.isValidUrl(url));
   }
+  
+  static cleanDemocracyLabUrl(url: ?string): string {
+    // Remove url snippet
+    let _url: string = url || window.location.href;
+    return _url.replace("#_=_","");
+  }
 }
 
 export default urlHelper


### PR DESCRIPTION
Facebook appends "#_=_" to the end of their callback urls, and this change makes us ignore this symbol during url routing.