### PR TITLE
Fix new user newsletter signup error

### DIFF
--- a/common/helpers/mailing_list.py
+++ b/common/helpers/mailing_list.py
@@ -27,7 +27,8 @@ class SubscribeToMailingList(object):
 
         api = Mailchimp(api_key)
         try:
-            api.lists.subscribe(list_id, {'email': self.email})
+            merge_vars = {'FNAME': self.first_name, 'LNAME': self.last_name}
+            api.lists.subscribe(list_id, {'email': self.email}, merge_vars=merge_vars)
         except (ListDoesNotExistError, EmailNotExistsError, ListAlreadySubscribedError, Error) as e:
             self.print_error(repr(e))
             return False


### PR DESCRIPTION
We weren't passing new users' first and last names when signing them up for our newsletter.