### PR TITLE
Create Group: Prompt user to log in if not already

### DIFF
--- a/common/components/controllers/CreateGroupController.jsx
+++ b/common/components/controllers/CreateGroupController.jsx
@@ -4,7 +4,8 @@ import React from "react";
 import CurrentUser from "../../components/utils/CurrentUser.js";
 import Section from "../enums/Section.js";
 import Headers from "../common/Headers.jsx";
-
+import LogInController from "./LogInController.jsx";
+import VerifyEmailBlurb from "../common/notification/VerifyEmailBlurb.jsx";
 import GroupOverviewForm from "../componentsBySection/CreateGroup/GroupOverviewForm.jsx";
 import GroupPreviewForm from "../componentsBySection/CreateGroup/GroupPreviewForm.jsx";
 import GroupResourcesForm from "../componentsBySection/CreateGroup/GroupResourcesForm.jsx";
@@ -114,7 +115,6 @@ class CreateGroupController extends React.PureComponent<{||},State> {
   }
   
   render(): React$Node {
-    
     return (
       <React.Fragment>
         <Headers
@@ -123,12 +123,8 @@ class CreateGroupController extends React.PureComponent<{||},State> {
         />
         
         <div className="form-body">
-          <FormWorkflow
-            steps={this.state.steps}
-            isLoading={this.state.groupId && !this.state.group}
-            formFields={this.state.group}
-          />
-          {/* {!CurrentUser.isLoggedIn()
+
+          {!CurrentUser.isLoggedIn()
             ? <LogInController prevPage={Section.CreateGroup}/>
             : <React.Fragment>
                 {CurrentUser.isEmailVerified()
@@ -141,7 +137,7 @@ class CreateGroupController extends React.PureComponent<{||},State> {
                   )
                   : <VerifyEmailBlurb/>}
               </React.Fragment>
-          } */}
+          }
         </div>
       </React.Fragment>
     );


### PR DESCRIPTION
This changes the Create Group page flow to match that of Create Project when it comes to users who aren't signed in.  If they navigate to the page while not signed in, they will be prompted to sign in before getting access to the Create Group form.