### PR TITLE
Add support for simultaneous live events

### DIFF
--- a/common/components/componentsBySection/CreateEvent/AboutEventDisplay.jsx
+++ b/common/components/componentsBySection/CreateEvent/AboutEventDisplay.jsx
@@ -150,7 +150,7 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
       //TODO: Handle un-verified users
       text = "Join Event";
       //TODO: Incorporate live event id into Live Event page
-      url = urlHelper.section(Section.LiveEvent);
+      url = urlHelper.section(Section.LiveEvent, {id: this.props.event.event_live_id});
     } else {
       text = "Log In to Join Event";
       url = urlHelper.logInThenReturn();

--- a/common/components/controllers/LiveEventController.jsx
+++ b/common/components/controllers/LiveEventController.jsx
@@ -3,12 +3,21 @@
 import React from 'react';
 import CurrentUser from "../utils/CurrentUser.js";
 import LogInController from "./LogInController.jsx";
-import Section from "../enums/Section";
+import Section from "../enums/Section.js";
+import urlHelper from "../utils/url.js";
 import _ from "lodash";
 
-class LiveEventController extends React.Component<{||}> {
+type State = {|
+  iframeUrl: string
+|};
+
+class LiveEventController extends React.Component<{||}, State> {
   constructor(): void {
     super();
+    
+    this.state = {
+      iframeUrl: window.QIQO_IFRAME_URL.replace("EVENT_ID", urlHelper.argument("id"))
+    };
   }
 
   render(): React$Node {
@@ -17,7 +26,7 @@ class LiveEventController extends React.Component<{||}> {
         ? <LogInController prevPage={Section.LiveEvent}/>
         : (
           <div className="LiveEvent-root">
-            <iframe src={_.unescape(window.QIQO_IFRAME_URL)} />
+            <iframe src={_.unescape(this.state.iframeUrl)} />
           </div>
         )
     );

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -124,3 +124,12 @@ export PRIVACY_POLICY_URL='https://d1agxr2dqkgkuy.cloudfront.net/documents/2020.
 
 # if we have a hackathon or similar event we want displayed in the nav for the duration, put it here
 export EVENT_URL='https://democracylab.org/index/?section=AboutEvent&id=1'
+
+# Qiqochat live event iframe url with placeholders
+export QIQO_IFRAME_URL='https://qiqochat.com/api/v1/iframe?&source[api_key]={api_key}&source_user_uuid={source_user_uuid}&qiqo_user_uuid={qiqo_user_uuid}&return_to="/breakout/0/EVENT_ID?embedded=true"'
+export QIQO_API_KEY=democracylab
+
+# For Qiqochat user registration, do not enable these unless you are working on this feature
+# export QIQO_API_SECRET=SECRET
+# export QIQO_USERS_ENDPOINT='https://api.qiqochat.com/api/v1/users'
+# export QIQO_CIRCLE_UUID=nmitq


### PR DESCRIPTION
Currently we only support a single live event at any given time, controlled by QIQO_IFRAME_URL.  The Join Event button on the Event profile page will always go to this url, and its live event id only controls whether the button is seen or not.  Effectively, this means we can only support a single live event at any moment.

To support multiple live events, we now include a placeholder event id argument in QIQO_IFRAME_URL, and the Join Event button for a given event will link to the Live Event page corresponding to the live event id.