### PR TITLE
Form Fixes and Polish

### DIFF
--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -79,7 +79,8 @@ class ProjectCreationForm(ModelForm):
             print('notifying project creation')
             send_project_creation_notification(project)
 
-        Cache.refresh(CacheKeys.ProjectTagCounts)
+        if project.is_searchable:
+            Cache.refresh(CacheKeys.ProjectTagCounts)
 
         return project
 

--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -72,7 +72,7 @@ class ProjectCreationForm(ModelForm):
 
         merge_json_changes(ProjectLink, project, form, 'project_links')
         merge_json_changes(ProjectFile, project, form, 'project_files')
-        merge_json_changes(ProjectPosition, project, form, 'project_positions')
+        tags_changed |= merge_json_changes(ProjectPosition, project, form, 'project_positions')
 
         merge_single_file(project, form, FileCategory.THUMBNAIL, 'project_thumbnail_location')
 

--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -58,11 +58,12 @@ class ProjectCreationForm(ModelForm):
 
         read_form_fields_point(project, form, 'project_location_coords', 'project_latitude', 'project_longitude')
 
-        read_form_field_tags(project, form, 'project_issue_area')
-        read_form_field_tags(project, form, 'project_stage')
-        read_form_field_tags(project, form, 'project_technologies')
-        read_form_field_tags(project, form, 'project_organization')
-        read_form_field_tags(project, form, 'project_organization_type')
+        tags_changed = False
+        tags_changed |= read_form_field_tags(project, form, 'project_issue_area')
+        tags_changed |= read_form_field_tags(project, form, 'project_stage')
+        tags_changed |= read_form_field_tags(project, form, 'project_technologies')
+        tags_changed |= read_form_field_tags(project, form, 'project_organization')
+        tags_changed |= read_form_field_tags(project, form, 'project_organization_type')
 
         if not request.user.is_staff:
             project.project_date_modified = timezone.now()
@@ -79,7 +80,7 @@ class ProjectCreationForm(ModelForm):
             print('notifying project creation')
             send_project_creation_notification(project)
 
-        if project.is_searchable:
+        if project.is_searchable and tags_changed:
             Cache.refresh(CacheKeys.ProjectTagCounts)
 
         return project

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -662,6 +662,12 @@ class ProjectPosition(models.Model):
 
     @staticmethod
     def merge_changes(project, positions):
+        """
+        Merge project position changes
+        :param project: Project with position changes
+        :param positions: Position changes
+        :return: True if there were position changes
+        """
         added_positions = list(filter(lambda position: 'id' not in position, positions))
         updated_positions = list(filter(lambda position: 'id' in position, positions))
         updated_positions_ids = set(map(lambda position: position['id'], updated_positions))
@@ -679,6 +685,8 @@ class ProjectPosition(models.Model):
 
         for deleted_position_id in deleted_position_ids:
             ProjectPosition.delete_position(existing_projects_by_id[deleted_position_id])
+
+        return len(added_positions) > 0 or len(updated_positions) > 0 or len(deleted_position_ids) > 0
 
 
 class ProjectFile(models.Model):

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -18,6 +18,7 @@ from django.db.models import Q
 from .models import FileCategory, Project, ProjectFile, ProjectPosition, UserAlert, VolunteerRelation, Group, Event, ProjectRelationship
 from .helpers.projects import projects_tag_counts
 from .sitemaps import SitemapPages
+from common.caching.cache import Cache, CacheKeys
 from common.helpers.collections import flatten, count_occurrences
 from common.helpers.db import unique_column_values
 from common.helpers.s3 import presign_s3_upload, user_has_permission_for_s3_file, delete_s3_file
@@ -352,6 +353,7 @@ def approve_project(request, project_id):
         if user.is_staff:
             project.is_searchable = True
             project.save()
+            Cache.refresh(CacheKeys.ProjectTagCounts)
             SitemapPages.update()
             notify_project_owners_project_approved(project)
             messages.success(request, 'Project Approved')

