### PR TITLE
Replace Organizations with Groups on Project Profile

### DIFF
--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -79,11 +79,11 @@
   }
 }
 
-.AboutProjects-links, .AboutProjects-files, .AboutProjects-communities, .AboutProjects-team {
+.AboutProjects-links, .AboutProjects-files, .AboutProjects-groups, .AboutProjects-team {
   padding: 10px 5px 10px 15px;
 }
 
-.AboutProjects-links, .AboutProjects-files, .AboutProjects-communities {
+.AboutProjects-links, .AboutProjects-files, .AboutProjects-groups {
   border-bottom: $color-grey-disabled solid 1px;
 }
 
@@ -281,7 +281,10 @@
   }
 }
 
-.AboutProjects-communities {
+.AboutProjects-groups {
+  ul {
+    padding-left: 0;
+  }
   li {
     list-style-type: none;
   }

--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -287,7 +287,21 @@
   }
   li {
     list-style-type: none;
+    margin-bottom: 20px;
   }
+  a {
+    vertical-align: top; /* align text with top of group icon instead of bottom */
+  }
+}
+.AboutProjects-group-image {
+  height: 60px;
+  width: 60px;
+  display: inline-block;
+  margin-right: 10px;
+  img {
+    object-fit: contain;
+    max-width: 100%;
+    }
 }
 
 .AboutProjects-links  {

--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -298,10 +298,13 @@
   width: 60px;
   display: inline-block;
   margin-right: 10px;
-  img {
+  img, i {
     object-fit: contain;
     max-width: 100%;
     }
+  i {
+    color: $color-text-dark;
+  }
 }
 
 .AboutProjects-links  {

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -21,6 +21,8 @@ import Sort from "../../utils/sort.js";
 import {LinkTypes} from "../../constants/LinkConstants.js";
 import InviteProjectToGroupButton from "./InviteProjectToGroupButton.jsx";
 import ApproveGroupsSection from "./ApproveGroupsSection.jsx";
+import url from "../../utils/url.js";
+import Section from "../../enums/Section.js";
 
 
 type Props = {|
@@ -154,7 +156,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
                 <ul>
                   {
                     project.project_groups.map((group, i) => {
-                      return <li key={i}>{group.group_name}</li>
+                      return <li key={i}><a href={url.section(Section.AboutGroup, {id: group.group_id})}>{group.group_name}</a></li>
                     })
                   }
                 </ul>

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -383,12 +383,16 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
     }
 
     _renderGroupIcon(group): ?Array<React$Node> {
-      if(!_.isEmpty(group.group_thumbnail)) {
-        return <div className="AboutProjects-group-image"><a href={url.section(Section.AboutGroup, {id: group.group_id})}><img src={group.group_thumbnail.publicUrl} alt={group.group_name + " Logo"} /></a></div>
-        } else {
-        return <div className="AboutProjects-group-image"><a href={url.section(Section.AboutGroup, {id: group.group_id})}><i className={Glyph(GlyphStyles.Users, GlyphSizes.X3)}></i></a></div>
-        }
-      }
+      return (
+        <div className="AboutProjects-group-image">
+          <a href={url.section(Section.AboutGroup, {id: group.group_id})}>
+            {!_.isEmpty(group.group_thumbnail)
+            ? <img src={group.group_thumbnail.publicUrl} alt={group.group_name + " Logo"} />
+            : <i className={Glyph(GlyphStyles.Users, GlyphSizes.X3)}></i>}
+            </a>
+          </div>
+      )
+    }
   }
 
 export default AboutProjectDisplay;

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -147,14 +147,14 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
             </React.Fragment>
           }
 
