### PR TITLE
set tabs to column on mobile/tablet, row on desktop (unchanged)

### DIFF
--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -147,6 +147,7 @@
 .AboutProjects_tabs {
   clear: both;
   display:flex;
+  flex-direction: row; // column mobile, row desktop
   flex-wrap: wrap;
   justify-self: flex-start;
   align-self: flex-end;
@@ -341,6 +342,9 @@
 
   .AboutProjects-positions-available {
     border-bottom: $color-grey-disabled solid 1px;
+  }
+  .AboutProjects_tabs {
+    flex-direction: column;
   }
 
 }


### PR DESCRIPTION
Before we add a 4th tab to project profile pages, this is a quick fix for how they display on mobile. Rather than awkwardly breaking into two rows, they should be in column on mobile and remain unchanged as a row on desktop.

now:
![image](https://user-images.githubusercontent.com/16870466/91896696-2294c200-ec4e-11ea-86b8-41fb1535b64a.png)

fix:
![image](https://user-images.githubusercontent.com/16870466/91896735-2e808400-ec4e-11ea-8ae4-1961626ed9e0.png)
