### PR TITLE
Update html_email_frame.html

### DIFF
--- a/democracylab/templates/emails/html_email_frame.html
+++ b/democracylab/templates/emails/html_email_frame.html
@@ -122,7 +122,9 @@
 			color: #999999;
 			font-family: sans-serif;" class="footer">
 
-                Copyright &copy; 2019 DemocracyLab. All Rights Reserved.
+                Copyright &copy; 
+		2019 DemocracyLab. 
+		All Rights Reserved.
             </td>
         </tr>
 


### PR DESCRIPTION
Broke up copyright symbol into three different lines for easier readability.