### PR TITLE
Don't make my groups/projects requests for users not logged in

### DIFF
--- a/common/components/stores/MyGroupsStore.js
+++ b/common/components/stores/MyGroupsStore.js
@@ -4,6 +4,7 @@ import {ReduceStore} from 'flux/utils';
 import {Record} from 'immutable'
 import UniversalDispatcher from './UniversalDispatcher.js';
 import type {FileInfo} from "../common/FileInfo.jsx";
+import CurrentUser from "../utils/CurrentUser.js";
 
 // TODO: Rename isApproved to is_searchable
 export type MyGroupData = {|
@@ -52,7 +53,7 @@ class MyGroupsStore extends ReduceStore<State> {
     // TODO: See if we need to ensure no duplicate action names between stores that use UniversalDispatcher
     switch (action.type) {
       case 'INIT':
-        if(!state.isLoading || !state.myGroups) {
+        if(CurrentUser.isLoggedIn() && (!state.isLoading || !state.myGroups)) {
           return this._loadGroups(state);
         } else {
           return state;

--- a/common/components/stores/MyProjectsStore.js
+++ b/common/components/stores/MyProjectsStore.js
@@ -4,6 +4,7 @@ import {ReduceStore} from 'flux/utils';
 import {Record} from 'immutable'
 import type {TagDefinition, VolunteerUserData} from '../utils/ProjectAPIUtils.js';
 import UniversalDispatcher from './UniversalDispatcher.js';
+import CurrentUser from "../utils/CurrentUser.js";
 
 export type MyProjectData = {|
   +project_id: number,
@@ -55,7 +56,7 @@ class MyProjectsStore extends ReduceStore<State> {
     // TODO: See if we need to ensure no duplicate action names between stores that use UniversalDispatcher
     switch (action.type) {
       case 'INIT':
-        if(!state.isLoading || !state.myProjects) {
+        if(CurrentUser.isLoggedIn() && (!state.isLoading || !state.myProjects)) {
           return this._loadProjects(state);
         } else {
           return state;


### PR DESCRIPTION
We were making calls to retrieve a user's groups and projects even when they weren't logged in (which always returns nothing).  To reduce unneeded calls, now we will only make the requests when the user is logged in.