--- a/common/components/common/positions/AboutPositionEntry.jsx
+++ b/common/components/common/positions/AboutPositionEntry.jsx
@@ -23,11 +23,13 @@ class AboutPositionEntry extends React.PureComponent<Props> {
   }
 
   render(): React$Node {
+    const showApplyButton: boolean = this.props.onClickApply && !CurrentUser.isOwnerOrVolunteering(this.props.project);
+    
     return (
         <div className="Position-entry">
           <div className="Position-header">
           {this._renderHeader()}
-          {!CurrentUser.isOwnerOrVolunteering(this.props.project) && this._renderApplyButton()}
+          {showApplyButton && this._renderApplyButton()}
           </div>
           { this.props.position.descriptionUrl &&
               <div className="Position-description-link"><a href={this.props.position.descriptionUrl} target="_blank" rel="noopener noreferrer">

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -35,6 +35,7 @@ type Props = {|
 
 type State = {|
   project: ?ProjectDetailsAPIData,
+  viewOnly: boolean,
   volunteers: ?$ReadOnlyArray<VolunteerDetailsAPIData>,
   showJoinModal: boolean,
   positionToJoin: ?PositionInfo,
@@ -50,6 +51,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
     super();
     this.state = {
       project: props.project,
+      viewOnly: props.viewOnly || url.argument('embedded'),
       volunteers: props.project && props.project.project_volunteers,
       showContactModal: false,
       showPositionModal: false,
@@ -68,6 +70,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
   componentWillReceiveProps(nextProps: Props): void {
     this.setState({
       project: nextProps.project,
+      viewOnly: props.viewOnly || url.argument('embedded'),
       volunteers: nextProps.project.project_volunteers
     });
   }
@@ -228,7 +231,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
                 handleClose={this.confirmJoinProject.bind(this)}
               />
 
-              {!this.props.viewOnly && this._renderContactAndVolunteerButtons()}
+              {!this.state.viewOnly && this._renderContactAndVolunteerButtons()}
 
             </div>
 

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -390,7 +390,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
 
   _renderPositions(): ?Array<React$Node> {
     const project: ProjectDetailsAPIData = this.state.project;
-    const canApply: boolean = CurrentUser.canVolunteerForProject(project);
+    const canApply: boolean = !this.state.viewOnly && CurrentUser.canVolunteerForProject(project);
     return project && project.project_positions && _.chain(project.project_positions).sortBy(['roleTag.subcategory', 'roleTag.display_name']).value()
       .map((position, i) => {
         return <AboutPositionEntry

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -70,7 +70,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
   componentWillReceiveProps(nextProps: Props): void {
     this.setState({
       project: nextProps.project,
-      viewOnly: props.viewOnly || url.argument('embedded'),
+      viewOnly: nextProps.viewOnly || url.argument('embedded'),
       volunteers: nextProps.project.project_volunteers
     });
   }

--- a/common/components/controllers/CreateProjectController.jsx
+++ b/common/components/controllers/CreateProjectController.jsx
@@ -99,7 +99,7 @@ class CreateProjectController extends React.PureComponent<{||},State> {
   }
 
   loadProjectDetails(project: ProjectDetailsAPIData): void {
-    if(!CurrentUser.isOwner(project)) {
+    if(!CurrentUser.isCoOwnerOrOwner(project) && !CurrentUser.isStaff()) {
       // TODO: Handle someone other than owner
     } else {
       this.setState({

--- a/common/components/controllers/SectionController.jsx
+++ b/common/components/controllers/SectionController.jsx
@@ -71,7 +71,7 @@ class SectionController extends React.Component<{||}, State> {
       case Section.CreateProject:
         return <CreateProjectController />;
       case Section.EditProject:
-        return <EditProjectController />;
+        return <CreateProjectController />;
       case Section.FindProjects:
         return <FindProjectsController />;
       case Section.FindGroups:

--- a/common/components/forms/FormWorkflow.jsx
+++ b/common/components/forms/FormWorkflow.jsx
@@ -32,6 +32,7 @@ type State<T> = {|
   showConfirmDiscardChanges: boolean,
   navigateToStepUponDiscardConfirmation: number,
   savedEmblemVisible: boolean,
+  isSubmitting: boolean,
   clickedNext: boolean,
   initialFormFields: T,
   currentFormFields: T,
@@ -50,6 +51,7 @@ class FormWorkflow<T> extends React.PureComponent<Props<T>,State<T>> {
       formIsValid: false,
       fieldsUpdated: false,
       savedEmblemVisible: false,
+      isSubmitting: false,
       clickedNext: false,
       showConfirmDiscardChanges: false,
       initialFormFields: null,
@@ -119,6 +121,7 @@ class FormWorkflow<T> extends React.PureComponent<Props<T>,State<T>> {
   onSubmit(event: SyntheticEvent<HTMLFormElement>): void {
     event.preventDefault();
     const currentStep: FormWorkflowStepConfig = this.props.steps[this.state.currentStep];
+    this.setState({isSubmitting: true});
     const submitFunc: Function = () => {
       currentStep.onSubmit(event, this.formRef, this.onSubmitSuccess.bind(this, currentStep.onSubmitSuccess));
     };
@@ -132,7 +135,8 @@ class FormWorkflow<T> extends React.PureComponent<Props<T>,State<T>> {
         clickedNext: false,
         currentStep: this.state.currentStep + 1,
         fieldsUpdated: false,
-        savedEmblemVisible: false
+        savedEmblemVisible: false,
+        isSubmitting: false
       }));
     }
     if (this.state.fieldsUpdated) {
@@ -207,7 +211,7 @@ class FormWorkflow<T> extends React.PureComponent<Props<T>,State<T>> {
                   <span className='create-project-saved-emblem'><i className={GlyphStyles.CircleCheck} aria-hidden="true"></i> Saved</span>}
 
                 <input type="submit" className="btn btn-primary create-btn"
-                      disabled={!this.state.formIsValid}
+                      disabled={!this.state.formIsValid || this.state.isSubmitting}
                       value={this.onLastStep() ? "PUBLISH" : "Next"}
                 />
               </div>

--- a/common/components/forms/FormWorkflow.jsx
+++ b/common/components/forms/FormWorkflow.jsx
@@ -2,13 +2,12 @@
 
 import React from "react";
 import Button from 'react-bootstrap/Button';
-import _ from 'lodash'
-
+import {Glyph, GlyphStyles, GlyphSizes} from "../utils/glyphs.js";
+import _ from "lodash";
 import ConfirmationModal from "../common/confirmation/ConfirmationModal.jsx";
 import StepIndicatorBars from "../common/StepIndicatorBars.jsx";
 import LoadingMessage from "../chrome/LoadingMessage.jsx";
 import utils from "../utils/utils.js";
-import GlyphStyles from "../utils/glyphs.js";
 
 
 export type FormWorkflowStepConfig<T> = {|
@@ -179,7 +178,6 @@ class FormWorkflow<T> extends React.PureComponent<Props<T>,State<T>> {
 
   _renderForm(): React$Node {
     const FormComponent: React$Node = this.props.steps[this.state.currentStep].formComponent;
-
     return (
       <form
         onSubmit={this.onSubmit.bind(this)}
@@ -210,10 +208,14 @@ class FormWorkflow<T> extends React.PureComponent<Props<T>,State<T>> {
                 {!this.state.savedEmblemVisible ? "" :
                   <span className='create-project-saved-emblem'><i className={GlyphStyles.CircleCheck} aria-hidden="true"></i> Saved</span>}
 
-                <input type="submit" className="btn btn-primary create-btn"
+                <button type="submit" className="btn btn-primary create-btn"
                       disabled={!this.state.formIsValid || this.state.isSubmitting}
-                      value={this.onLastStep() ? "PUBLISH" : "Next"}
-                />
+                >
+                  {this.state.isSubmitting
+                    ? <i className={Glyph(GlyphStyles.LoadingSpinner, GlyphSizes.LG)}></i>
+                    : this.onLastStep() ? "PUBLISH" : "Next"
+                  }
+                </button>
               </div>
             </div>
       </form>

--- a/common/helpers/form_helpers.py
+++ b/common/helpers/form_helpers.py
@@ -23,8 +23,16 @@ def read_form_field_datetime(model, form, field_name):
 
 
 def read_form_field_tags(model, form, field_name):
+    """
+    Read tags form field into model field
+    :param model: Model containing tag field
+    :param form: Form data from front-end
+    :param field_name: Name of field shared by model and form
+    :return: True if changes to model tag field were made
+    """
     if field_name in form.data:
-        Tag.merge_tags_field(getattr(model, field_name), form.data.get(field_name))
+        return Tag.merge_tags_field(getattr(model, field_name), form.data.get(field_name))
+    return False
 
 
 def read_form_fields_point(model, form, point_field_name, lat_field_name, long_field_name):

--- a/common/helpers/form_helpers.py
+++ b/common/helpers/form_helpers.py
@@ -44,11 +44,20 @@ def read_form_fields_point(model, form, point_field_name, lat_field_name, long_f
 
 
 def merge_json_changes(model_class, model, form, field_name):
+    """
+    Merge changes from json form field to model field
+    :param model_class: Model class
+    :param model: Model instance
+    :param form: form wrapper
+    :param field_name: field name in model and form
+    :return: True if there were changes
+    """
     if field_name in form.data:
         json_text = form.data.get(field_name)
         if len(json_text) > 0:
             json_object = json.loads(json_text)
-            model_class.merge_changes(model, json_object)
+            return model_class.merge_changes(model, json_object)
+    return False
 
 
 def merge_single_file(model, form, file_category, field_name):

--- a/common/models/tags.py
+++ b/common/models/tags.py
@@ -57,8 +57,14 @@ class Tag(models.Model):
 
     @staticmethod
     def merge_tags_field(tags_field, tag_entries):
+        """
+        Merge tag entries into a tag field
+        :param tags_field: model tag field
+        :param tag_entries: comma-separated string of tag slugs
+        :returns True if any changes were made
+        """
         tag_entries = tag_entries or ""
-        tag_entry_slugs = set(tag_entries.split(','))
+        tag_entry_slugs = set(tag_entries.split(',') if tag_entries else [])
         existing_tag_slugs = set(tags_field.slugs())
 
         tags_to_add = list(tag_entry_slugs - existing_tag_slugs)
@@ -70,3 +76,4 @@ class Tag(models.Model):
         for tag in tags_to_remove:
             if len(tag) > 0:
                 tags_field.remove(tag)
+        return len(tags_to_add) > 0 or len(tags_to_remove) > 0


### PR DESCRIPTION
## Create/Edit Page ## 
- Form Next/PUBLISH buttons are now disabled while the save api call is ongoing
- Spinner is shown on button while the save api call is ongoing 
- Create Project workflow now used when editing project after publishing

## Caching ##
- Refresh project tag cache when admin approves project
- Only re-cache project tag counts when tags change for a searchable project upon saving

## Project Profile ##
- Don't show Contact/Volunteer buttons when in embedded viewa