### PR TITLE
Cache project json data

### DIFF
--- a/civictechprojects/caching/cache.py
+++ b/civictechprojects/caching/cache.py
@@ -1,0 +1,18 @@
+from common.caching.cache import Cache
+
+
+class ProjectCacheManager:
+    _cache_key_prefix = 'project_'
+
+    def get(self, project):
+        return Cache.get(self._get_key(project))
+
+    def refresh(self, project, value):
+        Cache.refresh(self._get_key(project), value)
+        return value
+
+    def _get_key(self, project):
+        return self._cache_key_prefix + str(project.id)
+
+
+ProjectCache = ProjectCacheManager()

--- a/civictechprojects/caching/cache.py
+++ b/civictechprojects/caching/cache.py
@@ -8,6 +8,7 @@ class ProjectCacheManager:
         return Cache.get(self._get_key(project))
 
     def refresh(self, project, value):
+        print('Re-caching project ' + str(project))
         Cache.refresh(self._get_key(project), value)
         return value
 

--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -113,17 +113,18 @@ class EventCreationForm(ModelForm):
         if not is_co_owner_or_staff(request.user, event):
             raise PermissionDenied()
 
+        project_fields_changed = False
         read_form_field_string(event, form, 'event_agenda')
         read_form_field_string(event, form, 'event_description')
         read_form_field_string(event, form, 'event_short_description')
-        read_form_field_string(event, form, 'event_name')
-        read_form_field_string(event, form, 'event_location')
+        project_fields_changed |= read_form_field_string(event, form, 'event_name')
+        project_fields_changed |= read_form_field_string(event, form, 'event_location')
         read_form_field_string(event, form, 'event_rsvp_url')
         read_form_field_string(event, form, 'event_live_id')
-        read_form_field_string(event, form, 'event_organizers_text')
+        project_fields_changed |= read_form_field_string(event, form, 'event_organizers_text')
 
-        read_form_field_datetime(event, form, 'event_date_start')
-        read_form_field_datetime(event, form, 'event_date_end')
+        project_fields_changed |= read_form_field_datetime(event, form, 'event_date_start')
+        project_fields_changed |= read_form_field_datetime(event, form, 'event_date_end')
 
         read_form_field_boolean(event, form, 'is_searchable')
         read_form_field_boolean(event, form, 'is_created')
@@ -132,9 +133,12 @@ class EventCreationForm(ModelForm):
 
         event.event_date_modified = timezone.now()
 
-        merge_single_file(event, form, FileCategory.THUMBNAIL, 'event_thumbnail_location')
+        project_fields_changed |= merge_single_file(event, form, FileCategory.THUMBNAIL, 'event_thumbnail_location')
 
         event.save()
+
+        if project_fields_changed:
+            event.update_linked_items()
 
         return event
 

--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -5,6 +5,7 @@ from .models import Project, ProjectLink, ProjectFile, ProjectPosition, FileCate
 from .sitemaps import SitemapPages
 from democracylab.emails import send_project_creation_notification, send_group_creation_notification
 from democracylab.models import get_request_contributor
+from civictechprojects.caching.cache import ProjectCache
 from common.caching.cache import Cache, CacheKeys
 from common.helpers.date_helpers import parse_front_end_datetime
 from common.helpers.form_helpers import is_creator_or_staff, is_co_owner_or_staff, read_form_field_string, read_form_field_boolean, \
@@ -82,6 +83,9 @@ class ProjectCreationForm(ModelForm):
 
         if project.is_searchable and tags_changed:
             Cache.refresh(CacheKeys.ProjectTagCounts)
+
+        # TODO: Don't recache when nothing has changed
+        ProjectCache.refresh(project)
 
         return project
 

--- a/civictechprojects/helpers/projects.py
+++ b/civictechprojects/helpers/projects.py
@@ -5,7 +5,7 @@ from collections import Counter
 
 
 def projects_tag_counts():
-    return Cache.get(CacheKeys.ProjectTagCounts, _projects_tag_counts)
+    return Cache.get(CacheKeys.ProjectTagCounts, generator_func=_projects_tag_counts)
 
 
 def _projects_tag_counts():

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -7,6 +7,7 @@ from democracylab.models import Contributor
 from common.models.tags import Tag
 from taggit.managers import TaggableManager
 from taggit.models import TaggedItemBase
