### PR TITLE
Cache expensive operations for tags api call

### DIFF
--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -5,6 +5,7 @@ from .models import Project, ProjectLink, ProjectFile, ProjectPosition, FileCate
 from .sitemaps import SitemapPages
 from democracylab.emails import send_project_creation_notification, send_group_creation_notification
 from democracylab.models import get_request_contributor
+from common.caching.cache import Cache, CacheKeys
 from common.helpers.date_helpers import parse_front_end_datetime
 from common.helpers.form_helpers import is_creator_or_staff, is_co_owner_or_staff, read_form_field_string, read_form_field_boolean, \
     merge_json_changes, merge_single_file, read_form_field_tags, read_form_field_datetime, read_form_fields_point
@@ -77,6 +78,8 @@ class ProjectCreationForm(ModelForm):
         if is_created_original != project.is_created:
             print('notifying project creation')
             send_project_creation_notification(project)
+
+        Cache.refresh(CacheKeys.ProjectTagCounts)
 
         return project
 

--- a/civictechprojects/helpers/projects.py
+++ b/civictechprojects/helpers/projects.py
@@ -1,8 +1,14 @@
 from civictechprojects.models import Project, ProjectPosition
 from common.helpers.dictionaries import merge_dicts
+from common.caching.cache import Cache, CacheKeys
 from collections import Counter
 
+
 def projects_tag_counts():
+    return Cache.get(CacheKeys.ProjectTagCounts, _projects_tag_counts)
+
+
+def _projects_tag_counts():
     projects = Project.objects.filter(is_searchable=True)
     issues, technologies, stage, organization, organization_type, positions = [], [], [], [], [], []
     if projects:

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -39,9 +39,6 @@ from django.views.decorators.cache import cache_page
 import requests
 
 
-
-# TODO: Set getCounts to default to false if it's not passed? Or some hardening against malformed API requests
-@cache_page(1200) #cache duration in seconds, cache_page docs: https://docs.djangoproject.com/en/2.1/topics/cache/#the-per-view-cache
 def tags(request):
     url_parts = request.GET.urlencode()
     query_terms = urlparse.parse_qs(

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -705,15 +705,6 @@ def projects_with_meta_data(projects, project_pages, project_count):
     }
 
 
-def available_tag_filters(projects, selected_tag_filters):
-    project_tags = projects_tag_counts(projects)
-    # Remove any filters that are already selected
-    for tag in selected_tag_filters:
-        if project_tags[tag]:
-            project_tags.pop(tag)
-    return project_tags
-
-
 # TODO: Move group search code into new file
 def groups_list(request):
     url_parts = request.GET.urlencode()

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -46,37 +46,16 @@ def tags(request):
     url_parts = request.GET.urlencode()
     query_terms = urlparse.parse_qs(
         url_parts, keep_blank_values=0, strict_parsing=0)
-    if 'category' in query_terms:
-        category = query_terms.get('category')[0]
-        queryset = get_tags_by_category(category)
-        countoption = bool(strtobool(query_terms.get('getCounts')[0]))
-        if countoption == True:
-            activetagdict = projects_tag_counts()
-            querydict = {tag.tag_name:tag for tag in queryset}
-            resultdict = {}
+    queryset = get_tags_by_category(query_terms.get('category')[0]) if 'category' in query_terms else Tag.objects.all()
+    activetagdict = projects_tag_counts()
+    querydict = {tag.tag_name: tag for tag in queryset}
+    resultdict = {}
 
-            for slug in querydict.keys():
-                resultdict[slug] = Tag.hydrate_tag_model(querydict[slug])
-                resultdict[slug]['num_times'] = activetagdict[slug] if slug in activetagdict else 0
-            tags = list(resultdict.values())
-        else:
-            tags = list(queryset.values())
-    else:
-        countoption = bool(strtobool(query_terms.get('getCounts')[0]))
-        if countoption == True:
-            queryset = Tag.objects.all()
-            activetagdict = projects_tag_counts()
-            querydict = {tag.tag_name:tag for tag in queryset}
-            resultdict = {}
-
-            for slug in querydict.keys():
-                resultdict[slug] = Tag.hydrate_tag_model(querydict[slug])
-                resultdict[slug]['num_times'] = activetagdict[slug] if slug in activetagdict else 0
-            tags = list(resultdict.values())
-        else:
-            queryset = Tag.objects.all()
-            tags = list(queryset.values())
-    return JsonResponse(tags, safe=False)
+    for slug in querydict.keys():
+        resultdict[slug] = Tag.hydrate_tag_model(querydict[slug])
+        resultdict[slug]['num_times'] = activetagdict[slug] if slug in activetagdict else 0
+    tags_list = list(resultdict.values())
+    return JsonResponse(tags_list, safe=False)
 
 
 @cache_page(1200) #cache duration in seconds, cache_page docs: https://docs.djangoproject.com/en/2.1/topics/cache/#the-per-view-cache

--- a/common/caching/cache.py
+++ b/common/caching/cache.py
@@ -1,0 +1,29 @@
+from django.core.cache import cache
+from enum import Enum
+
+
+class CacheKeys(Enum):
+    ProjectTagCounts = 'project_tag_counts'
+
+
+class CacheWrapper:
+    _cache_generators = {}
+
+    def __init__(self, cache_backend):
+        self._cache = cache_backend
+
+    def get(self, key, generator_func):
+        return self._cache.get(key) or self._set(key, generator_func)
+
+    def refresh(self, key):
+        self._cache.set(key, self._cache_generators[key]() if key in self._cache_generators else None)
+
+    def _set(self, key, generator_func):
+        if generator_func is not None:
+            self._cache_generators[key] = generator_func
+        generated_value = self._cache_generators[key]()
+        self._cache.set(key, generated_value)
+        return generated_value
+
+
+Cache = CacheWrapper(cache)

--- a/common/caching/cache.py
+++ b/common/caching/cache.py
@@ -13,9 +13,19 @@ class CacheWrapper:
         self._cache = cache_backend
 
     def get(self, key, generator_func):
+        """
+        Retrieve cached value, and cache the value if it is not already cached
+        :param key: Key of value to retrieve
+        :param generator_func: Function that generates value
+        :return: Value mapped to key
+        """
         return self._cache.get(key) or self._set(key, generator_func)
 
     def refresh(self, key):
+        """
+        Refresh the cached value for a given key, such as when the underlying data has changed
+        :param key: Key of value to re-cache
+        """
         self._cache.set(key, self._cache_generators[key]() if key in self._cache_generators else None)
 
     def _set(self, key, generator_func):


### PR DESCRIPTION
Our most expensive frequently used api endpoint is /tags, and the most expensive step of that is collecting all of the tag counts.  Originally we were using django's request-level caching, but that has proven to be sub-optimal as it requires a hard cache timeout, which then necessitates a job to be run to keep the cache alive (and so changes to the tags don't show up between re-caches).

This change introduces a wrapper for django's low-level cache, which is used to cache the results of the tag count operation, and re-cache the value whenever a project is updated.  This will let us remove the re-caching job, and allow for immediate cache updates.