### PR TITLE
Peter/findevents

### DIFF
--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -100,7 +100,7 @@ class EventCreationForm(ModelForm):
             event_date_start=parse(form.data.get('event_date_start'), fuzzy=True),
             event_date_end=parse(form.data.get('event_date_end'), fuzzy=True),
             event_short_description=form.data.get('event_short_description'),
-            is_created=True,
+            is_created=False,
             is_searchable=True
         )
         event = Event.objects.get(id=event.id)
@@ -128,7 +128,7 @@ class EventCreationForm(ModelForm):
             raise PermissionDenied()
     
         form = ProjectCreationForm(request.POST)
-    
+
         read_form_field_string(event, form, 'event_agenda')
         read_form_field_string(event, form, 'event_description')
         read_form_field_string(event, form, 'event_short_description')

--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -1,4 +1,3 @@
-from dateutil.parser import parse
 from django.forms import ModelForm
 from django.core.exceptions import PermissionDenied
 from django.utils import timezone
@@ -6,6 +5,7 @@ from .models import Project, ProjectLink, ProjectFile, ProjectPosition, FileCate
 from .sitemaps import SitemapPages
 from democracylab.emails import send_project_creation_notification, send_group_creation_notification
 from democracylab.models import get_request_contributor
+from common.helpers.date_helpers import parse_front_end_datetime
 from common.helpers.form_helpers import is_creator_or_staff, is_co_owner_or_staff, read_form_field_string, read_form_field_boolean, \
     merge_json_changes, merge_single_file, read_form_field_tags, read_form_field_datetime, read_form_fields_point
 
@@ -87,47 +87,23 @@ class EventCreationForm(ModelForm):
         fields = '__all__'
 
     @staticmethod
-    def create_event(request):
-
+    def create_or_edit_event(request, event_id):
         form = EventCreationForm(request.POST)
-        # TODO: Form validation
-        event = Event.objects.create(
-            event_creator=get_request_contributor(request),
-            event_date_created=timezone.now(),
-            event_name=form.data.get('event_name'),
-            event_location=form.data.get('event_location'),
-            event_rsvp_url=form.data.get('event_rsvp_url'),
-            event_date_start=parse(form.data.get('event_date_start'), fuzzy=True),
-            event_date_end=parse(form.data.get('event_date_end'), fuzzy=True),
-            event_short_description=form.data.get('event_short_description'),
-            is_created=False,
-            is_searchable=True
-        )
-        event = Event.objects.get(id=event.id)
-
-        merge_single_file(event, form, FileCategory.THUMBNAIL, 'event_thumbnail_location')
-
-        event.save()
-        return event
-
-    @staticmethod
-    def delete_event(request, event_id):
-        event = Event.objects.get(id=event_id)
-
-        if not is_creator_or_staff(request.user, event):
-            raise PermissionDenied()
-
-        event.delete()
-
-
-    @staticmethod
-    def edit_event(request, event_id):
-        event = Event.objects.get(id=event_id)
+        if event_id is not None:
+            event = Event.objects.get(id=event_id)
+        else:
+            event = Event.objects.create(
+                event_creator=get_request_contributor(request),
+                event_date_created=timezone.now(),
+                event_name=form.data.get('event_name'),
+                event_date_start=parse_front_end_datetime(form.data.get('event_date_start')),
+                event_date_end=parse_front_end_datetime(form.data.get('event_date_end')),
+                is_created=False,
+                is_searchable=True
+            )
 
         if not is_co_owner_or_staff(request.user, event):
             raise PermissionDenied()
-    
-        form = ProjectCreationForm(request.POST)
 
         read_form_field_string(event, form, 'event_agenda')
         read_form_field_string(event, form, 'event_description')
@@ -144,14 +120,23 @@ class EventCreationForm(ModelForm):
         read_form_field_boolean(event, form, 'is_created')
 
         read_form_field_tags(event, form, 'event_legacy_organization')
-    
+
         event.event_date_modified = timezone.now()
 
         merge_single_file(event, form, FileCategory.THUMBNAIL, 'event_thumbnail_location')
 
         event.save()
-    
+
         return event
+
+    @staticmethod
+    def delete_event(request, event_id):
+        event = Event.objects.get(id=event_id)
+
+        if not is_creator_or_staff(request.user, event):
+            raise PermissionDenied()
+
+        event.delete()
 
 
 class GroupCreationForm(ModelForm):

--- a/civictechprojects/static/css/partials/_FindEventController.scss
+++ b/civictechprojects/static/css/partials/_FindEventController.scss
@@ -17,28 +17,13 @@
   text-decoration: none;
   color: $color-text-dark;
   display: grid;
-  grid-template-columns: 30% 50% 20%;
-  grid-template-rows: 1;
+  grid-template-columns: 100%;
+  grid-template-rows: 100%;
   height: 100%;
 }
-.EventCard-info {
-  grid-column: 2;
-  overflow-wrap: break-word;
-}
-.EventCard-info ul {
-  color: $color-text-grey;
-  list-style-type: none;
-  font-size: 0.875rem;
-  word-break: break-all; //break long items to stay in container
-  padding: 0;
-}
-.EventCard-info li {
-  margin-top: 0.25rem;
-  display: block;
-}
-
 .EventCard-logo {
   grid-column: 1;
+  grid-row: 1;
   display: grid;
 }
 .EventCard-url-text {
@@ -53,6 +38,42 @@
   display: block;
   margin: auto;
 }
+.EventCard-info {
+  grid-column: 1;
+  grid-row: 2;
+  overflow-wrap: break-word;
+}
+.EventCard-info ul {
+  color: $color-text-grey;
+  list-style-type: none;
+  font-size: 0.875rem;
+  word-break: break-all; //break long items to stay in container
+  padding: 0;
+}
+.EventCard-info li {
+  margin-top: 0.25rem;
+  display: block;
+}
 .EventCard-time {
-  grid-column: 3;
+  grid-column: 1;
+  grid-row: 3;
+}
+
+@include media-breakpoint-up(md) {
+  .EventCard-root a {
+    grid-template-columns: 30% 50% 20%;
+    grid-template-rows: 100%;
+  }
+  .EventCard-logo {
+    grid-column: 1;
+    grid-row: 1;
+  }
+  .EventCard-info {
+    grid-column: 2;
+    grid-row: 1;
+  }
+  .EventCard-time {
+    grid-column: 3;
+    grid-row: 1;
+  }
 }

--- a/civictechprojects/static/css/partials/_FindEventController.scss
+++ b/civictechprojects/static/css/partials/_FindEventController.scss
@@ -7,11 +7,7 @@
 }
 .EventCard-root h2 {
   font-size: 1.333rem;
-  margin: 0.5rem 0.5rem 0.5rem 0; /* left margin is built into card design */
-}
-.EventCard-root h3 {
-  font-size: 1.0rem;
-  font-weight: bold;
+  margin: 0.5rem 0;
 }
 .EventCard-root h4 {
   font-size: 0.875rem;
@@ -21,54 +17,33 @@
   text-decoration: none;
   color: $color-text-dark;
   display: grid;
-  grid-template-columns: 30% 2% 34% 34%;
-  grid-template-rows: auto;
+  grid-template-columns: 30% 50% 20%;
+  grid-template-rows: 1;
   height: 100%;
 }