+from civictechprojects.caching.cache import ProjectCache
 from common.helpers.form_helpers import is_json_field_empty
 from common.helpers.dictionaries import merge_dicts
 from common.helpers.collections import flatten, count_occurrences
@@ -108,6 +109,9 @@ class Project(Archived):
         return owners + list(map(lambda pv: pv.volunteer, project_co_owners))
 
     def hydrate_to_json(self):
+        return ProjectCache.get(self) or ProjectCache.refresh(self, self._hydrate_to_json())
+
+    def _hydrate_to_json(self):
         files = ProjectFile.objects.filter(file_project=self.id)
         thumbnail_files = list(files.filter(file_category=FileCategory.THUMBNAIL.value))
         other_files = list(files.filter(file_category=FileCategory.ETC.value))

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -444,6 +444,12 @@ class Event(Archived):
 
         return [Tag.hydrate_to_json(project.id, list(project.project_issue_area.all().values())) for project in project_list]
 
+    def update_linked_items(self):
+        # Recache linked projects
+        project_relationships = ProjectRelationship.objects.filter(relationship_event=self)
+        for project_relationship in project_relationships:
+            project_relationship.relationship_project.recache()
+
 
 class ProjectRelationship(models.Model):
     relationship_project = models.ForeignKey(Project, related_name='relationships', blank=True, null=True)

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -338,7 +338,7 @@ def get_project(request, project_id):
 
     if project is not None:
         if project.is_searchable or is_co_owner_or_staff(get_request_contributor(request), project):
-            return JsonResponse(project.hydrate_to_json())
+            return JsonResponse(project.hydrate_to_json(), safe=False)
         else:
             return HttpResponseForbidden()
     else:

--- a/common/caching/cache.py
+++ b/common/caching/cache.py
@@ -12,23 +12,25 @@ class CacheWrapper:
     def __init__(self, cache_backend):
         self._cache = cache_backend
 
-    def get(self, key, generator_func):
+    def get(self, key, generator_func=None):
         """
         Retrieve cached value, and cache the value if it is not already cached
         :param key: Key of value to retrieve
         :param generator_func: Function that generates value
         :return: Value mapped to key
         """
-        return self._cache.get(key) or self._set(key, generator_func)
+        return self._cache.get(key) or (generator_func and self._set_with_generator(key, generator_func))
 
-    def refresh(self, key):
+    def refresh(self, key, value=None):
         """
         Refresh the cached value for a given key, such as when the underlying data has changed
         :param key: Key of value to re-cache
+        :param value: Value to cache
         """
-        self._cache.set(key, self._cache_generators[key]() if key in self._cache_generators else None)
+        _value = value or (self._cache_generators[key]() if key in self._cache_generators else None)
+        self._cache.set(key, _value)
 
-    def _set(self, key, generator_func):
+    def _set_with_generator(self, key, generator_func):
         if generator_func is not None:
             self._cache_generators[key] = generator_func
         generated_value = self._cache_generators[key]()

--- a/common/helpers/collections.py
+++ b/common/helpers/collections.py
@@ -22,3 +22,16 @@ def count_occurrences(collection):
         else:
             count_dict[item] = count_dict[item] + 1
     return count_dict
+
+
+def distinct(list_a, list_b, key_func):
+    """
+    Take two lists of arbitrary objects and get the union of distinct objects between the two
+    :param list_a: First object list
+    :param list_b: Second object list
+    :param key_func: function for extracting unique key from objects
+    :return:
+    """
+    lists_dict = {key_func(item): item for item in list_a}
+    lists_dict.update({key_func(item): item for item in list_b})
+    return lists_dict.values()

--- a/common/helpers/form_helpers.py
+++ b/common/helpers/form_helpers.py
@@ -23,12 +23,25 @@ def read_form_field_string(model, form, field_name, transformation=None):
         setattr(model, field_name, form_field_content)
     return field_changed
 
+
 def read_form_field_boolean(model, form, field_name):
+    """
+    :param model: Model containing boolean field
+    :param form: Form data from front-end
+    :param field_name: Name of field shared by model and form
+    :return: True if changes to model boolean field were made
+    """
     read_form_field_string(model, form, field_name, lambda str: strtobool(str))
 
 
 def read_form_field_datetime(model, form, field_name):
