### PR TITLE
removes copyright from emails template and add creative commons verbiage

### DIFF
--- a/democracylab/templates/emails/html_email_frame.html
+++ b/democracylab/templates/emails/html_email_frame.html
@@ -120,11 +120,29 @@
 			padding-top: 20px;
 			padding-bottom: 20px;
 			color: #999999;
-			font-family: sans-serif;" class="footer">
-
-                Copyright &copy; 2019 DemocracyLab. All Rights Reserved.
-            </td>
-        </tr>
+            font-family: sans-serif;" class="footer"
+            >
+            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+                <img
+                alt="Creative Commons License"
+                style="border-width:0"
+                src="https://i.creativecommons.org/l/by/4.0/88x31.png"
+                />
+            </a>
+            <br />This work by 
+            <a
+            xmlns:cc="http://creativecommons.org/ns#"
+            href="https://www.democracylab.org/"
+            property="cc:attributionName"
+            rel="cc:attributionURL"
+            >
+            https://www.democracylab.org/ 
+        </a>is licensed under a 
+        <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+            Creative Commons Attribution 4.0 International License.
+        </a>
+    </td>
+</tr>
 
         <!-- End of WRAPPER -->
     </table>


### PR DESCRIPTION
Removed copyright from emails template and replaces with creative commons languages.