### PR TITLE
Project Caching Bug Fixes

### DIFF
--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -444,11 +444,20 @@ class Event(Archived):
 
         return [Tag.hydrate_to_json(project.id, list(project.project_issue_area.all().values())) for project in project_list]
 
+    def get_linked_projects(self):
+        # Get projects by legacy organization
+        projects = None
+        legacy_org_slugs = self.event_legacy_organization.slugs()
+        if legacy_org_slugs and len(legacy_org_slugs) > 0:
+            projects = Project.objects.filter(project_organization__name__in=legacy_org_slugs)
+        return projects
+
     def update_linked_items(self):
         # Recache linked projects
-        project_relationships = ProjectRelationship.objects.filter(relationship_event=self)
-        for project_relationship in project_relationships:
-            project_relationship.relationship_project.recache()
+        projects = self.get_linked_projects()
+        if projects:
+            for project in projects:
+                project.recache()
 
 
 class ProjectRelationship(models.Model):

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -909,6 +909,7 @@ def volunteer_with_project(request, project_id):
         role=role,
         application_text=message)
     send_volunteer_application_email(volunteer_relation)
+    project.recache()
     return HttpResponse(status=200)
 
 
@@ -950,7 +951,9 @@ def conclude_volunteering_with_project(request, application_id):
     send_volunteer_conclude_email(user, volunteer_relation.project.project_name)
 
     body = json.loads(request.body)
+    project = Project.objects.get(id=volunteer_relation.project.id)
     volunteer_relation.delete()
+    project.recache()
 
     notify_project_owners_volunteer_concluded_email(volunteer_relation, body['message'])
     return HttpResponse(status=200)
@@ -975,6 +978,7 @@ def accept_project_volunteer(request, application_id):
         volunteer_relation.approved_date = timezone.now()
         volunteer_relation.save()
         update_project_timestamp(request, volunteer_relation.project)
+        volunteer_relation.project.recache()
         if request.method == 'GET':
             messages.add_message(request, messages.SUCCESS, volunteer_relation.volunteer.full_name() + ' has been approved as a volunteer.')
             return redirect(about_project_url)
@@ -994,6 +998,7 @@ def promote_project_volunteer(request, application_id):
         volunteer_relation.is_co_owner = True
         volunteer_relation.save()
         update_project_timestamp(request, volunteer_relation.project)
+        volunteer_relation.project.recache()
         return HttpResponse(status=200)
     else:
         raise PermissionDenied()
@@ -1015,7 +1020,9 @@ def reject_project_volunteer(request, application_id):
                                   subject=email_subject,
                                   template=email_template)
         update_project_timestamp(request, volunteer_relation.project)
+        project = Project.objects.get(id=volunteer_relation.project.id)
         volunteer_relation.delete()
+        project.recache()
         return HttpResponse(status=200)
     else:
         raise PermissionDenied()
@@ -1038,7 +1045,9 @@ def dismiss_project_volunteer(request, application_id):
                                subject=email_subject,
                                template=email_template)
         update_project_timestamp(request, volunteer_relation.project)
+        project = Project.objects.get(id=volunteer_relation.project.id)
         volunteer_relation.delete()
+        project.recache()
         return HttpResponse(status=200)
     else:
         raise PermissionDenied()
@@ -1063,6 +1072,7 @@ def demote_project_volunteer(request, application_id):
         send_to_project_volunteer(volunteer_relation=volunteer_relation,
                                subject=email_subject,
                                template=email_template)
+        volunteer_relation.project.recache()
         return HttpResponse(status=200)
     else:
         raise PermissionDenied()
@@ -1094,6 +1104,8 @@ def leave_project(request, project_id):
                                template=email_template)
         update_project_timestamp(request, volunteer_relation.project)
         volunteer_relation.delete()
+        project = Project.objects.get(id=project_id)
+        project.recache()
         return HttpResponse(status=200)
     else:
         raise PermissionDenied()

--- a/common/management/commands/project_external_updates.py
+++ b/common/management/commands/project_external_updates.py
@@ -73,6 +73,7 @@ def add_commits_to_database(project, commits_to_ingest):
     from civictechprojects.models import ProjectCommit
     for commit_info in commits_to_ingest:
         ProjectCommit.create(project, commit_info[0], 'master', commit_info[1])
+    project.recache()
 
 
 def get_project_latest_commit_date(project):


### PR DESCRIPTION
## Project Profile ##
- Applying to volunteer with project recaches project, as does accepting/rejecting/dismissing volunteers.
- Inviting project to join group recaches project, as does accepting/rejecting group join requests
- Fixed issue with event edits not causing linked project re-caching
- Ingesting github commits for a project now recaches it 