-    read_form_field_string(model, form, field_name, lambda str: parse_front_end_datetime(str))
+    """
+    :param model: Model containing datetime field
+    :param form: Form data from front-end
+    :param field_name: Name of field shared by model and form
+    :return: True if changes to model datetime field were made
+    """
+    return read_form_field_string(model, form, field_name, lambda str: parse_front_end_datetime(str))
 
 
 def read_form_field_tags(model, form, field_name):
@@ -76,7 +89,6 @@ def merge_single_file(model, form, file_category, field_name):
     :param form: form wrapper
     :param file_category: File type
     :param field_name: field name in model and form
-    :return: True if there were changes
     :return: True if there were changes
     """
     from civictechprojects.models import ProjectFile

--- a/democracylab/forms.py
+++ b/democracylab/forms.py
@@ -3,6 +3,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.core.exceptions import PermissionDenied
 from .models import Contributor
 from civictechprojects.models import ProjectLink, ProjectFile, FileCategory
+from common.helpers.form_helpers import read_form_field_string
 from common.helpers.qiqo_chat import SubscribeUserToQiqoChat
 from common.models.tags import Tag
 
@@ -22,12 +23,13 @@ class DemocracyLabUserCreationForm(UserCreationForm):
         if not request.user.username == user.username:
             raise PermissionDenied()
 
+        project_fields_changed = False
         form = DemocracyLabUserCreationForm(request.POST)
-        user.about_me = form.data.get('about_me')
-        user.postal_code = form.data.get('postal_code')
-        user.country = form.data.get('country')
-        user.first_name = form.data.get('first_name')
-        user.last_name = form.data.get('last_name')
+        project_fields_changed |= read_form_field_string(user, form, 'first_name')
+        project_fields_changed |= read_form_field_string(user, form, 'last_name')
+        read_form_field_string(user, form, 'about_me')
+        read_form_field_string(user, form, 'postal_code')
+        read_form_field_string(user, form, 'country')
 
         Tag.merge_tags_field(user.user_technologies, form.data.get('user_technologies'))
 
@@ -46,11 +48,14 @@ class DemocracyLabUserCreationForm(UserCreationForm):
         user_thumbnail_location = form.data.get('user_thumbnail_location')
         if len(user_thumbnail_location) > 0:
             thumbnail_file_json = json.loads(user_thumbnail_location)
-            ProjectFile.replace_single_file(user, FileCategory.THUMBNAIL, thumbnail_file_json)
+            project_fields_changed |= ProjectFile.replace_single_file(user, FileCategory.THUMBNAIL, thumbnail_file_json)
 
         user_resume_file = form.data.get('user_resume_file')
         if len(user_resume_file) > 0:
             user_resume_file_json = json.loads(user_resume_file)
             ProjectFile.replace_single_file(user, FileCategory.RESUME, user_resume_file_json)
+
+        if project_fields_changed:
+            user.update_linked_items()
 
         SubscribeUserToQiqoChat(user)

--- a/democracylab/models.py
+++ b/democracylab/models.py
@@ -2,6 +2,7 @@ import uuid
 from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
+from common.helpers.collections import distinct
 from common.models.tags import Tag
 from taggit.managers import TaggableManager
 from taggit.models import TaggedItemBase
@@ -76,6 +77,17 @@ class Contributor(User):
             user['user_thumbnail'] = thumbnail_files[0].to_json()
 
         return user
+
+    def update_linked_items(self):
+        # Recache owned projects
+        owned_projects = civictechprojects.models.Project.objects.filter(project_creator=self)
+
+        # Recache projects user is volunteering with
+        volunteering_projects = list(map(lambda vr: vr.project, civictechprojects.models.VolunteerRelation.objects.filter(volunteer=self)))
+
+        all_projects = distinct(owned_projects, volunteering_projects, lambda project: project.id)
+        for project in all_projects:
+            project.recache()
 
 
 def get_contributor_by_username(username):


### PR DESCRIPTION
Our full project json contains a lot of data from multiple tables, contributing to the load time for the project profile page.  This change caches the project json, refreshing the data when the project or objects displayed on the project page(Groups, Events, Volunteers) change.