### PR TITLE
Hide menu in embedded view

### DIFF
--- a/common/components/chrome/MainHeader.jsx
+++ b/common/components/chrome/MainHeader.jsx
@@ -61,13 +61,15 @@ class MainHeader extends React.Component<{||}, State > {
 
   componentDidMount() {
     UniversalDispatcher.dispatch({type: 'INIT'});
-    this._handleHeightChange(this.mainHeaderRef.current.clientHeight);
+    if(this.mainHeaderRef && this.mainHeaderRef.current) {
+      this._handleHeightChange(this.mainHeaderRef.current.clientHeight);
+    }
   }
 
 
 
   render(): React$Node {
-    return (
+    return this.state.showHeader ? (
       <div ref={this.mainHeaderRef} className="MainHeader-root">
         <AlertHeader
           onAlertClose={this._handleAlertClosing.bind(this)}
@@ -77,7 +79,7 @@ class MainHeader extends React.Component<{||}, State > {
           {this._renderNavBar()}
         </div>
       </div>
-    );
+    ) : null;
   }
 
   _renderNavBar() {


### PR DESCRIPTION
This is a fix for a change that wasn't migrated from the old menu to the new menu.  Whenever &embedded=1 is in the url, we need to hide the menu, in order to facilitate a clean view when a democracylab page is embedded on another site.