### PR TITLE
Peter/remove event hero

### DIFF
--- a/common/components/controllers/FindEventsController.jsx
+++ b/common/components/controllers/FindEventsController.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 import Headers from "../common/Headers.jsx";
-import SplashScreen, {HeroImage} from "../componentsBySection/FindProjects/SplashScreen.jsx";
 import EventCardsContainer from "../componentsBySection/FindEvents/EventCardsContainer.jsx";
 import EventFilterContainer from "../componentsBySection/FindEvents/filters/EventFilterContainer.jsx";
 import React from 'react';
@@ -34,8 +33,6 @@ class FindEventsController extends React.PureComponent {
           description="Optimizing the connection between skilled volunteers and tech-for-good events"
         />
         <div className="FindEventsController-root">
-          <SplashScreen className="FindEventsController-topsplash" header={"Tech-for-Good Events"} img={HeroImage.FindEvents}>
-          </SplashScreen>
           <div className="container">
             <div className="row">
               <EventFilterContainer />

--- a/common/components/controllers/FindEventsController.jsx
+++ b/common/components/controllers/FindEventsController.jsx
@@ -25,6 +25,8 @@ class FindEventsController extends React.PureComponent {
       }});
   }
 
+
+//TODO: When enabling EventfilterContainer, remove "justify-content-center" class from row div
   render(): React$Node {
     return (
       <React.Fragment>
@@ -34,8 +36,8 @@ class FindEventsController extends React.PureComponent {
         />
         <div className="FindEventsController-root">
           <div className="container">
-            <div className="row">
-              <EventFilterContainer />
+            <div className="row justify-content-center">
+              {/*EventFilterContainer />*/}
               <EventCardsContainer showSearchControls={true}/>
             </div>
           </div>


### PR DESCRIPTION
 - removes hero image from Find Events page
 - horizontally centers event calendar items on page

That horizontal change is a temporary page cleanup fix until we get `<EventFilterContainer />` functioning, and has a TODO item noting that.