-.EventCard-description {
-  grid-column: 1 / 5;
-  grid-row: 3;
-  padding-top: 0.5rem; /* only on mobile */
-  padding-left: 0.5rem; /* only on mobile */
-  padding-right: 0.5rem; /* always */
-  border-top: solid lightgray 1.5px;
+.EventCard-info {
+  grid-column: 2;
+  overflow-wrap: break-word;
 }
-.EventCard-subinfo {
-  grid-column: 3 / 5;
-  grid-row: 2;
-}
-.EventCard-subinfo ul {
+.EventCard-info ul {
   color: $color-text-grey;
   list-style-type: none;
   font-size: 0.875rem;
   word-break: break-all; //break long items to stay in container
   padding: 0;
 }
-.EventCard-subinfo li {
+.EventCard-info li {
   margin-top: 0.25rem;
   display: block;
 }
-.EventCard-subinfo li:first-of-type {
-  margin-top: 0;
-  padding-top: 0.25rem;
-}
-.EventCard-subinfo li svg {
-  margin-right: 0.375rem;
-}
-.EventCard-title {
-  overflow-wrap: break-word; // prevent long project titles from breaking flow
-  grid-column: 3 / 5;
-  grid-row: 1 / 2;
-}
+
 .EventCard-logo {
-  grid-column: 1 / 2;
-  grid-row: 1 / 3;
-  border-right: solid lightgray 1.5px;
+  grid-column: 1;
   display: grid;
 }
 .EventCard-url-text {
     overflow: hidden;
-    text-Overflow: ellipsis;
+    text-overflow: ellipsis;
     white-Space: nowrap;
     margin: auto;
 }
@@ -78,19 +53,6 @@
   display: block;
   margin: auto;
 }
-.EventCard-skills {
-  grid-column: 1 / 5;
-  grid-row: 4;
-  padding: 0 0 0 8px;
-}
-.EventCard-skills ul {
-  padding: 0;
-}
-.EventCard-skills ul li {
-  display: inline-block;
-  list-style-type: none;
-  background: $color-grey-medium;
-  border-radius: 1rem;
-  padding: 0.25rem 0.5rem;
-  margin: 0.25rem 0.5rem 0.25rem 0;
+.EventCard-time {
+  grid-column: 3;
 }

--- a/civictechprojects/static/css/partials/_FindEventController.scss
+++ b/civictechprojects/static/css/partials/_FindEventController.scss
@@ -1,3 +1,7 @@
+.FindEventsController-topsplash .SplashScreen-content {
+  padding-bottom: 3rem;
+}
+
 .EventCard-root {
   background-color: $color-background-light;
   border: 1px solid $color-grey-frame-border;
@@ -56,8 +60,8 @@
   text-decoration: none;
   color: $color-text-dark;
   display: grid;
-  grid-template-columns: 100%;
-  grid-template-rows: 100%;
+  grid-template-columns: auto;
+  grid-template-rows: auto;
   height: 100%;
 }
 // margin-bottom because we don't have pagination, keeping cards off the edge of the footer
@@ -80,10 +84,9 @@
     margin: auto;
 }
 .EventCard-logo img {
-  max-width: calc(100% - 8px);
-  max-height: calc(100% - 8px);
+  max-width: 98%;
   display: block;
-  margin: auto;
+  margin: 2px auto; /* handles rounded edges better to push it off the top a touch */
 }
 .EventCard-info {
   grid-column: 1;
@@ -110,7 +113,7 @@
 
 @include media-breakpoint-up(md) {
   .EventCard-root a {
-    grid-template-columns: 30% 50% 20%;
+    grid-template-columns: 37% 48% 15%;
     grid-template-rows: 100%;
   }
   .EventCard-logo {
@@ -127,6 +130,9 @@
   .EventCard-time {
     grid-column: 3;
     grid-row: 1;
-    margin: 0 16px 0 auto;
+    margin: 0 8px 0 auto;
+  }
+  .EventCard-logo img {
+    margin: auto;
   }
 }

--- a/civictechprojects/static/css/partials/_FindEventController.scss
+++ b/civictechprojects/static/css/partials/_FindEventController.scss
@@ -1,0 +1,96 @@
+.EventCard-root {
+  background-color: $color-background-light;
+  border-radius: 6px;
+  box-shadow: 0px 0px 10px 2px rgba(0,0,0,0.15);
+  color: $color-text-dark;
+  margin: 0.5rem 0;
+}
+.EventCard-root h2 {
+  font-size: 1.333rem;
+  margin: 0.5rem 0.5rem 0.5rem 0; /* left margin is built into card design */
+}
+.EventCard-root h3 {
+  font-size: 1.0rem;
+  font-weight: bold;
+}
+.EventCard-root h4 {
+  font-size: 0.875rem;
+  color: $color-text-grey;
+}
+.EventCard-root a {
+  text-decoration: none;
+  color: $color-text-dark;
+  display: grid;
+  grid-template-columns: 30% 2% 34% 34%;
+  grid-template-rows: auto;
+  height: 100%;
+}
+.EventCard-description {
+  grid-column: 1 / 5;
+  grid-row: 3;
+  padding-top: 0.5rem; /* only on mobile */
+  padding-left: 0.5rem; /* only on mobile */
+  padding-right: 0.5rem; /* always */
+  border-top: solid lightgray 1.5px;
+}
+.EventCard-subinfo {
+  grid-column: 3 / 5;
+  grid-row: 2;
+}
+.EventCard-subinfo ul {
+  color: $color-text-grey;
+  list-style-type: none;
+  font-size: 0.875rem;
+  word-break: break-all; //break long items to stay in container
+  padding: 0;
+}
+.EventCard-subinfo li {
+  margin-top: 0.25rem;
+  display: block;
+}
+.EventCard-subinfo li:first-of-type {
+  margin-top: 0;
+  padding-top: 0.25rem;
+}
+.EventCard-subinfo li svg {
+  margin-right: 0.375rem;
+}
+.EventCard-title {
+  overflow-wrap: break-word; // prevent long project titles from breaking flow
+  grid-column: 3 / 5;
+  grid-row: 1 / 2;
+}
+.EventCard-logo {
+  grid-column: 1 / 2;
+  grid-row: 1 / 3;
+  border-right: solid lightgray 1.5px;
+  display: grid;
+}
+.EventCard-url-text {
+    overflow: hidden;
+    text-Overflow: ellipsis;
+    white-Space: nowrap;
+    margin: auto;
+}
+.EventCard-logo img {
+  max-width: 97%;
+  max-height: 95%;
+  display: block;
+  margin: auto;
+}
+.EventCard-skills {
+  grid-column: 1 / 5;
+  grid-row: 4;
+  padding: 0 0 0 8px;
+}
+.EventCard-skills ul {
+  padding: 0;
+}
+.EventCard-skills ul li {
+  display: inline-block;
+  list-style-type: none;
+  background: $color-grey-medium;
+  border-radius: 1rem;
+  padding: 0.25rem 0.5rem;
+  margin: 0.25rem 0.5rem 0.25rem 0;
+}

--- a/civictechprojects/static/css/partials/_FindEventController.scss
+++ b/civictechprojects/static/css/partials/_FindEventController.scss
@@ -1,10 +1,26 @@
 .EventCard-root {
   background-color: $color-background-light;
-  border-radius: 6px;
-  box-shadow: 0px 0px 10px 2px rgba(0,0,0,0.15);
+  border: 1px solid $color-grey-frame-border;
   color: $color-text-dark;
-  margin: 0.5rem 0;
+  width: 100%;
 }
+
+// only round corners for top edge of first, bottom edge of last item per day grouping
+.EventCard-root:first-of-type {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+.EventCard-root:last-of-type {
+  border-bottom-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
+
+// avoid double border for days with multiple events (thus multiple cards)
+.EventCard-root:nth-of-type(n+2) {
+  border-top: none;
+}
+
+
 .FindEventsController-topsplash h1 {
   font-size: 4rem;
 }
@@ -16,6 +32,14 @@
   font-size: 16px;
   margin-bottom: 16px;
   color: $color-text-grey;
+}
+.EventCard-dateheader, .EventCard-day-container {
+  width: 100%;
+}
+.EventCard-dateheader {
+  margin-top: 2rem;
+  font-size: 24px;
+  font-weight: 500;
 }
 .EventCard-info {
   display: flex;
@@ -52,12 +76,12 @@
 .EventCard-url-text {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-Space: nowrap;
+    white-space: nowrap;
     margin: auto;
 }
 .EventCard-logo img {
-  max-width: 97%;
-  max-height: 95%;
+  max-width: calc(100% - 8px);
+  max-height: calc(100% - 8px);
   display: block;
   margin: auto;
 }
@@ -70,7 +94,6 @@
   color: $color-text-grey;
   list-style-type: none;
   font-size: 0.875rem;
-  word-break: break-all; //break long items to stay in container
   padding: 0;
 }
 .EventCard-info li {

--- a/civictechprojects/static/css/partials/_FindEventController.scss
+++ b/civictechprojects/static/css/partials/_FindEventController.scss
@@ -5,6 +5,9 @@
   color: $color-text-dark;
   margin: 0.5rem 0;
 }
+.FindEventsController-topsplash h1 {
+  font-size: 4rem;
+}
 .EventCard-root h2 {
   font-size: 1.333rem;
   margin: 0.5rem 0;

--- a/civictechprojects/static/css/partials/_FindEventController.scss
+++ b/civictechprojects/static/css/partials/_FindEventController.scss
@@ -2,6 +2,10 @@
   padding-bottom: 3rem;
 }
 
+.EventCardContainer-section-header {
+  margin-top: 1.25rem;
+}
+
 .EventCard-root {
   background-color: $color-background-light;
   border: 1px solid $color-grey-frame-border;

--- a/civictechprojects/static/css/partials/_FindEventController.scss
+++ b/civictechprojects/static/css/partials/_FindEventController.scss
@@ -9,12 +9,24 @@
   font-size: 4rem;
 }
 .EventCard-root h2 {
-  font-size: 1.333rem;
-  margin: 0.5rem 0;
+  font-size: 22px;
+  margin: 22px 0 12px 0;
 }
 .EventCard-root h4 {
-  font-size: 0.875rem;
+  font-size: 16px;
+  margin-bottom: 16px;
   color: $color-text-grey;
+}
+.EventCard-info {
+  display: flex;
+  flex-direction: column;
+}
+.EventCard-info li {
+  font-size: 18px;
+}
+.EventCard-info li i {
+  font-size: 13px; /* ratio determined, should be standardized */
+  margin-right: 5px;
 }
 .EventCard-root a {
   text-decoration: none;
@@ -24,6 +36,14 @@
   grid-template-rows: 100%;
   height: 100%;
 }
+// margin-bottom because we don't have pagination, keeping cards off the edge of the footer
+.EventCards-card-container {
+  margin-bottom: 3rem;
+}
+.EventCard-info, .EventCard-time {
+  margin-left: 0.5rem;
+}
+
 .EventCard-logo {
   grid-column: 1;
   grid-row: 1;
@@ -60,6 +80,9 @@
 .EventCard-time {
   grid-column: 1;
   grid-row: 3;
+  h2 {
+    font-weight: 400;
+  }
 }
 
 @include media-breakpoint-up(md) {
@@ -75,8 +98,12 @@
     grid-column: 2;
     grid-row: 1;
   }
+  .EventCard-info ul {
+    margin-top: auto;
+  }
   .EventCard-time {
     grid-column: 3;
     grid-row: 1;
+    margin: 0 16px 0 auto;
   }
 }

--- a/civictechprojects/static/css/styles.scss
+++ b/civictechprojects/static/css/styles.scss
@@ -90,3 +90,4 @@
 @import 'partials/LiveEvent';
 @import 'partials/CreateForm';
 @import 'partials/ApproveGroupsSection';
+@import 'partials/FindEventController';

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -233,7 +233,7 @@ def event_create(request):
 
     event = None
     try:
-        event = EventCreationForm.create_event(request)
+        event = EventCreationForm.create_or_edit_event(request, None)
     except PermissionDenied:
         return HttpResponseForbidden()
     return JsonResponse(event.hydrate_to_json())
@@ -245,7 +245,7 @@ def event_edit(request, event_id):
 
     event = None
     try:
-        event = EventCreationForm.edit_event(request, event_id)
+        event = EventCreationForm.create_or_edit_event(request, event_id)
     except PermissionDenied:
         return HttpResponseForbidden()
 

--- a/common/components/chrome/MainHeader.jsx
+++ b/common/components/chrome/MainHeader.jsx
@@ -115,7 +115,7 @@ class MainHeader extends React.Component<{||}, State > {
       </Navbar>
     )
   }
-  
+
   _renderEventNavItems(): ?React$Node {
     const eventLinks: Array<React$Node> = [];
     if(CurrentUser.isStaff()) {
@@ -124,6 +124,7 @@ class MainHeader extends React.Component<{||}, State > {
     if(window.EVENT_URL) {
       eventLinks.push(<NavDropdown.Item href={_.unescape(window.EVENT_URL)}>Upcoming Event</NavDropdown.Item>);
     }
+    eventLinks.push(this._renderNavDropdownItem(Section.FindEvents, "Find Events"));
     return !_.isEmpty(eventLinks)
     ? (
       <NavDropdown title="Events" id="nav-events">

--- a/common/components/componentsBySection/CreateEvent/EventPreviewForm.jsx
+++ b/common/components/componentsBySection/CreateEvent/EventPreviewForm.jsx
@@ -4,16 +4,17 @@ import React from "react";
 import DjangoCSRFToken from "django-react-csrftoken";
 import {OnReadySubmitFunc} from "./EventFormCommon.jsx";
 import AboutEventDisplay from "./AboutEventDisplay.jsx";
+import type {EventData} from "../../utils/EventAPIUtils.js";
 
 type Props = {|
-  event: ?ProjectDetailsAPIData,
+  project: ?EventData,
   readyForSubmit: OnReadySubmitFunc
 |};
 
 /**
  * Shows preview for project before finalizing
  */
-class ProjectPreviewForm extends React.PureComponent<Props> {
+class EventPreviewForm extends React.PureComponent<Props> {
   constructor(props: Props): void {
     super(props);
     // All fields optional
@@ -25,7 +26,7 @@ class ProjectPreviewForm extends React.PureComponent<Props> {
     return (
       <React.Fragment>
         <DjangoCSRFToken/>
-        <input type="hidden" name="is_searchable" value="True"/>
+        <input type="hidden" name="is_created" value="True"/>
         <AboutEventDisplay
           event={this.props.project}
           viewOnly={true}
@@ -35,4 +36,4 @@ class ProjectPreviewForm extends React.PureComponent<Props> {
   }
 }
 
-export default ProjectPreviewForm;
+export default EventPreviewForm;

--- a/common/components/componentsBySection/FindEvents/EventCard.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCard.jsx
@@ -1,0 +1,115 @@
+// @flow
+
+import React from "react";
+import Section from "../../../components/enums/Section.js";
+import url from "../../utils/url.js";
+import Moment from "react-moment";
+import type {Dictionary} from "../../types/Generics.jsx";
+import Sort from "../../utils/sort.js";
+import Truncate from "../../utils/truncate.js";
+import GlyphStyles from "../../utils/glyphs.js";
+import utils from "../../utils/utils.js";
+import EventAPIUtils, {EventTileAPIData} from "../../utils/EventAPIUtils.js";
+import type {TagDefinition} from "../../utils/ProjectAPIUtils.js";
+
+type Props = {|
+  Event: EventTileAPIData,
+  tagDictionary: Dictionary<TagDefinition>,
+  maxTextLength: number,
+  maxIssuesCount: number
+|};
+//fontawesome fixed width class
+const glyphFixedWidth = " fa-fw";
+
+class EventCard extends React.PureComponent<Props> {
+  constructor(): void {
+    super();
+  }
+
+  render(): React$Node {
+    return (
+        <div className="ProjectCard-root">
+          <a href={url.section(Section.AboutEvent, {id: this.props.Event.Event_id})}
+            rel="noopener noreferrer">
+            {this._renderLogo()}
+            {this._renderSubInfo()}
+            {this._renderTitleAndIssue()}
+            {this._renderEventDescription()}
+            {this._renderIssueAreas()}
+          </a>
+        </div>
+    );
+  }
+  _renderLogo(): React$Node {
+
+    return (
+      <div className="ProjectCard-logo">
+        <img src={this.props.Event && this.props.Event.Event_thumbnail ? this.props.Event.Event_thumbnail.publicUrl : "/static/images/projectlogo-default.png"}/>
+      </div>
+    )
+  }
+  _renderTitleAndIssue(): React$Node {
+    const Event: EventTileAPIData = this.props.Event;
+    return (
+      <div className="ProjectCard-title">
+        <h2>{Event.Event_name}</h2>
+        <h4>
+          {Event.Event_project_count + " " + utils.pluralize("project","projects", Event.Event_project_count)}
+        </h4>
+      </div>
+    )
+  }
+  _renderEventDescription(): React$Node {
+    return (
+        <div className="ProjectCard-description">
+          <p>{Truncate.stringT(this.props.Event.Event_short_description, this.props.maxTextLength)}</p>
+        </div>
+    );
+  }
+  _renderIssueAreas(): React$Node {
+    return (
+    <div className="ProjectCard-skills">
+      <h3>Issues</h3>
+      {this._generateIssueList()}
+    </div>
+    )
+  }
+  _generateIssueList(): React$Node {
+    // Get sorted truncated list of tag names
+    let issueNames: $ReadOnlyArray<string> = Sort.byCountDictionary(this.props.Event.Event_issue_areas);
+    issueNames = issueNames.map((issueName: string) => this.props.tagDictionary[issueName].display_name);
+    issueNames = Truncate.arrayT(issueNames, this.props.maxIssuesCount);
+
+    return (
+      <ul>
+        {issueNames.map((issueName: string, i: number) =>
+          <li key={i}>{issueName}</li>
+        )}
+      </ul>
+    );
+  }
+  _renderSubInfo(): React$Node {
+    const Event: EventTileAPIData = this.props.Event;
+    const location: string = Event.Event_country && EventAPIUtils.getLocationDisplayName(Event.Event_country);
+    return (
+      <div className="ProjectCard-subinfo">
+        <ul>
+        {location &&
+          <li>
+            <i className={GlyphStyles.MapMarker + glyphFixedWidth}></i>
+            {location}
+          </li>
+        }
+        {Event.Event_date_modified &&
+          <li>
+            <i className={GlyphStyles.Clock + glyphFixedWidth}></i>
+            <Moment fromNow>{Event.Event_date_modified}</Moment>
+          </li>
+        }
+        </ul>
+      </div>
+    )
+  }
+}
+
+export default EventCard;

--- a/common/components/componentsBySection/FindEvents/EventCard.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCard.jsx
@@ -7,7 +7,7 @@ import Moment from "react-moment";
 import type {Dictionary} from "../../types/Generics.jsx";
 import Sort from "../../utils/sort.js";
 import Truncate from "../../utils/truncate.js";
-import GlyphStyles from "../../utils/glyphs.js";
+import {Glyph, GlyphWidth, GlyphStyles} from "../../utils/glyphs.js";
 import utils from "../../utils/utils.js";
 import {EventTileAPIData} from "../../utils/EventAPIUtils.js";
 import type {TagDefinition} from "../../utils/ProjectAPIUtils.js";
@@ -18,8 +18,6 @@ type Props = {|
   maxTextLength: number,
   maxIssuesCount: number
 |};
-//fontawesome fixed width class
-const glyphFixedWidth = " fa-fw";
 
 class EventCard extends React.PureComponent<Props> {
   constructor(): void {
@@ -60,7 +58,7 @@ class EventCard extends React.PureComponent<Props> {
         {location &&
           <ul>
             <li>
-              <i className={GlyphStyles.MapMarker + glyphFixedWidth}></i>
+              <i className={Glyph(GlyphStyles.MapMarker, GlyphWidth.Fixed)}></i>
               {location}
             </li>
           </ul>

--- a/common/components/componentsBySection/FindEvents/EventCard.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCard.jsx
@@ -28,7 +28,7 @@ class EventCard extends React.PureComponent<Props> {
 
   render(): React$Node {
     return (
-        <div className="ProjectCard-root">
+        <div className="EventCard-root">
           <a href={url.section(Section.AboutEvent, {id: this.props.event.event_id})}
             rel="noopener noreferrer">
             {this._renderLogo()}
@@ -42,7 +42,7 @@ class EventCard extends React.PureComponent<Props> {
   _renderLogo(): React$Node {
 
     return (
-      <div className="ProjectCard-logo">
+      <div className="EventCard-logo">
         <img src={this.props.event && this.props.event.event_thumbnail ? this.props.event.event_thumbnail.publicUrl : "/static/images/projectlogo-default.png"}/>
       </div>
     )
@@ -50,7 +50,7 @@ class EventCard extends React.PureComponent<Props> {
   _renderTitleAndIssue(): React$Node {
     const Event: EventTileAPIData = this.props.event;
     return (
-      <div className="ProjectCard-title">
+      <div className="EventCard-title">
         <h2>{Event.event_name}</h2>
         <h4>
           "DemocracyLab"
@@ -60,7 +60,7 @@ class EventCard extends React.PureComponent<Props> {
   }
   _renderEventDescription(): React$Node {
     return (
-        <div className="ProjectCard-description">
+        <div className="EventCard-description">
           <p>{Truncate.stringT(this.props.event.event_short_description, this.props.maxTextLength)}</p>
         </div>
     );
@@ -69,7 +69,7 @@ class EventCard extends React.PureComponent<Props> {
     const Event: EventTileAPIData = this.props.event;
     const location: string = Event.event_location;
     return (
-      <div className="ProjectCard-subinfo">
+      <div className="EventCard-subinfo">
         <ul>
         {location &&
           <li>

--- a/common/components/componentsBySection/FindEvents/EventCard.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCard.jsx
@@ -9,11 +9,11 @@ import Sort from "../../utils/sort.js";
 import Truncate from "../../utils/truncate.js";
 import GlyphStyles from "../../utils/glyphs.js";
 import utils from "../../utils/utils.js";
-import EventAPIUtils, {EventTileAPIData} from "../../utils/EventAPIUtils.js";
+import {EventTileAPIData} from "../../utils/EventAPIUtils.js";
 import type {TagDefinition} from "../../utils/ProjectAPIUtils.js";
 
 type Props = {|
-  Event: EventTileAPIData,
+  event: EventTileAPIData,
   tagDictionary: Dictionary<TagDefinition>,
   maxTextLength: number,
   maxIssuesCount: number
@@ -29,13 +29,12 @@ class EventCard extends React.PureComponent<Props> {
   render(): React$Node {
     return (
         <div className="ProjectCard-root">
-          <a href={url.section(Section.AboutEvent, {id: this.props.Event.Event_id})}
+          <a href={url.section(Section.AboutEvent, {id: this.props.event.event_id})}
             rel="noopener noreferrer">
             {this._renderLogo()}
             {this._renderSubInfo()}
             {this._renderTitleAndIssue()}
             {this._renderEventDescription()}
-            {this._renderIssueAreas()}
           </a>
         </div>
     );
@@ -44,17 +43,17 @@ class EventCard extends React.PureComponent<Props> {
 
     return (
       <div className="ProjectCard-logo">
-        <img src={this.props.Event && this.props.Event.Event_thumbnail ? this.props.Event.Event_thumbnail.publicUrl : "/static/images/projectlogo-default.png"}/>
+        <img src={this.props.event && this.props.event.event_thumbnail ? this.props.event.event_thumbnail.publicUrl : "/static/images/projectlogo-default.png"}/>
       </div>
     )
   }
   _renderTitleAndIssue(): React$Node {
-    const Event: EventTileAPIData = this.props.Event;
+    const Event: EventTileAPIData = this.props.event;
     return (
       <div className="ProjectCard-title">
-        <h2>{Event.Event_name}</h2>
+        <h2>{Event.event_name}</h2>
         <h4>
-          {Event.Event_project_count + " " + utils.pluralize("project","projects", Event.Event_project_count)}
+          "DemocracyLab"
         </h4>
       </div>
     )
@@ -62,35 +61,13 @@ class EventCard extends React.PureComponent<Props> {
   _renderEventDescription(): React$Node {
     return (
         <div className="ProjectCard-description">
-          <p>{Truncate.stringT(this.props.Event.Event_short_description, this.props.maxTextLength)}</p>
+          <p>{Truncate.stringT(this.props.event.event_short_description, this.props.maxTextLength)}</p>
         </div>
     );
   }
-  _renderIssueAreas(): React$Node {
-    return (
-    <div className="ProjectCard-skills">
-      <h3>Issues</h3>
-      {this._generateIssueList()}
-    </div>
-    )
-  }
-  _generateIssueList(): React$Node {
-    // Get sorted truncated list of tag names
-    let issueNames: $ReadOnlyArray<string> = Sort.byCountDictionary(this.props.Event.Event_issue_areas);
-    issueNames = issueNames.map((issueName: string) => this.props.tagDictionary[issueName].display_name);
-    issueNames = Truncate.arrayT(issueNames, this.props.maxIssuesCount);
-
-    return (
-      <ul>
-        {issueNames.map((issueName: string, i: number) =>
-          <li key={i}>{issueName}</li>
-        )}
-      </ul>
-    );
-  }
   _renderSubInfo(): React$Node {
-    const Event: EventTileAPIData = this.props.Event;
-    const location: string = Event.Event_country && EventAPIUtils.getLocationDisplayName(Event.Event_country);
+    const Event: EventTileAPIData = this.props.event;
+    const location: string = Event.event_location;
     return (
       <div className="ProjectCard-subinfo">
         <ul>
@@ -100,10 +77,10 @@ class EventCard extends React.PureComponent<Props> {
             {location}
           </li>
         }
-        {Event.Event_date_modified &&
+        {Event.event_date_start &&
           <li>
             <i className={GlyphStyles.Clock + glyphFixedWidth}></i>
-            <Moment fromNow>{Event.Event_date_modified}</Moment>
+            <Moment fromNow>{Event.event_date_start}</Moment>
           </li>
         }
         </ul>

--- a/common/components/componentsBySection/FindEvents/EventCard.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCard.jsx
@@ -74,7 +74,7 @@ class EventCard extends React.PureComponent<Props> {
     return (
       <div className="EventCard-time">
         {Event.event_date_start &&
-          <p><Moment format="LT">{Event.event_date_start}</Moment></p>
+          <h2><Moment format="LT">{Event.event_date_start}</Moment></h2>
         }
       </div>
     );

--- a/common/components/componentsBySection/FindEvents/EventCard.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCard.jsx
@@ -31,62 +31,55 @@ class EventCard extends React.PureComponent<Props> {
         <div className="EventCard-root">
           <a href={url.section(Section.AboutEvent, {id: this.props.event.event_id})}
             rel="noopener noreferrer">
-            {this._renderLogo()}
-            {this._renderSubInfo()}
-            {this._renderTitleAndIssue()}
-            {this._renderEventDescription()}
+            {this._renderEventLogo()}
+            {this._renderEventInformation()}
+            {this._renderEventTime()}
           </a>
         </div>
     );
   }
-  _renderLogo(): React$Node {
 
+  _renderEventLogo(): React$Node {
     return (
       <div className="EventCard-logo">
         <img src={this.props.event && this.props.event.event_thumbnail ? this.props.event.event_thumbnail.publicUrl : "/static/images/projectlogo-default.png"}/>
       </div>
-    )
-  }
-  _renderTitleAndIssue(): React$Node {
-    const Event: EventTileAPIData = this.props.event;
-    return (
-      <div className="EventCard-title">
-        <h2>{Event.event_name}</h2>
-        <h4>
-          "DemocracyLab"
-        </h4>
-      </div>
-    )
-  }
-  _renderEventDescription(): React$Node {
-    return (
-        <div className="EventCard-description">
-          <p>{Truncate.stringT(this.props.event.event_short_description, this.props.maxTextLength)}</p>
-        </div>
     );
   }
-  _renderSubInfo(): React$Node {
+
+  //TODO: add organizer field to create event form/db record so we can use that instead
+  _renderEventInformation(): React$Node {
     const Event: EventTileAPIData = this.props.event;
     const location: string = Event.event_location;
     return (
-      <div className="EventCard-subinfo">
-        <ul>
+      <div className="EventCard-info">
+        <h2>{Event.event_name}</h2>
+        <h4>
+          DemocracyLab
+        </h4>
         {location &&
-          <li>
-            <i className={GlyphStyles.MapMarker + glyphFixedWidth}></i>
-            {location}
-          </li>
+          <ul>
+            <li>
+              <i className={GlyphStyles.MapMarker + glyphFixedWidth}></i>
+              {location}
+            </li>
+          </ul>
         }
-        {Event.event_date_start &&
-          <li>
-            <i className={GlyphStyles.Clock + glyphFixedWidth}></i>
-            <Moment fromNow>{Event.event_date_start}</Moment>
-          </li>
-        }
-        </ul>
       </div>
-    )
+    );
   }
+
+  _renderEventTime(): React$Node {
+    const Event: EventTileAPIData = this.props.event;
+    return (
+      <div className="EventCard-time">
+        {Event.event_date_start &&
+          <p><Moment format="LT">{Event.event_date_start}</Moment></p>
+        }
+      </div>
+    );
+  }
+
 }
 
 export default EventCard;

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -1,155 +1,154 @@
 // @flow
 
-// 
-// import React from 'react';
-// import type {ReduceStore} from 'flux/utils';
-// import GroupSearchSort from "./GroupSearchSort.jsx";
-// import GroupTagContainer from "./GroupTagContainer.jsx";
-// import {Container} from 'flux/utils';
-// import {List} from 'immutable'
-// import GroupCard from "./GroupCard.jsx";
-// import GroupSearchStore from "../../stores/GroupSearchStore.js";
-// import GroupSearchDispatcher from "../../stores/GroupSearchDispatcher.js";
-// import LoadingMessage from '../../chrome/LoadingMessage.jsx';
-// import prerender from "../../utils/prerender.js";
-// import type {LocationRadius} from "../../stores/ProjectSearchStore.js";
-// import {Dictionary, createDictionary} from "../../types/Generics.jsx";
-// import type {TagDefinition} from "../../utils/ProjectAPIUtils.js";
-// import type {GroupTileAPIData} from "../../utils/GroupAPIUtils.js";
-// import utils from "../../utils/utils.js";
-// import _ from 'lodash';
-//
-//
-// type Props = {|
-//   showSearchControls: ?boolean,
-//   staticHeaderText: ?string,
-//   fullWidth: ?boolean,
-// |}
-//
-// type State = {|
-//   groups: List<GroupTileAPIData>,
-//   group_pages: number,
-//   current_page: number,
-//   group_count: number,
-//   location: LocationRadius,
-//   tagDictionary: Dictionary<TagDefinition>
-// |};
+import React from 'react';
+import type {ReduceStore} from 'flux/utils';
+import EventSearchSort from "./EventSearchSort.jsx";
+import EventTagContainer from "./EventTagContainer.jsx";
+import {Container} from 'flux/utils';
+import {List} from 'immutable'
+import EventCard from "./EventCard.jsx";
+import EventSearchStore from "../../stores/EventSearchStore.js";
+import EventSearchDispatcher from "../../stores/EventSearchDispatcher.js";
+import LoadingMessage from '../../chrome/LoadingMessage.jsx';
+import prerender from "../../utils/prerender.js";
+import type {LocationRadius} from "../../stores/ProjectSearchStore.js";
+import {Dictionary, createDictionary} from "../../types/Generics.jsx";
+import type {TagDefinition} from "../../utils/ProjectAPIUtils.js";
+import type {EventTileAPIData} from "../../utils/EventAPIUtils.js";
+import utils from "../../utils/utils.js";
+import _ from 'lodash';
+
+
+type Props = {|
+  showSearchControls: ?boolean,
+  staticHeaderText: ?string,
+  fullWidth: ?boolean,
+|}
+
+type State = {|
+  events: List<EventTileAPIData>,
+  event_pages: number,
+  current_page: number,
+  event_count: number,
+  location: LocationRadius,
+  tagDictionary: Dictionary<TagDefinition>
+|};
 
 class EventCardsContainer extends React.Component<Props, State> {
-//
-//   static getStores(): $ReadOnlyArray<ReduceStore> {
-//     return [GroupSearchStore];
-//   }
-//
-//   static calculateState(prevState: State): State {
-//     return {
-//       groups: GroupSearchStore.getGroups(),
-//       group_pages: GroupSearchStore.getGroupPages(),
-//       group_count: GroupSearchStore.getNumberOfGroups(),
-//       current_page: GroupSearchStore.getCurrentPage(),
-//       groups_loading: GroupSearchStore.getGroupsLoading(),
-//       keyword: GroupSearchStore.getKeyword() || '',
-//       tags: GroupSearchStore.getSelectedTags() || [],
-//       location: GroupSearchStore.getLocation() || '',
-//       tagDictionary: GroupSearchStore.getAllTags() || []
-//     };
-//   }
-//
-//   render(): React$Node {
-//     return (
-//       <div className={`ProjectCardContainer col-12 ${this.props.fullWidth ? '' : 'col-md-8 col-lg-9 p-0 m-0'}`}>
-//         <div className="container-fluid">
-//           {
-//             this.props.showSearchControls
-//             ? (
-//               <React.Fragment>
-//                 <GroupSearchSort/>
-//                 <GroupTagContainer/>
-//               </React.Fragment>
-//               )
-//             : null
-//           }
-//           <div className="row">
-//             {!_.isEmpty(this.state.groups) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}
-//             {this._renderCards()}
-//           </div>
-//           <div>
-//             {this._renderPagination()}
-//           </div>
-//         </div>
-//       </div>
-//     );
-//   }
-//
-//   _renderCardHeaderText(): React$Node {
-//     if (this.props.staticHeaderText) {
-//       return this.props.staticHeaderText;
-//     } else if (this.state.keyword || this.state.tags.size > 0 || (this.state.location && this.state.location.latitude && this.state.location.longitude)) {
-//       return this.state.group_count + " " + utils.pluralize("group", "groups", this.state.group_count) + " found";
-//     } else {
-//       return 'Find groups that match your interests'
-//     }
-//   }
-//
-//   _renderCards(): React$Node {
-//     return !this.state.groups
-//       ? <LoadingMessage message="Loading groups..." />
-//       : this.state.groups.size === 0
-//         ? 'No Groups match the provided criteria. Try a different set of filters or search term.'
-//         : this.state.groups.map(
-//           (group: GroupTileAPIData, index: number) =>
-//             <div className="col-sm-12 col-lg-6">
-//               <GroupCard
-//                 group={group}
-//                 key={index}
-//                 maxTextLength={140}
-//                 maxIssuesCount={4}
-//                 tagDictionary={this.state.tagDictionary}
-//               />
-//             </div>
-//       );
-//     }
-//
-//   _handleFetchNextPage(e: object): void {
-//     e.preventDefault();
-//
-//     const nextPage = this.state.current_page + 1 <= this.state.group_pages
-//       ? this.state.current_page + 1
-//       : this.state.current_page;
-//
-//     this.setState({current_page: nextPage }, function () {
-//       GroupSearchDispatcher.dispatch({
-//         type: 'SET_PAGE',
-//         page: this.state.current_page,
-//       });
-//     });
-//   }
-//
-//   _renderPagination(): ?React$Node {
-//     if ((this.state.current_page === this.state.group_pages) && !this.state.groups_loading ) {
-//       return null;
-//     }
-//     if (!_.isEmpty(this.state.groups) && this.state.groups_loading) {
-//       return (
-//         <div className="page_selection_footer">
-//           <button className="btn btn-primary disabled">
-//             Loading...
-//           </button>
-//         </div>
-//       )
-//     }
-//     return (
-//       this.state.groups && this.state.groups.size !== 0
-//       ? <div className="page_selection_footer">
-//         <button className="btn btn-primary" onClick={this._handleFetchNextPage.bind(this)}>
-//           More Groups...
-//         </button>
-//       </div>
-//       : null
-//     );
-//   }
-// }
-//
+
+  static getStores(): $ReadOnlyArray<ReduceStore> {
+    return [EventSearchStore];
+  }
+
+  static calculateState(prevState: State): State {
+    return {
+      events: EventSearchStore.getEvents(),
+      event_pages: EventSearchStore.getEventPages(),
+      event_count: EventSearchStore.getNumberOfEvents(),
+      current_page: EventSearchStore.getCurrentPage(),
+      events_loading: EventSearchStore.getEventsLoading(),
+      keyword: EventSearchStore.getKeyword() || '',
+      tags: EventSearchStore.getSelectedTags() || [],
+      location: EventSearchStore.getLocation() || '',
+      tagDictionary: EventSearchStore.getAllTags() || []
+    };
+  }
+
+  render(): React$Node {
+    return (
+      <div className={`ProjectCardContainer col-12 ${this.props.fullWidth ? '' : 'col-md-8 col-lg-9 p-0 m-0'}`}>
+        <div className="container-fluid">
+          {
+            this.props.showSearchControls
+            ? (
+              <React.Fragment>
+                <EventSearchSort/>
+                <EventTagContainer/>
+              </React.Fragment>
+              )
+            : null
+          }
+          <div className="row">
+            {!_.isEmpty(this.state.events) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}
+            {this._renderCards()}
+          </div>
+          <div>
+            {this._renderPagination()}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  _renderCardHeaderText(): React$Node {
+    if (this.props.staticHeaderText) {
+      return this.props.staticHeaderText;
+    } else if (this.state.keyword || this.state.tags.size > 0 || (this.state.location && this.state.location.latitude && this.state.location.longitude)) {
+      return this.state.event_count + " " + utils.pluralize("event", "events", this.state.event_count) + " found";
+    } else {
+      return 'Find events that match your interests'
+    }
+  }
+
+  _renderCards(): React$Node {
+    return !this.state.events
+      ? <LoadingMessage message="Loading events..." />
+      : this.state.events.size === 0
+        ? 'No Events match the provided criteria. Try a different set of filters or search term.'
+        : this.state.events.map(
+          (event: EventTileAPIData, index: number) =>
+            <div className="col-12">
+              <EventCard
+                event={event}
+                key={index}
+                maxTextLength={140}
+                maxIssuesCount={4}
+                tagDictionary={this.state.tagDictionary}
+              />
+            </div>
+      );
+    }
+
+  _handleFetchNextPage(e: object): void {
+    e.preventDefault();
+
+    const nextPage = this.state.current_page + 1 <= this.state.event_pages
+      ? this.state.current_page + 1
+      : this.state.current_page;
+
+    this.setState({current_page: nextPage }, function () {
+      EventSearchDispatcher.dispatch({
+        type: 'SET_PAGE',
+        page: this.state.current_page,
+      });
+    });
+  }
+
+  _renderPagination(): ?React$Node {
+    if ((this.state.current_page === this.state.event_pages) && !this.state.events_loading ) {
+      return null;
+    }
+    if (!_.isEmpty(this.state.events) && this.state.events_loading) {
+      return (
+        <div className="page_selection_footer">
+          <button className="btn btn-primary disabled">
+            Loading...
+          </button>
+        </div>
+      )
+    }
+    return (
+      this.state.events && this.state.events.size !== 0
+      ? <div className="page_selection_footer">
+        <button className="btn btn-primary" onClick={this._handleFetchNextPage.bind(this)}>
+          More Events...
+        </button>
+      </div>
+      : null
+    );
+  }
+}
+
 
 
 export default Container.create(EventCardsContainer);

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -120,7 +120,7 @@ class EventCardsContainer extends React.Component<Props, State> {
     const pastEvents: $ReadOnlyArray<EventsDateGrouping> = upcomingPastEvents[1];
     return (
       <React.Fragment>
-        <h1>Upcoming Events</h1>
+        <h1 className="EventCardContainer-section-header">Upcoming Events</h1>
         {!_.isEmpty(upcomingEvents) ? (
           <React.Fragment>
             {this._renderEventsGrouping(upcomingEvents)}
@@ -129,7 +129,7 @@ class EventCardsContainer extends React.Component<Props, State> {
         }
         {!_.isEmpty(pastEvents) && (
           <React.Fragment>
-            <h1>Past Events</h1>
+            <h1 className="EventCardContainer-section-header">Past Events</h1>
             {this._renderEventsGrouping(pastEvents)}
           </React.Fragment>
           )
@@ -137,7 +137,7 @@ class EventCardsContainer extends React.Component<Props, State> {
       </React.Fragment>
     );
   }
-  
+
   _renderEventsGrouping(eventsByDate: $ReadOnlyArray<EventsDateGrouping>): React$Node {
     return (eventsByDate.map((input) => (
         <React.Fragment>

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -120,12 +120,12 @@ class EventCardsContainer extends React.Component<Props, State> {
     const pastEvents: $ReadOnlyArray<EventsDateGrouping> = upcomingPastEvents[1];
     return (
       <React.Fragment>
-        {!_.isEmpty(upcomingEvents) && (
+        <h1>Upcoming Events</h1>
+        {!_.isEmpty(upcomingEvents) ? (
           <React.Fragment>
-            <h1>Upcoming Events</h1>
             {this._renderEventsGrouping(upcomingEvents)}
           </React.Fragment>
-          )
+        ) : (<div className="EventCard-day-container"><p>No events currently scheduled, check back soon!</p></div>)
         }
         {!_.isEmpty(pastEvents) && (
           <React.Fragment>

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -47,10 +47,7 @@ class EventCardsContainer extends React.Component<Props, State> {
       event_count: EventSearchStore.getNumberOfEvents(),
       current_page: EventSearchStore.getCurrentPage(),
       events_loading: EventSearchStore.getEventsLoading(),
-      keyword: EventSearchStore.getKeyword() || '',
-      tags: EventSearchStore.getSelectedTags() || [],
-      location: EventSearchStore.getLocation() || '',
-      tagDictionary: EventSearchStore.getAllTags() || []
+      keyword: EventSearchStore.getKeyword() || ''
     };
   }
 
@@ -62,8 +59,8 @@ class EventCardsContainer extends React.Component<Props, State> {
             this.props.showSearchControls
             ? (
               <React.Fragment>
-                <EventSearchSort/>
-                <EventTagContainer/>
+                {/*<EventSearchSort/>*/}
+                {/*<EventTagContainer/>*/}
               </React.Fragment>
               )
             : null
@@ -83,7 +80,7 @@ class EventCardsContainer extends React.Component<Props, State> {
   _renderCardHeaderText(): React$Node {
     if (this.props.staticHeaderText) {
       return this.props.staticHeaderText;
-    } else if (this.state.keyword || this.state.tags.size > 0 || (this.state.location && this.state.location.latitude && this.state.location.longitude)) {
+    } else if (this.state.keyword) {
       return this.state.event_count + " " + utils.pluralize("event", "events", this.state.event_count) + " found";
     } else {
       return 'Find events that match your interests'

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -31,7 +31,7 @@ function generateEventsDateListings(events: $ReadOnlyArray<EventTileAPIData>): $
   const groupings: Dictionary<EventTileAPIData> =  _.groupBy(events, (event: EventTileAPIData) => {
     return moment(event.event_date_start).startOf('day').format(dateHeaderFormat)
   });
-  
+
   const eventsDateListings: $ReadOnlyArray<EventsDateGrouping> = Object.keys(groupings).map( (dateKey) => {
     return {
       date: moment(dateKey, dateHeaderFormat),
@@ -39,7 +39,7 @@ function generateEventsDateListings(events: $ReadOnlyArray<EventTileAPIData>): $
       events: _.reverse(_.sortBy(groupings[dateKey], ['event_date_start']))
     }
   });
-  
+
   return _.reverse(_.sortBy(eventsDateListings, ['date']));
 }
 
@@ -94,7 +94,7 @@ class EventCardsContainer extends React.Component<Props, State> {
           }
           <div className="row EventCards-card-container">
             {!_.isEmpty(this.state.events) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}
-            {this._renderCards()}
+            {this._renderEventsByDate()}
           </div>
           {/*<div>
             {this._renderPagination()}
@@ -111,27 +111,34 @@ class EventCardsContainer extends React.Component<Props, State> {
       return this.state.event_count + " " + utils.pluralize("event", "events", this.state.event_count) + " found";
     } else {
       return 'Find events that match your interests'
+    };
+  }
+
+  _renderEventsByDate(): React$Node {
+    if(this.state.eventsByDate) {
+      console.log(this.state.eventsByDate);
+      return (this.state.eventsByDate.map((input) => (
+        <React.Fragment>
+          <h4 className="EventCard-dateheader">{input.dateString}</h4>
+          <div className="EventCard-day-container">
+            {input.events.map(
+              (event: EventsDateGrouping, index: number) =>
+                  <EventCard
+                    event={event}
+                    key={index}
+                    maxTextLength={140}
+                    maxIssuesCount={4}
+                    tagDictionary={this.state.tagDictionary}
+                  />
+              )
+            }
+          </div>
+        </React.Fragment>
+      ))
+      );
     }
   }
 
-  _renderCards(): React$Node {
-    return !this.state.events
-      ? <LoadingMessage message="Loading events..." />
-      : this.state.events.size === 0
-        ? 'No Events match the provided criteria. Try a different set of filters or search term.'
-        : this.state.events.map(
-          (event: EventTileAPIData, index: number) =>
-            <div className="col-12 EventCards-card">
-              <EventCard
-                event={event}
-                key={index}
-                maxTextLength={140}
-                maxIssuesCount={4}
-                tagDictionary={this.state.tagDictionary}
-              />
-            </div>
-      );
-    }
 
   _handleFetchNextPage(e: object): void {
     e.preventDefault();

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -80,7 +80,7 @@ class EventCardsContainer extends React.Component<Props, State> {
 
   render(): React$Node {
     return (
-      <div className={`ProjectCardContainer col-12 ${this.props.fullWidth ? '' : 'col-md-8 col-lg-9 p-0 m-0'}`}>
+      <div className={`ProjectCardContainer col-12 ${this.props.fullWidth ? '' : 'col-md-8 col-lg-9 p-lg-0 m-lg-0'}`}>
         <div className="container-fluid">
           {
             this.props.showSearchControls

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -1,0 +1,155 @@
+// @flow
+
+// 
+// import React from 'react';
+// import type {ReduceStore} from 'flux/utils';
+// import GroupSearchSort from "./GroupSearchSort.jsx";
+// import GroupTagContainer from "./GroupTagContainer.jsx";
+// import {Container} from 'flux/utils';
+// import {List} from 'immutable'
+// import GroupCard from "./GroupCard.jsx";
+// import GroupSearchStore from "../../stores/GroupSearchStore.js";
+// import GroupSearchDispatcher from "../../stores/GroupSearchDispatcher.js";
+// import LoadingMessage from '../../chrome/LoadingMessage.jsx';
+// import prerender from "../../utils/prerender.js";
+// import type {LocationRadius} from "../../stores/ProjectSearchStore.js";
+// import {Dictionary, createDictionary} from "../../types/Generics.jsx";
+// import type {TagDefinition} from "../../utils/ProjectAPIUtils.js";
+// import type {GroupTileAPIData} from "../../utils/GroupAPIUtils.js";
+// import utils from "../../utils/utils.js";
+// import _ from 'lodash';
+//
+//
+// type Props = {|
+//   showSearchControls: ?boolean,
+//   staticHeaderText: ?string,
+//   fullWidth: ?boolean,
+// |}
+//
+// type State = {|
+//   groups: List<GroupTileAPIData>,
+//   group_pages: number,
+//   current_page: number,
+//   group_count: number,
+//   location: LocationRadius,
+//   tagDictionary: Dictionary<TagDefinition>
+// |};
+
+class EventCardsContainer extends React.Component<Props, State> {
+//
+//   static getStores(): $ReadOnlyArray<ReduceStore> {
+//     return [GroupSearchStore];
+//   }
+//
+//   static calculateState(prevState: State): State {
+//     return {
+//       groups: GroupSearchStore.getGroups(),
+//       group_pages: GroupSearchStore.getGroupPages(),
+//       group_count: GroupSearchStore.getNumberOfGroups(),
+//       current_page: GroupSearchStore.getCurrentPage(),
+//       groups_loading: GroupSearchStore.getGroupsLoading(),
+//       keyword: GroupSearchStore.getKeyword() || '',
+//       tags: GroupSearchStore.getSelectedTags() || [],
+//       location: GroupSearchStore.getLocation() || '',
+//       tagDictionary: GroupSearchStore.getAllTags() || []
+//     };
+//   }
+//
+//   render(): React$Node {
+//     return (
+//       <div className={`ProjectCardContainer col-12 ${this.props.fullWidth ? '' : 'col-md-8 col-lg-9 p-0 m-0'}`}>
+//         <div className="container-fluid">
+//           {
+//             this.props.showSearchControls
+//             ? (
+//               <React.Fragment>
+//                 <GroupSearchSort/>
+//                 <GroupTagContainer/>
+//               </React.Fragment>
+//               )
+//             : null
+//           }
+//           <div className="row">
+//             {!_.isEmpty(this.state.groups) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}
+//             {this._renderCards()}
+//           </div>
+//           <div>
+//             {this._renderPagination()}
+//           </div>
+//         </div>
+//       </div>
+//     );
+//   }
+//
+//   _renderCardHeaderText(): React$Node {
+//     if (this.props.staticHeaderText) {
+//       return this.props.staticHeaderText;
+//     } else if (this.state.keyword || this.state.tags.size > 0 || (this.state.location && this.state.location.latitude && this.state.location.longitude)) {
+//       return this.state.group_count + " " + utils.pluralize("group", "groups", this.state.group_count) + " found";
+//     } else {
+//       return 'Find groups that match your interests'
+//     }
+//   }
+//
+//   _renderCards(): React$Node {
+//     return !this.state.groups
+//       ? <LoadingMessage message="Loading groups..." />
+//       : this.state.groups.size === 0
+//         ? 'No Groups match the provided criteria. Try a different set of filters or search term.'
+//         : this.state.groups.map(
+//           (group: GroupTileAPIData, index: number) =>
+//             <div className="col-sm-12 col-lg-6">
+//               <GroupCard
+//                 group={group}
+//                 key={index}
+//                 maxTextLength={140}
+//                 maxIssuesCount={4}
+//                 tagDictionary={this.state.tagDictionary}
+//               />
+//             </div>
+//       );
+//     }
+//
+//   _handleFetchNextPage(e: object): void {
+//     e.preventDefault();
+//
+//     const nextPage = this.state.current_page + 1 <= this.state.group_pages
+//       ? this.state.current_page + 1
+//       : this.state.current_page;
+//
+//     this.setState({current_page: nextPage }, function () {
+//       GroupSearchDispatcher.dispatch({
+//         type: 'SET_PAGE',
+//         page: this.state.current_page,
+//       });
+//     });
+//   }
+//
+//   _renderPagination(): ?React$Node {
+//     if ((this.state.current_page === this.state.group_pages) && !this.state.groups_loading ) {
+//       return null;
+//     }
+//     if (!_.isEmpty(this.state.groups) && this.state.groups_loading) {
+//       return (
+//         <div className="page_selection_footer">
+//           <button className="btn btn-primary disabled">
+//             Loading...
+//           </button>
+//         </div>
+//       )
+//     }
+//     return (
+//       this.state.groups && this.state.groups.size !== 0
+//       ? <div className="page_selection_footer">
+//         <button className="btn btn-primary" onClick={this._handleFetchNextPage.bind(this)}>
+//           More Groups...
+//         </button>
+//       </div>
+//       : null
+//     );
+//   }
+// }
+//
+
+
+export default Container.create(EventCardsContainer);

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -93,8 +93,8 @@ class EventCardsContainer extends React.Component<Props, State> {
             : null
           }
           <div className="row EventCards-card-container">
-            {!_.isEmpty(this.state.events) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}
-            {this._renderEventsByDate()}
+            {/*{!_.isEmpty(this.state.events) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}*/}
+            {!_.isEmpty(this.state.events) && this._renderEvents()}
           </div>
           {/*<div>
             {this._renderPagination()}
@@ -114,31 +114,50 @@ class EventCardsContainer extends React.Component<Props, State> {
     };
   }
 
-  _renderEventsByDate(): React$Node {
-    if(this.state.eventsByDate) {
-      console.log(this.state.eventsByDate);
-      return (this.state.eventsByDate.map((input) => (
+  _renderEvents(): React$Node {
+    const upcomingPastEvents: Array<$ReadOnlyArray<EventsDateGrouping>> = _.partition(this.state.eventsByDate, (event: EventsDateGrouping) => event.date > moment());
+    const upcomingEvents: $ReadOnlyArray<EventsDateGrouping> = upcomingPastEvents[0];
+    const pastEvents: $ReadOnlyArray<EventsDateGrouping> = upcomingPastEvents[1];
+    return (
+      <React.Fragment>
+        {!_.isEmpty(upcomingEvents) && (
+          <React.Fragment>
+            <h1>Upcoming Events</h1>
+            {this._renderEventsGrouping(upcomingEvents)}
+          </React.Fragment>
+          )
+        }
+        {!_.isEmpty(pastEvents) && (
+          <React.Fragment>
+            <h1>Past Events</h1>
+            {this._renderEventsGrouping(pastEvents)}
+          </React.Fragment>
+          )
+        }
+      </React.Fragment>
+    );
+  }
+  
+  _renderEventsGrouping(eventsByDate: $ReadOnlyArray<EventsDateGrouping>): React$Node {
+    return (eventsByDate.map((input) => (
         <React.Fragment>
           <h4 className="EventCard-dateheader">{input.dateString}</h4>
           <div className="EventCard-day-container">
             {input.events.map(
               (event: EventsDateGrouping, index: number) =>
-                  <EventCard
-                    event={event}
-                    key={index}
-                    maxTextLength={140}
-                    maxIssuesCount={4}
-                    tagDictionary={this.state.tagDictionary}
-                  />
-              )
-            }
+                <EventCard
+                  event={event}
+                  key={index}
+                  maxTextLength={140}
+                  maxIssuesCount={4}
+                  tagDictionary={this.state.tagDictionary}
+                />
+            )}
           </div>
         </React.Fragment>
       ))
-      );
-    }
+    );
   }
-
 
   _handleFetchNextPage(e: object): void {
     e.preventDefault();

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -75,13 +75,13 @@ class EventCardsContainer extends React.Component<Props, State> {
               )
             : null
           }
-          <div className="row">
+          <div className="row EventCards-card-container">
             {!_.isEmpty(this.state.events) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}
             {this._renderCards()}
           </div>
-          <div>
+          {/*<div>
             {this._renderPagination()}
-          </div>
+          </div> */}
         </div>
       </div>
     );
@@ -104,7 +104,7 @@ class EventCardsContainer extends React.Component<Props, State> {
         ? 'No Events match the provided criteria. Try a different set of filters or search term.'
         : this.state.events.map(
           (event: EventTileAPIData, index: number) =>
-            <div className="col-12">
+            <div className="col-12 EventCards-card">
               <EventCard
                 event={event}
                 key={index}

--- a/common/components/componentsBySection/FindEvents/EventSearchBar.jsx
+++ b/common/components/componentsBySection/FindEvents/EventSearchBar.jsx
@@ -1,0 +1,57 @@
+// @flow
+
+import React, { SyntheticEvent } from 'react';
+import type {FluxReduceStore} from 'flux/utils';
+import {Container} from 'flux/utils';
+import GlyphStyles from "../../utils/glyphs.js";
+import metrics from "../../utils/metrics.js";
+import EventSearchStore from "../../stores/EventSearchStore.js";
+import EventSearchDispatcher from "../../stores/EventSearchDispatcher.js";
+
+type State = {|
+  keyword: string,
+|};
+
+class EventSearchBar extends React.Component<{||}, State> {
+
+  static getStores(): $ReadOnlyArray<FluxReduceStore> {
+    return [EventSearchStore];
+  }
+
+  static calculateState(prevState: State): State {
+    return {
+      keyword: EventSearchStore.getKeyword() || '',
+    };
+  }
+
+  render(): React$Node {
+    return (
+      <div className="ProjectSearchBar-root">
+        <i className={GlyphStyles.Search}></i>
+        <input
+          className="ProjectSearchBar-input"
+          onChange={e => this.setState({keyword: e.target.value})}
+          onKeyPress={this._handleKeyPress.bind(this)}
+          placeholder="Search Events"
+          value={this.state.keyword}
+        />
+      </div>
+    );
+  }
+
+  _handleKeyPress(e: SyntheticEvent<HTMLInputElement>): void {
+    if (e.key === 'Enter') {
+      this._onSubmitKeyword();
+    }
+  }
+
+  _onSubmitKeyword(): void {
+    EventSearchDispatcher.dispatch({
+      type: 'SET_KEYWORD',
+      keyword: this.state.keyword,
+    });
+    metrics.logEventSearchByKeywordEvent(this.state.keyword);
+  }
+}
+
+export default Container.create(EventSearchBar);

--- a/common/components/componentsBySection/FindEvents/EventSearchSort.jsx
+++ b/common/components/componentsBySection/FindEvents/EventSearchSort.jsx
@@ -1,0 +1,79 @@
+
+// @flow
+import type {FluxReduceStore} from 'flux/utils';
+import {Container} from 'flux/utils';
+import React from 'react';
+import Select from 'react-select';
+import EventSearchBar from "./EventSearchBar.jsx";
+import {SelectOption} from "../../types/SelectOption.jsx";
+import metrics from "../../utils/metrics.js";
+import EventSearchStore from "../../stores/EventSearchStore.js";
+import EventSearchDispatcher from "../../stores/EventSearchDispatcher.js";
+
+
+type State = {|
+  sortField: string
+|};
+
+// change this to Upcoming / Past only, based on event timestamp
+const sortOptions: $ReadOnlyArray<SelectOption>  = [
+    {value: "", label: "Date Modified"},
+    {value: "event_name", label: "Name - Ascending"},
+    {value: "-event_name", label: "Name - Descending"}
+  ];
+
+class EventSearchSort extends React.Component<{||}, State> {
+
+  static getStores(): $ReadOnlyArray<FluxReduceStore> {
+    return [EventSearchStore];
+  }
+
+  static calculateState(prevState: State): State {
+    const sortField = EventSearchStore.getSortField();
+
+    const state = {
+      sortField: sortField ? sortOptions.find(option => option.value === sortField) : sortOptions[0]
+    };
+
+    return state;
+  }
+
+  render(): React$Node {
+    return (
+      <div className="ProjectSearchSort-container">
+          <EventSearchBar />
+          {this._renderSortFieldDropdown()}
+      </div>
+    );
+  }
+
+  _handleSubmitSortField(sortOption: SelectOption): void {
+    this.setState({sortField: sortOption.value}, function () {
+      this._onSubmitSortField();
+    });
+  }
+
+  _onSubmitSortField(): void {
+    EventSearchDispatcher.dispatch({
+      type: 'SET_SORT',
+      sortField: this.state.sortField,
+    });
+    metrics.logEventSearchChangeSortEvent(this.state.sortField);
+  }
+
+  _renderSortFieldDropdown(): React$Node{
+    // TODO: Replace with Selector component
+    return <Select
+      options={sortOptions}
+      value={this.state && this.state.sortField}
+      onChange={this._handleSubmitSortField.bind(this)}
+      classNamePrefix="ProjectSearchSort"
+      className="form-control ProjectSearchSort-sortform"
+      simpleValue={true}
+      isClearable={false}
+      isMulti={false}
+    />
+  }
+}
+
+export default Container.create(EventSearchSort);

--- a/common/components/componentsBySection/FindEvents/EventTagContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventTagContainer.jsx
@@ -1,0 +1,67 @@
+// @flow
+
+import React from 'react';
+import type {FluxReduceStore} from 'flux/utils';
+import {Container} from 'flux/utils';
+import {LocationRadius} from '../../stores/ProjectSearchStore.js';
+import CloseablePill from "../FindProjects/CloseablePill.jsx";
+import type {TagDefinition} from "../../utils/ProjectAPIUtils.js";
+import EventSearchDispatcher from "../../stores/EventSearchDispatcher.js";
+import ProjectTagContainer from "../FindProjects/ProjectTagContainer.jsx";
+import EventSearchStore from "../../stores/EventSearchStore.js";
+
+type PillConfig = {|
+  label: string,
+  closeAction: () => void
+|};
+
+type State = {|
+  pillConfigs: $ReadOnlyArray<PillConfig>
+|};
+
+// TODO: Refactor into shared component between Project and Event search pages
+class EventTagContainer extends React.Component<{||}, State> {
+
+  static getStores(): $ReadOnlyArray<FluxReduceStore> {
+    return [EventSearchStore];
+  }
+
+  static calculateState(prevState: State): State {
+
+    let pillConfigs: Array<PillConfig> = [];
+    pillConfigs = pillConfigs.concat(EventSearchStore.getSelectedTags().toJS().map((tag: TagDefinition) => {
+      return {
+        label: tag.display_name,
+        closeAction: () => EventSearchDispatcher.dispatch({type: 'REMOVE_TAG', tag: tag})
+      };
+    }));
+
+    const locationRadius: LocationRadius = EventSearchStore.getLocation();
+    if(locationRadius && locationRadius.latitude && locationRadius.longitude) {
+      pillConfigs.push({
+        label: ProjectTagContainer.getLocationPillLabel(locationRadius),
+        closeAction: () => EventSearchDispatcher.dispatch({type: 'SET_LOCATION', locationRadius: null})
+      });
+    }
+
+    return {
+      pillConfigs: pillConfigs
+    };
+  }
+
+  render(): React$Node {
+    return (
+      <div className="ProjectTagContainer-root">
+        {
+          this.state.pillConfigs.map( (pillConfig: PillConfig) => {
+            return (
+              <CloseablePill key={pillConfig.label} label={pillConfig.label} closeAction={pillConfig.closeAction}/>
+            );
+          })
+        }
+      </div>
+    );
+  }
+}
+
+export default Container.create(EventTagContainer);

--- a/common/components/componentsBySection/FindEvents/filters/EventFilterContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/filters/EventFilterContainer.jsx
@@ -1,22 +1,27 @@
-
 // @flow
-//
-// import React from 'react';
-// import GroupFilterDataContainer from "./GroupFilterDataContainer.jsx";
-// import ResetGroupSearchButton from "./ResetGroupSearchButton.jsx";
-//
-// class GroupFilterContainer extends React.PureComponent<{||}> {
-//
-//   render(): React$Node {
-//     return (
-//       <div className="ProjectFilterContainer-root col-12 col-md-4 col-lg-3 pl-0 pr-0">
-//         <div className="ProjectFilterContainer-reset">
-//           <ResetGroupSearchButton />
-//         </div>
-//           <GroupFilterDataContainer />
-//       </div>
-//     );
-//   }
-// }
-//
-// export default GroupFilterContainer;
+
+import React from 'react';
+// import EventFilterDataContainer from "./EventFilterDataContainer.jsx";
+// import ResetEventSearchButton from "./ResetEventSearchButton.jsx";
+
+class EventFilterContainer extends React.PureComponent<{||}> {
+
+  render(): React$Node {
+    return (
+      <div className="EventFilterContainer-root col-12 col-md-4 col-lg-3 pl-0 pr-0">
+      </div>
+    );
+  }
+}
+
+
+// enable this when we enable filters
+// return (
+//   <div className="EventFilterContainer-root col-12 col-md-4 col-lg-3 pl-0 pr-0">
+//     <div className="EventFilterContainer-reset">
+//       <ResetEventSearchButton />
+//     </div>
+//       <EventFilterDataContainer />
+//   </div>
+
+export default EventFilterContainer;

--- a/common/components/componentsBySection/FindEvents/filters/EventFilterContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/filters/EventFilterContainer.jsx
@@ -1,0 +1,22 @@
+
+// @flow
+//
+// import React from 'react';
+// import GroupFilterDataContainer from "./GroupFilterDataContainer.jsx";
+// import ResetGroupSearchButton from "./ResetGroupSearchButton.jsx";
+//
+// class GroupFilterContainer extends React.PureComponent<{||}> {
+//
+//   render(): React$Node {
+//     return (
+//       <div className="ProjectFilterContainer-root col-12 col-md-4 col-lg-3 pl-0 pr-0">
+//         <div className="ProjectFilterContainer-reset">
+//           <ResetGroupSearchButton />
+//         </div>
+//           <GroupFilterDataContainer />
+//       </div>
+//     );
+//   }
+// }
+//
+// export default GroupFilterContainer;

--- a/common/components/componentsBySection/FindEvents/filters/EventFilterContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/filters/EventFilterContainer.jsx
@@ -9,6 +9,7 @@ class EventFilterContainer extends React.PureComponent<{||}> {
   render(): React$Node {
     return (
       <div className="EventFilterContainer-root col-12 col-md-4 col-lg-3 pl-0 pr-0">
+        (Filters coming soon)
       </div>
     );
   }

--- a/common/components/componentsBySection/FindEvents/filters/EventFilterContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/filters/EventFilterContainer.jsx
@@ -9,7 +9,6 @@ class EventFilterContainer extends React.PureComponent<{||}> {
   render(): React$Node {
     return (
       <div className="EventFilterContainer-root col-12 col-md-4 col-lg-3 pl-0 pr-0">
-        (Filters coming soon)
       </div>
     );
   }

--- a/common/components/componentsBySection/FindEvents/filters/EventFilterDataContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/filters/EventFilterDataContainer.jsx
@@ -1,0 +1,123 @@
+// @flow
+
+import React from "react"
+import {Container} from "flux/utils";
+import {ReduceStore} from "flux/utils";
+import {TagDefinition, TagDefinitionCount} from "../../../utils/ProjectAPIUtils.js";
+import EventLocationSearchSection from "./EventLocationSearchSection.jsx";
+import EventAPIUtils from "../../../utils/EventAPIUtils.js";
+import EventSearchStore from "../../../stores/EventSearchStore.js";
+import EventSearchDispatcher from "../../../stores/EventSearchDispatcher.js";
+import RenderFilterCategory from "../../FindProjects/Filters/RenderFilterCategory.jsx";
+import metrics from "../../../utils/metrics";
+import _ from "lodash";
+
+/**
+ * @title: Title of the dropdown
+ */
+type Props = {|
+  title: string
+|};
+
+type State = {|
+  tagsByCategory: Dictionary<$ReadOnlyArray<TagDefinitionCount>>,
+  filterCounts: ?{ [key: string]: number },
+  selectedTags: ?{ [key: string]: boolean },
+|};
+
+class EventFilterDataContainer extends React.Component<Props, State> {
+  constructor(props: Props): void {
+    super(props);
+    this.state = {
+      tags: null,
+      selectedTags: null,
+      filterCounts: null
+    };
+
+    // passing true to fetchTagsByCategory asks backend to return num_times in API response
+    EventAPIUtils.fetchAllTags((tags: $ReadOnlyArray<TagDefinitionCount>) => {
+      //Need to do some work before setting state: Remove empty tags, generate cat/subcat totals, cleanup, then set state.
+      //Generate category and subcategory totals - this is number of FILTERS and not total number of PROJECTS
+      //So this may be used for "Select All" checkbox reference but will not be used for display of counts in DOM
+      let subcatCount = _.countBy(tags, "subcategory" );
+      let catCount = _.countBy(tags, "category");
+      let countMergeResult = _.merge(catCount, subcatCount)
+      //Event tags by category before generating child components
+      let sorted = _.groupBy(tags, "category");
+
+      //last, set state with our computed data
+      this.setState({
+        filterCounts: countMergeResult,
+        tagsByCategory: sorted
+      });
+    });
+    this._checkEnabled = this._checkEnabled.bind(this);
+    this._selectOption = this._selectOption.bind(this);
+  }
+
+  static getStores(): $ReadOnlyArray<ReduceStore> {
+    return [EventSearchStore];
+  }
+
+  static calculateState(prevState: State): State {
+    return {
+      selectedTags:_.mapKeys(EventSearchStore.getSelectedTags().toArray(), (tag: TagDefinition) => tag.tag_name)
+    };
+  }
+
+  render(): React$Node {
+    //should render a number of <RenderFilterCategory> child components
+
+    return (
+      <div>
+        { this.state.tagsByCategory ? this._renderFilterCategories() : null }
+        <EventLocationSearchSection />
+      </div>
+    );
+  }
+
+  _renderFilterCategories(): void {
+    // TODO: Display in sorted order if we have more than one tag category
+    const categories: $ReadOnlyArray<string> = Object.keys(this.state.tagsByCategory);
+    const displayFilters: $ReadOnlyArray<React$Node> = categories.map(key =>
+      <RenderFilterCategory
+        key={key}
+        categoryCount={_.sumBy(this.state.tagsByCategory[key], "num_times")} //for displaying "category total" numbers
+        category={key}
+        data={_.sortBy(this.state.tagsByCategory[key], (tag) => tag.display_name.toUpperCase())}
+        hasSubcategories={_.every(this.state.tagsByCategory[key], "subcategory")}
+        checkEnabled={this._checkEnabled}
+        selectOption={this._selectOption}
+      />
+    );
+    return (
+        <div className="ProjectFilterDataContainer-root">
+            {displayFilters}
+        </div>
+    );
+  }
+
+  _checkEnabled(tag: TagDefinition): boolean {
+    return !!this.state.selectedTags[tag.tag_name];
+  }
+
+  _selectOption(tag: TagDefinition): void {
+    let tagInState = _.has(this.state.selectedTags, tag.tag_name);
+    //if tag is NOT currently in state, add it, otherwise remove
+    if(!tagInState) {
+      EventSearchDispatcher.dispatch({
+        type: "ADD_TAG",
+        tag: tag.tag_name,
+      });
+      metrics.logSearchFilterByTagEvent(tag);
+    } else {
+      EventSearchDispatcher.dispatch({
+        type: "REMOVE_TAG",
+        tag: tag,
+      });
+    }
+  }
+}
+
+
+export default Container.create(EventFilterDataContainer);

--- a/common/components/componentsBySection/FindEvents/filters/EventLocationSearchSection.jsx
+++ b/common/components/componentsBySection/FindEvents/filters/EventLocationSearchSection.jsx
@@ -1,0 +1,172 @@
+// @flow
+import React from 'react';
+import type {FluxReduceStore} from 'flux/utils';
+import {Container} from 'flux/utils';
+import type {LocationRadius}  from "../../../stores/ProjectSearchStore.js";
+import EventSearchStore from "../../../stores/EventSearchStore.js";
+import EventSearchDispatcher from "../../../stores/EventSearchDispatcher.js";
+import LocationAutocomplete from "../../../common/location/LocationAutocomplete.jsx";
+import type {LocationInfo} from "../../../common/location/LocationInfo";
+import Selector from "../../../common/selection/Selector.jsx";
+import {CountrySelector} from "../../../common/selection/CountrySelector.jsx";
+import {CountryCodeFormats, CountryData, DefaultCountry} from "../../../constants/Countries.js";
+import GlyphStyles from '../../../utils/glyphs.js'
+
+
+type State = {|
+  countryCode: string,
+  countryOptions: $ReadOnlyArray<CountryData>,
+  locationRadius: LocationRadius,
+  locationPlaceholder: ?LocationInfo,
+  locationInfo: LocationInfo,
+  searchRadius: number,
+  locationExpanded: boolean
+|};
+
+//define CSS classes as consts for toggling, same as RenderFilterCategory.jsx
+const classCategoryExpanded = 'ProjectFilterContainer-category ProjectFilterContainer-expanded';
+const classCategoryCollapsed = 'ProjectFilterContainer-category ProjectFilterContainer-collapsed';
+
+const DefaultSearchRadius: number = 50;
+
+class EventLocationSearchSection extends React.Component<Props, State> {
+  constructor(props: Props): void {
+    super(props);
+    this.state = {
+      searchRadius: DefaultSearchRadius,
+      countryCode: DefaultCountry.ISO_3,
+      locationExpanded: false
+    };
+
+    this.updateLocationState = this.updateLocationState.bind(this);
+  }
+
+  static getStores(): $ReadOnlyArray<FluxReduceStore> {
+    return [EventSearchStore];
+  }
+
+  static calculateState(prevState: State): State {
+    const state: State = {
+      countryOptions: EventSearchStore.getCountryList()
+    };
+    state.locationRadius = EventSearchStore.getLocation() || {};
+    if(!_.isEmpty(state.locationRadius) && (!prevState || !prevState.locationInfo)) {
+      // Placeholder lat/long location in Near field
+      state.countryCode = null;
+      state.locationInfo = {latitude: state.locationRadius.latitude, longitude: state.locationRadius.longitude};
+      state.searchRadius = state.locationRadius.radius;
+    } else if (_.isEmpty(state.locationRadius)) {
+      // If filters were cleared
+      state.locationInfo = null;
+    }
+
+    return state;
+  }
+
+  //handle expand/collapse
+  _handleExpand(event) {
+    this.setState(prevState => ({
+      locationExpanded: !prevState.locationExpanded
+    }));
+  }
+
+  updateLocationState(locationInfo: ?LocationInfo, searchRadius: ?number): void {
+
+    if(searchRadius && !_.isEmpty(locationInfo)) {
+      // Case: Setting new location state filter
+      const locationRadius: LocationRadius = {
+        latitude: locationInfo.latitude,
+        longitude: locationInfo.longitude,
+        radius: searchRadius,
+        metadata: locationInfo
+      };
+      if(!_.isEqual(locationRadius, this.state.locationRadius)) {
+        this.setState({locationInfo: locationInfo}, () => {
+          EventSearchDispatcher.dispatch({
+            type: 'SET_LOCATION',
+            locationRadius: locationRadius
+          });
+        });
+      }
+    } else if (!_.isEmpty(this.state.locationRadius)) {
+      // Case: Clearing location state filter after clearing Near box
+      this.setState({locationRadius: null}, () => {
+        EventSearchDispatcher.dispatch({
+          type: 'SET_LOCATION',
+          locationRadius: null
+        });
+      });
+    }
+  }
+
+  onCountrySelect(country: CountryData): void {
+    if(this.state.countryCode !== country.ISO_3) {
+      this.setState({countryCode: country.ISO_3});
+    }
+  }
+
+  onLocationSelect(locationInfo: LocationInfo): void {
+    if(!this.state.locationInfo || !locationInfo || this.state.locationInfo !== locationInfo.location_id ) {
+      this.updateLocationState(locationInfo, this.state.searchRadius);
+    }
+  }
+
+  onRadiusSelect(searchRadius: number): void {
+    if(!this.state.searchRadius || this.state.searchRadius !== searchRadius ) {
+      this.setState({searchRadius: searchRadius}, () => this.updateLocationState(this.state.locationInfo, searchRadius));
+    }
+  }
+
+  _renderSelector(): React$Node {
+    return (
+      <React.Fragment>
+
+        <label>Country(Required)</label>
+        <CountrySelector
+          countryCode={this.state.countryCode}
+          countryOptions={this.state.countryOptions}
+          countryCodeFormat={CountryCodeFormats.ISO_3}
+          onSelection={this.onCountrySelect.bind(this)}
+        />
+
+        <label>Near</label>
+        <LocationAutocomplete
+          countryCode={this.state.countryCode}
+          onSelect={this.onLocationSelect.bind(this)}
+          selected={this.state.locationInfo}
+        />
+
+        <label>Distance</label>
+        <Selector
+          id="radius"
+          isSearchable={false}
+          isClearable={false}
+          isMultiSelect={false}
+          options={[5,10,25,50,100,200]}
+          labelGenerator={(num) => num + " Miles"}
+          selected={this.state.searchRadius || DefaultSearchRadius}
+          onSelection={this.onRadiusSelect.bind(this)}
+        />
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    return (
+        <div className="LocationSearchContainer">
+          <div className={this.state.locationExpanded ? classCategoryExpanded : classCategoryCollapsed}>
+            <div className='ProjectFilterContainer-category-header' id="location-search-section" onClick={(e) => this._handleExpand(e)}>
+              <span>Location</span>
+              <span className="ProjectFilterContainer-showtext">{this.state.locationExpanded ? <i className={GlyphStyles.ChevronUp}></i> : <i className={GlyphStyles.ChevronDown}></i>}</span>
+            </div>
+            <div className="ProjectFilterContainer-content LocationSearchContainer-content">
+              {this._renderSelector()}
+            </div>
+          </div>
+        </div>
+    );
+  }
+
+}
+
+export default Container.create(EventLocationSearchSection);

--- a/common/components/componentsBySection/FindEvents/filters/ResetEventFilterButton.jsx
+++ b/common/components/componentsBySection/FindEvents/filters/ResetEventFilterButton.jsx
@@ -1,0 +1,52 @@
+// @flow
+import type {ReduceStore} from 'flux/utils';
+import {List} from 'immutable'
+import {Container} from 'flux/utils';
+import EventSearchStore from "../../../stores/EventSearchStore.js";
+import EventSearchDispatcher from "../../../stores/EventSearchDispatcher.js";
+import type {LocationRadius} from "../../stores/ProjectSearchStore.js";
+import React from 'react';
+import _ from 'lodash';
+
+type State = {|
+  keyword: string,
+  tags: List<TagDefinition>,
+  sortField: string,
+  locationRadius: LocationRadius
+|};
+
+class ResetEventSearchButton extends React.Component<{||}, State> {
+
+  static getStores(): $ReadOnlyArray<ReduceStore> {
+    return [EventSearchStore];
+  }
+
+  static calculateState(prevState: State): State {
+    return {
+      keyword: EventSearchStore.getKeyword() || '',
+      tags: EventSearchStore.getSelectedTags() || [],
+      sortField: EventSearchStore.getSortField() || '',
+      locationRadius: EventSearchStore.getLocation() || {}
+    };
+  }
+
+  render(): React$Node {
+    return (
+      <React.Fragment>
+        <button
+          className="btn btn-primary btn-block reset-search-button"
+          disabled={!(this.state.keyword || this.state.tags.size > 0 || this.state.sortField || !_.isEmpty(this.state.locationRadius)) }
+          onClick={this._clearFilters.bind(this)}>
+          Clear Filters
+        </button>
+      </React.Fragment>
+    );
+  }
+  _clearFilters(): void {
+    EventSearchDispatcher.dispatch({
+      type: 'CLEAR_FILTERS',
+    });
+  }
+}
+
+export default Container.create(ResetEventSearchButton);

--- a/common/components/componentsBySection/FindProjects/ResetSearchButton.jsx
+++ b/common/components/componentsBySection/FindProjects/ResetSearchButton.jsx
@@ -10,10 +10,6 @@ import _ from 'lodash';
 
 type State = {|
   keyword: string,
-  tags: List<TagDefinition>,
-  sortField: string,
-  location: string,
-  locationRadius: LocationRadius
 |};
 
 class ResetSearchButton extends React.Component<{||}, State> {
@@ -25,10 +21,6 @@ class ResetSearchButton extends React.Component<{||}, State> {
   static calculateState(prevState: State): State {
     return {
       keyword: ProjectSearchStore.getKeyword() || '',
-      tags: ProjectSearchStore.getTags() || [],
-      sortField: ProjectSearchStore.getSortField() || '',
-      location: ProjectSearchStore.getLegacyLocation() || '',
-      locationRadius: ProjectSearchStore.getLocation() || {}
     };
   }
 
@@ -37,7 +29,7 @@ class ResetSearchButton extends React.Component<{||}, State> {
       <React.Fragment>
         <button
           className="btn btn-primary btn-block reset-search-button"
-          disabled={!(this.state.keyword || this.state.tags.size > 0 || this.state.sortField || this.state.location || !_.isEmpty(this.state.locationRadius)) }
+          disabled={!this.state.keyword}
           onClick={this._clearFilters.bind(this)}>
           Clear Filters
         </button>

--- a/common/components/componentsBySection/FindProjects/ResetSearchButton.jsx
+++ b/common/components/componentsBySection/FindProjects/ResetSearchButton.jsx
@@ -10,6 +10,10 @@ import _ from 'lodash';
 
 type State = {|
   keyword: string,
+  tags: List<TagDefinition>,
+  sortField: string,
+  location: string,
+  locationRadius: LocationRadius
 |};
 
 class ResetSearchButton extends React.Component<{||}, State> {
@@ -21,6 +25,10 @@ class ResetSearchButton extends React.Component<{||}, State> {
   static calculateState(prevState: State): State {
     return {
       keyword: ProjectSearchStore.getKeyword() || '',
+      tags: ProjectSearchStore.getTags() || [],
+      sortField: ProjectSearchStore.getSortField() || '',
+      location: ProjectSearchStore.getLegacyLocation() || '',
+      locationRadius: ProjectSearchStore.getLocation() || {}
     };
   }
 
@@ -29,7 +37,7 @@ class ResetSearchButton extends React.Component<{||}, State> {
       <React.Fragment>
         <button
           className="btn btn-primary btn-block reset-search-button"
-          disabled={!this.state.keyword}
+          disabled={!(this.state.keyword || this.state.tags.size > 0 || this.state.sortField || this.state.location || !_.isEmpty(this.state.locationRadius)) }
           onClick={this._clearFilters.bind(this)}>
           Clear Filters
         </button>

--- a/common/components/componentsBySection/FindProjects/SplashScreen.jsx
+++ b/common/components/componentsBySection/FindProjects/SplashScreen.jsx
@@ -23,12 +23,13 @@ export const HeroImage: { [key: string]: string } = {
   MidLanding: "CodeForGood_072719_MSReactor-034.jpg",
   BottomLanding: "SplashImage-7178-1400.jpg",
   AboutMission: "CodeForGood_072719_MSReactor-003.jpg",
+  FindEvents: "CodeForGood_072719_MSReactor-020.jpg"
 };
 
 const heroImages: $ReadOnlyArray<string> = [
   HeroImage.TopLanding,
   "CodeForGood_072719_MSReactor-074.jpg",
-  "CodeForGood_072719_MSReactor-020.jpg"
+  HeroImage.FindEvents
 ];
 
 class SplashScreen extends React.PureComponent<Props> {

--- a/common/components/controllers/FindEventsController.jsx
+++ b/common/components/controllers/FindEventsController.jsx
@@ -1,0 +1,36 @@
+// @flow
+
+import Headers from "../common/Headers.jsx";
+import SplashScreen, {HeroImage} from "../componentsBySection/FindProjects/SplashScreen.jsx";
+import EventCardsContainer from "../componentsBySection/FindEvents/EventCardsContainer.jsx";
+import EventFilterContainer from "../componentsBySection/FindEvents/filters/EventFilterContainer.jsx";
+import React from 'react';
+
+class FindEventsController extends React.PureComponent {
+  constructor(): void {
+    super();
+  }
+
+  render(): React$Node {
+    return (
+      <React.Fragment>
+        <Headers
+          title="DemocracyLab"
+          description="Optimizing the connection between skilled volunteers and tech-for-good events"
+        />
+        <div className="FindEventsController-root">
+          <SplashScreen className="FindEventsController-topsplash" header={"Find Events Title Goes Here"} img={HeroImage.FindEvents}>
+          <div className="container">
+            <div className="row">
+              <EventFilterContainer />
+              <EventCardsContainer showSearchControls={true}/>
+            </div>
+          </div>
+        </div>
+      </React.Fragment>
+    );
+  }
+
+}
+
+export default FindGroupsController;

--- a/common/components/controllers/FindEventsController.jsx
+++ b/common/components/controllers/FindEventsController.jsx
@@ -34,7 +34,8 @@ class FindEventsController extends React.PureComponent {
           description="Optimizing the connection between skilled volunteers and tech-for-good events"
         />
         <div className="FindEventsController-root">
-          <SplashScreen className="FindEventsController-topsplash" header={"Find Events Title Goes Here"} img={HeroImage.FindEvents} />
+          <SplashScreen className="FindEventsController-topsplash" header={"Tech-for-Good Events"} img={HeroImage.FindEvents}>
+          </SplashScreen>
           <div className="container">
             <div className="row">
               <EventFilterContainer />

--- a/common/components/controllers/FindEventsController.jsx
+++ b/common/components/controllers/FindEventsController.jsx
@@ -3,12 +3,26 @@
 import Headers from "../common/Headers.jsx";
 import SplashScreen, {HeroImage} from "../componentsBySection/FindProjects/SplashScreen.jsx";
 import EventCardsContainer from "../componentsBySection/FindEvents/EventCardsContainer.jsx";
-import EventFilterContainer from "../componentsBySection/FindEvents/filters/EventFilterContainer.jsx";
 import React from 'react';
+import type {FindGroupsArgs} from "../stores/GroupSearchStore";
+import urls from "../utils/url";
+import EventSearchDispatcher from "../stores/EventSearchDispatcher.js";
+import _ from "lodash";
 
 class FindEventsController extends React.PureComponent {
   constructor(): void {
     super();
+  }
+  
+  componentWillMount(): void {
+    let args: FindGroupsArgs = urls.arguments(document.location.search);
+    args = _.pick(args, ['keyword', 'page']);
+    EventSearchDispatcher.dispatch({
+      type: 'INIT',
+      findEventsArgs: !_.isEmpty(args) ? args : null,
+      searchSettings: {
+        updateUrl: true
+      }});
   }
 
   render(): React$Node {

--- a/common/components/controllers/FindEventsController.jsx
+++ b/common/components/controllers/FindEventsController.jsx
@@ -19,10 +19,9 @@ class FindEventsController extends React.PureComponent {
           description="Optimizing the connection between skilled volunteers and tech-for-good events"
         />
         <div className="FindEventsController-root">
-          <SplashScreen className="FindEventsController-topsplash" header={"Find Events Title Goes Here"} img={HeroImage.FindEvents}>
+          <SplashScreen className="FindEventsController-topsplash" header={"Find Events Title Goes Here"} img={HeroImage.FindEvents} />
           <div className="container">
             <div className="row">
-              <EventFilterContainer />
               <EventCardsContainer showSearchControls={true}/>
             </div>
           </div>
@@ -33,4 +32,4 @@ class FindEventsController extends React.PureComponent {
 
 }
 
-export default FindGroupsController;
+export default FindEventsController;

--- a/common/components/controllers/FindEventsController.jsx
+++ b/common/components/controllers/FindEventsController.jsx
@@ -3,6 +3,7 @@
 import Headers from "../common/Headers.jsx";
 import SplashScreen, {HeroImage} from "../componentsBySection/FindProjects/SplashScreen.jsx";
 import EventCardsContainer from "../componentsBySection/FindEvents/EventCardsContainer.jsx";
+import EventFilterContainer from "../componentsBySection/FindEvents/filters/EventFilterContainer.jsx";
 import React from 'react';
 import type {FindGroupsArgs} from "../stores/GroupSearchStore";
 import urls from "../utils/url";
@@ -13,7 +14,7 @@ class FindEventsController extends React.PureComponent {
   constructor(): void {
     super();
   }
-  
+
   componentWillMount(): void {
     let args: FindGroupsArgs = urls.arguments(document.location.search);
     args = _.pick(args, ['keyword', 'page']);
@@ -36,6 +37,7 @@ class FindEventsController extends React.PureComponent {
           <SplashScreen className="FindEventsController-topsplash" header={"Find Events Title Goes Here"} img={HeroImage.FindEvents} />
           <div className="container">
             <div className="row">
+              <EventFilterContainer />
               <EventCardsContainer showSearchControls={true}/>
             </div>
           </div>

--- a/common/components/controllers/SectionController.jsx
+++ b/common/components/controllers/SectionController.jsx
@@ -36,6 +36,7 @@ import AboutEventController from "./AboutEventController.jsx";
 import AboutGroupController from "./AboutGroupController.jsx";
 import ErrorController from "./ErrorController.jsx";
 import FindGroupsController from "./FindGroupsController.jsx";
+import FindEventsController from "./FindEventsController.jsx";
 
 type State = {|
   section: SectionType,
@@ -75,6 +76,8 @@ class SectionController extends React.Component<{||}, State> {
         return <FindProjectsController />;
       case Section.FindGroups:
         return <FindGroupsController />;
+      case Section.FindEvents:
+        return <FindEventsController />;
       case Section.Home:
         return <LandingController />;
       case Section.MyProjects:

--- a/common/components/enums/Section.js
+++ b/common/components/enums/Section.js
@@ -9,6 +9,7 @@ const Section = {
   Home: 'Home',
   FindProjects: 'FindProjects',
   FindGroups: 'FindGroups',
+  FindEvents: 'FindEvents',
   MyProjects: 'MyProjects',
   MyGroups: 'MyGroups',
   Profile: 'Profile',

--- a/common/components/stores/EventSearchDispatcher.js
+++ b/common/components/stores/EventSearchDispatcher.js
@@ -1,0 +1,8 @@
+// @flow
+
+import {Dispatcher} from 'flux';
+import type {EventSearchActionType} from "./EventSearchStore.js";
+
+const EventSearchDispatcher: Dispatcher<EventSearchActionType> = new Dispatcher();
+
+export default EventSearchDispatcher;

--- a/common/components/stores/EventSearchStore.js
+++ b/common/components/stores/EventSearchStore.js
@@ -1,0 +1,325 @@
+// @flow
+
+import type {Tag} from './TagStore';
+
+import {ReduceStore} from 'flux/utils';
+import EventSearchDispatcher from "./EventSearchDispatcher.js";
+import {SearchSettings, LocationRadius, locationRadiusToString, locationRadiusFromString} from "./ProjectSearchStore.js";
+import {List, Record} from 'immutable'
+import type {TagDefinition} from '../utils/ProjectAPIUtils.js';
+import {EventTileAPIData} from "../utils/EventAPIUtils.js";
+import TagCategory from "../common/tags/TagCategory.jsx";
+import urls from "../utils/url.js";
+import Section from "../enums/Section.js";
+import {CountryData, countryByCode} from "../constants/Countries.js";
+import type {Dictionary} from "../types/Generics.jsx";
+import _ from "lodash";
+
+export type FindEventsArgs = {|
+  keyword: string,
+  sortField: string,
+  locationRadius: string,
+  page: number,
+  issues: string,
+|};
+
+type FindEventsResponse = {|
+  groups: $ReadOnlyArray<EventTileAPIData>,
+  numPages: number,
+  numEvents: number,
+  tags: $ReadOnlyArray<TagDefinition>,
+  availableCountries: $ReadOnlyArray<string>
+|};
+
+type FindEventsData = {|
+  groups: $ReadOnlyArray<EventTileAPIData>,
+  availableCountries: $ReadOnlyArray<string>,
+  numPages: number,
+  numEvents: number,
+  allTags: Dictionary<TagDefinition>
+|};
+
+
+
+export type EventSearchActionType = {
+  type: 'INIT',
+  searchSettings: SearchSettings,
+  findEventsArgs: FindEventsArgs
+} | {
+  type: 'ADD_TAG',
+  tag: Tag,
+} | {
+  type: 'REMOVE_TAG',
+  tag: Tag,
+} | {
+  type: 'SET_KEYWORD',
+  keyword: string,
+} | {
+  type: 'SET_SORT',
+  sortField: string,
+} | {
+  type: 'SET_LOCATION',
+  locationRadius: ?LocationRadius
+} | {
+  type: 'SET_PAGE',
+  page: number,
+} | {
+  type: 'CLEAR_FILTERS',
+} | {
+  type: 'SET_GROUPS_DO_NOT_CALL_OUTSIDE_OF_STORE',
+  groupsResponse: FindEventsResponse,
+};
+
+const DEFAULT_STATE = {
+  keyword: '',
+  sortField: '',
+  locationRadius: null,
+  page: 1,
+  tags: List(),
+  allTags: {},
+  groupsData: {},
+  searchSettings: {
+    updateUrl: false
+  },
+  findEventsArgs: {},
+  filterApplied: false,
+  groupsLoading: false
+};
+
+class State extends Record(DEFAULT_STATE) {
+  keyword: string;
+  sortField: string;
+  locationRadius: LocationRadius;
+  page: number;
+  groupsData: FindEventsData;
+  tags: $ReadOnlyArray<string>;
+  searchSettings: SearchSettings;
+  findEventsArgs: FindEventsArgs;
+  filterApplied: boolean;
+  groupsLoading: boolean;
+}
+
+class EventSearchStore extends ReduceStore<State> {
+  constructor(): void {
+    super(EventSearchDispatcher);
+  }
+
+  getInitialState(): State {
+    return new State();
+  }
+
+  reduce(state: State, action: EventSearchActionType): State {
+    switch (action.type) {
+      case 'INIT':
+        let initialState: State = new State();
+        if(action.findEventsArgs) {
+          initialState = this._initializeFilters(initialState, action.findEventsArgs);
+        }
+        initialState = initialState.set('findEventsArgs', action.findEventsArgs || {});
+        initialState = initialState.set('searchSettings', action.searchSettings || {updateUrl: false});
+        return this._loadEvents(initialState, true);
+      case 'ADD_TAG':
+        state = state.set('filterApplied', true);
+        return this._loadEvents(this._addTagToState(state, action.tag));
+      case 'REMOVE_TAG':
+        state = state.set('tags', state.tags.filter(tag => tag !== action.tag.tag_name));
+        state = state.set('filterApplied', true);
+        return this._loadEvents(state);
+      case 'SET_KEYWORD':
+        return this._loadEvents(this._addKeywordToState(state, action.keyword));
+      case 'SET_SORT':
+        return this._loadEvents(this._addSortFieldToState(state, action.sortField));
+      case 'SET_LOCATION':
+        return this._loadEvents(this._addLocationToState(state, action.locationRadius));
+      case 'SET_PAGE':
+        return this._loadEvents(this._setPageNumberInState(state, action.page));
+      case 'CLEAR_FILTERS':
+        return this._loadEvents(this._clearFilters(state));
+      case 'SET_GROUPS_DO_NOT_CALL_OUTSIDE_OF_STORE':
+        let allTags = _.mapKeys(action.groupsResponse.tags, (tag:TagDefinition) => tag.tag_name);
+        // Remove all tag filters that don't match an existing tag name
+        state = state.set('tags', state.tags.filter(tag => allTags[tag]));
+        let currentEvents = state.groupsData.groups || List();
+        state = state.set('groupsData', {
+          groups: currentEvents.concat(action.groupsResponse.groups),
+          numPages: action.groupsResponse.numPages,
+          numEvents: action.groupsResponse.numEvents,
+          allTags: allTags,
+          availableCountries: action.groupsResponse.availableCountries
+        });
+        return state.set('groupsLoading', false);
+      default:
+        (action: empty);
+        return state;
+    }
+  }
+
+  _updateFindEventsArgs(state: State): State {
+    if(state.groupsData && state.groupsData.allTags) {
+      const findEventsArgs: FindEventsArgs = _.pickBy({
+        keyword: state.keyword,
+        sortField: state.sortField,
+        location: state.location,
+        locationRadius: state.locationRadius && state.locationRadius.latitude && state.locationRadius.longitude && locationRadiusToString(state.locationRadius),
+        issues: this._getTagCategoryParams(state, TagCategory.ISSUES),
+        url: state.url,
+      }, _.identity);
+      state = state.set('findEventsArgs', findEventsArgs);
+    }
+
+    return state;
+  }
+
+  _updateWindowUrl(state: State) {
+    if(state.findEventsArgs) {
+      // Only show the FindEvents page args that users care about
+      const urlArgs = _.omit(state.findEventsArgs, ['page']);
+      const windowUrl: string = urls.constructWithQueryString(urls.section(Section.FindEvents), urlArgs);
+      history.pushState({}, null, windowUrl);
+    }
+  }
+
+  _initializeFilters(state: State, findEventsArgs: FindEventsArgs): State {
+    state = this._addTagFilters(state, findEventsArgs.issues);
+    state = this._addKeywordToState(state, findEventsArgs.keyword);
+    state = this._addSortFieldToState(state, findEventsArgs.sortField);
+    state = this._addLocationToState(state, locationRadiusFromString(findEventsArgs.locationRadius));
+
+    return state;
+  }
+
+  _addTagFilters(state: State, filter:string): State {
+    if(filter) {
+      filter.split(",").forEach((tag) => {
+        state = this._addTagToState(state, tag);
+      });
+    }
+    return state;
+  }
+
+  _addTagToState(state: State, tag: string): State {
+    const newTags:$ReadOnlyArray<string> = state.tags.concat(tag);
+    state = state.set('filterApplied', true);
+    return state.set('tags', newTags);
+  }
+
+  _addKeywordToState(state: State, keyword: string): State {
+    state = state.set('keyword', keyword);
+    state = state.set('filterApplied', true);
+    return state;
+  }
+
+  _addSortFieldToState(state: State, sortField: string): State {
+    state = state.set('sortField', sortField);
+    state = state.set('filterApplied', true);
+    return state;
+  }
+
+  _addLocationToState(state: State, locationRadius: LocationRadius): State {
+    state = state.set('locationRadius', locationRadius);
+    state = state.set('filterApplied', true);
+    return state;
+  }
+
+  _setPageNumberInState(state: State, page: number): State {
+    state = state.set('page', page);
+    return state;
+  }
+
+  _clearFilters(state: State): State {
+    state = state.set('keyword', '');
+    state = state.set('sortField', '');
+    state = state.set('locationRadius', {});
+    state = state.set('tags', List());
+    state = state.set('page', 1);
+    state = state.set('filterApplied', false);
+    state = state.set('groupsData', {});
+    state = state.set('findEventsArgs', {page: 1});
+    return state;
+  }
+
+  _loadEvents(state: State, noUpdateUrl: ?boolean): State {
+    state = state.set('groupsLoading', true);
+    state = this._updateFindEventsArgs(state);
+    if (state.filterApplied) {
+      state = state.set('page', 1);
+      state = state.set('groupsData', {});
+      state = state.set('filterApplied', false);
+    }
+    if(state.searchSettings.updateUrl && !noUpdateUrl) {
+      this._updateWindowUrl(state);
+    }
+    const url: string = urls.constructWithQueryString(`/api/groups?page=${state.page}`,
+      Object.assign({}, state.findEventsArgs));
+    fetch(new Request(url))
+      .then(response => response.json())
+      .then( (findEventsResponse: FindEventsResponse ) =>
+        EventSearchDispatcher.dispatch({
+          type: 'SET_GROUPS_DO_NOT_CALL_OUTSIDE_OF_STORE',
+          groupsResponse: findEventsResponse
+        })
+      );
+    return state;
+  }
+
+  _getTagCategoryParams(state: State, category: string): ?string {
+    const tags = this.getSelectedTags(state).filter(tag => tag.category === category);
+    return tags.map(tag => tag.tag_name).join(',');
+  }
+
+  getKeyword(): string {
+    return this.getState().keyword;
+  }
+
+  getSortField(): string {
+    return this.getState().sortField;
+  }
+
+  getCountryList(): $ReadOnlyArray<CountryData> {
+    const groupsData: FindEventsData = this.getState().groupsData;
+    return groupsData && groupsData.availableCountries && groupsData.availableCountries.map(countryByCode);
+  }
+
+  getLocation(): LocationRadius {
+    return this.getState().locationRadius;
+  }
+
+  getEvents(): List<EventTileAPIData> {
+    const state: State = this.getState();
+    return state.groupsData && state.groupsData.groups;
+  }
+
+  getEventPages(): number {
+    const state: State = this.getState();
+    return state.groupsData && state.groupsData.numPages;
+  }
+
+  getCurrentPage(): number {
+    return this.getState().page;
+  }
+
+  getNumberOfEvents(): number {
+    const state: State = this.getState();
+    return state.groupsData && state.groupsData.numEvents;
+  }
+
+  getEventsLoading(): boolean {
+    return this.getState().groupsLoading;
+  }
+
+  getAllTags(): Dictionary<TagDefinition> {
+    const state: State = this.getState();
+    return state.groupsData && state.groupsData.allTags;
+  }
+
+  getSelectedTags(inProgressState: ?State): List<TagDefinition> {
+    const state: State = inProgressState || this.getState();
+    if(state.groupsData && state.groupsData.allTags && state.tags) {
+      return List(state.tags.map(tag => state.groupsData.allTags[tag]));
+    } else {
+      return List();
+    }
+  }
+}
+
+export default new EventSearchStore();

--- a/common/components/utils/EventAPIUtils.js
+++ b/common/components/utils/EventAPIUtils.js
@@ -21,6 +21,16 @@ export type EventData = {|
     event_legacy_organization: $ReadOnlyArray<TagDefinition>
 |};
 
+export type EventTileAPIData = {|
+    event_id: string,
+    event_date_start: Date,
+    event_date_end: Date,
+    event_name: string,
+    event_location: string,
+    event_short_description: string,
+    event_thumbnail: FileInfo
+|};
+
 export default class EventAPIUtils {
     static fetchEventDetails(id: number, callback: (EventData) => void, errCallback: (APIError) => void): void {
       fetch(new Request('/api/event/' + id + '/', {credentials: 'include'}))

--- a/common/helpers/constants.py
+++ b/common/helpers/constants.py
@@ -39,5 +39,6 @@ class FrontEndSection(Enum):
     AboutGroup = 'AboutGroup'
     EditGroup = 'EditGroup'
     FindGroups = 'FindGroups'
+    FindEvents = 'FindEvents'
     CreateGroup = 'CreateGroup'
     MyGroups = 'MyGroups'


### PR DESCRIPTION
- Adds Find Events page
- Lists events in "Upcoming" and "Past" based on start time of event. Upcoming will render a "check back soon" message if no upcoming events exist, Past will just not render if no past events exist.
- event cards contain the event image, event name, event organizer, location, and start time and are clickable and take you to the associated event page
- fixes some Create Event time-related bugs (thanks Marlon!)



This is MVP, Events page still needs in a future PR:
- filters based on issue area (potentially events need issue area tagging or reading tags of associated projects? as well)
- fulltext search and search bar.
- dropdown toggle between "Past" and "Upcoming" (as with our sort A-Z or Z-A on find projects, for example)
