### PR TITLE
New Token Generator for email verification

### DIFF
--- a/democracylab/emails.py
+++ b/democracylab/emails.py
@@ -6,6 +6,7 @@ from enum import Enum
 from html.parser import unescape
 from common.models.tags import Tag
 from common.helpers.date_helpers import DateTimeFormats, datetime_field_to_datetime, datetime_to_string
+from democracylab.tokens import email_verify_token_generator
 from democracylab.models import Contributor
 from civictechprojects.models import VolunteerRelation
 from common.helpers.constants import FrontEndSection
@@ -71,7 +72,7 @@ class HtmlEmailTemplate:
 def send_verification_email(contributor):
     # Get token
     user = Contributor.objects.get(id=contributor.id)
-    verification_token = default_token_generator.make_token(user)
+    verification_token = email_verify_token_generator.make_token(user)
     verification_url = settings.PROTOCOL_DOMAIN + '/verify_user/' + str(contributor.id) + '/' + verification_token
     # Send email with token
     email_template = HtmlEmailTemplate()\

--- a/democracylab/tokens.py
+++ b/democracylab/tokens.py
@@ -1,0 +1,84 @@
+from datetime import date
+
+from django.conf import settings
+from django.utils import six
+from django.utils.crypto import constant_time_compare, salted_hmac
+from django.utils.http import base36_to_int, int_to_base36
+
+
+# Generates email verification tokens
+# Adapted from django.contrib.auth.tokens.PasswordResetTokenGenerator
+class EmailVerifyTokenGenerator(object):
+    """
+    Strategy object used to generate and check tokens for the password
+    reset mechanism.
+    """
+    key_salt = "django.contrib.auth.tokens.PasswordResetTokenGenerator"
+
+    def make_token(self, user):
+        """
+        Returns a token that can be used once to do a password reset
+        for the given user.
+        """
+        return self._make_token_with_timestamp(user, self._num_days(self._today()))
+
+    def check_token(self, user, token):
+        """
+        Check that a password reset token is correct for a given user.
+        """
+        if not (user and token):
+            return False
+        # Parse the token
+        try:
+            ts_b36, hash = token.split("-")
+        except ValueError:
+            return False
+
+        try:
+            ts = base36_to_int(ts_b36)
+        except ValueError:
+            return False
+
+        # Check that the timestamp/uid has not been tampered with
+        if not constant_time_compare(self._make_token_with_timestamp(user, ts), token):
+            return False
+
+        # Check the timestamp is within limit
+        if (self._num_days(self._today()) - ts) > settings.PASSWORD_RESET_TIMEOUT_DAYS:
+            return False
+
+        return True
+
+    def _make_token_with_timestamp(self, user, timestamp):
+        # timestamp is number of days since 2001-1-1.  Converted to
+        # base 36, this gives us a 3 digit string until about 2121
+        ts_b36 = int_to_base36(timestamp)
+
+        # By hashing on the internal state of the user and using state
+        # that is sure to change (the password salt will change as soon as
+        # the password is set, at least for current Django auth, and
+        # last_login will also change), we produce a hash that will be
+        # invalid as soon as it is used.
+        # We limit the hash to 20 chars to keep URL short
+
+        hash = salted_hmac(
+            self.key_salt,
+            self._make_hash_value(user, timestamp),
+        ).hexdigest()[::2]
+        return "%s-%s" % (ts_b36, hash)
+
+    def _make_hash_value(self, user, timestamp):
+        # Ensure results are consistent across DB backends
+        return (
+                six.text_type(user.pk) + user.password + six.text_type(timestamp)
+        )
+
+    def _num_days(self, dt):
+        return (dt - date(2001, 1, 1)).days
+
+    def _today(self):
+        # Used for mocking in tests
+        return date.today()
+
+
+email_verify_token_generator = EmailVerifyTokenGenerator()

--- a/democracylab/views.py
+++ b/democracylab/views.py
@@ -12,6 +12,7 @@ import simplejson as json
 from .emails import send_verification_email, send_password_reset_email
 from .forms import DemocracyLabUserCreationForm
 from .models import Contributor, get_request_contributor, get_contributor_by_username
+from .tokens import email_verify_token_generator
 from oauth2 import registry
 
 
@@ -88,7 +89,7 @@ def verify_user(request, user_id, token):
     user = Contributor.objects.get(id=user_id)
 
     # Verify token
-    if default_token_generator.check_token(user, token):
+    if email_verify_token_generator.check_token(user, token):
         # TODO: Add feedback from the frontend to indicate success/failure
         contributor = Contributor.objects.get(id=user_id)
         contributor.email_verified = True


### PR DESCRIPTION
Our current token generator uses the same generator used for resetting passwords, which means that the tokens are invalidated whenever the user logs in.  In practice, this has resulted in confusion for users who log in twice before verifying their email, and seeing the verify email link fail.

To solve this, we've created a new token generator adapted from the password reset generator, that doesn't factor in the last login time, and thus does not invalidate the token when the user logs in.