-          {project && !_.isEmpty(project.project_organization) &&
+          {project && !_.isEmpty(project.project_groups) &&
             <React.Fragment>
-              <div className='AboutProjects-communities'>
-                <h4>Communities</h4>
+              <div className='AboutProjects-groups'>
+                <h4>Groups</h4>
                 <ul>
                   {
-                    project.project_organization.map((org, i) => {
-                      return <li key={i}>{org.display_name}</li>
+                    project.project_groups.map((group, i) => {
+                      return <li key={i}>{group.group_name}</li>
                     })
                   }
                 </ul>
@@ -162,7 +162,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
 
             </React.Fragment>
           }
-          
+
           {/*TODO: Groups section*/}
 
           <div className='AboutProjects-team'>
@@ -300,7 +300,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
                     .map(commit => <ProjectCommitCard commit={commit} />)
                 }
                 { project.project_commits.length > this.state.maxActivity && (
-                  
+
                   <div className="AboutProjects-show-more-activity-container">
                     <div className="btn btn-primary AboutProjects-show-more-activity"
                       onClick={this.handleShowMoreActivity}

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -23,6 +23,8 @@ import InviteProjectToGroupButton from "./InviteProjectToGroupButton.jsx";
 import ApproveGroupsSection from "./ApproveGroupsSection.jsx";
 import url from "../../utils/url.js";
 import Section from "../../enums/Section.js";
+import {Glyph, GlyphStyles, GlyphSizes} from '../../utils/glyphs.js';
+
 
 
 type Props = {|
@@ -382,9 +384,9 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
 
     _renderGroupIcon(group): ?Array<React$Node> {
       if(!_.isEmpty(group.group_thumbnail)) {
-        return <div className="AboutProjects-group-image"><img src={group.group_thumbnail.publicUrl} alt={group.group_name + " Logo"} /></div>
+        return <div className="AboutProjects-group-image"><a href={url.section(Section.AboutGroup, {id: group.group_id})}><img src={group.group_thumbnail.publicUrl} alt={group.group_name + " Logo"} /></a></div>
         } else {
-        return <div className="AboutProjects-group-image AboutProjects-group-image-no-logo"></div>
+        return <div className="AboutProjects-group-image"><a href={url.section(Section.AboutGroup, {id: group.group_id})}><i className={Glyph(GlyphStyles.Users, GlyphSizes.X3)}></i></a></div>
         }
       }
   }

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -156,7 +156,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
                 <ul>
                   {
                     project.project_groups.map((group, i) => {
-                      return <li key={i}><a href={url.section(Section.AboutGroup, {id: group.group_id})}>{group.group_name}</a></li>
+                      return <li key={i}>{this._renderGroupIcon(group)} <a href={url.section(Section.AboutGroup, {id: group.group_id})}>{group.group_name}</a></li>
                     })
                   }
                 </ul>
@@ -379,6 +379,14 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
         />;
       });
     }
-}
+
+    _renderGroupIcon(group): ?Array<React$Node> {
+      if(!_.isEmpty(group.group_thumbnail)) {
+        return <div className="AboutProjects-group-image"><img src={group.group_thumbnail.publicUrl} alt={group.group_name + " Logo"} /></div>
+        } else {
+        return <div className="AboutProjects-group-image AboutProjects-group-image-no-logo"></div>
+        }
+      }
+  }
 
 export default AboutProjectDisplay;

--- a/common/components/utils/glyphs.js
+++ b/common/components/utils/glyphs.js
@@ -37,7 +37,8 @@ export const GlyphStyles: {[key: string]: string} = {
   Envelope: "far fa-envelope", // https://fontawesome.com/icons/envelope?style=regular
   CreativeCommons: "fab fa-creative-commons", //https://fontawesome.com/icons/creative-commons?style=brands
   CreativeCommonsBy: "fab fa-creative-commons-by", // https://fontawesome.com/icons/creative-commons-by?style=brands
-  Calendar: "far fa-calendar" // https://fontawesome.com/icons/calendar?style=regular
+  Calendar: "far fa-calendar", // https://fontawesome.com/icons/calendar?style=regular
+  Users: "fas fa-users" // https://fontawesome.com/icons/users?style=solid
 };
 
 export const GlyphSizes: {[key: string]: string} = {


### PR DESCRIPTION
- [x] Removes Organizations from Project Profile left/info column section, replaces them with Groups
- [x] Groups section does not render if a project is a member of no groups
- [x] Group names in this list are linked to the group profile page
- [x] Placeholder icon for groups with no thumbnail image (as defined by group_thumbnail.publicUrl)
- [x] group image/placeholder image also links to group profile page