### PR TITLE
change donate/thankyou images

### DIFF
--- a/common/components/utils/cdn.js
+++ b/common/components/utils/cdn.js
@@ -4,8 +4,8 @@ export const Images: { [key: string]: string } = {
   DL_GLYPH: "dl_identity_node_mark.png",
   PLATFORM_SPLASH: "platform_splash.png",
   EVENT_SPLASH: "event_splash.png",
-  THANK_YOU: "ThankYouBG_slim.jpg",
-  DONATE_SPLASH: "DonateBG.jpg",
+  THANK_YOU: "CodeForGood_072719_MSReactor-020.jpg",
+  DONATE_SPLASH: "SplashImage-7178-1400.jpg",
   PAYPAL_BUTTON: "PaypalDonateButton.png",
   CORE_VALUES_BG: "CoreValuesBG520.png",
   PROBLEM_SOLUTION_BG: "PuzzleBG.png"


### PR DESCRIPTION
Changes images on our Donate and Thank You pages. Per design,
```
About us: CodeForGood_072719_MSReactor-003.jpg
Donate: IMG_7178
Post Donation: CodeForGood_072719_MSReactor-020.jpg
```

About Us already used -003.jpg since #380 so no changes made to that in this PR.