### PR TITLE
add recaptcha v3 instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/r/nikolaik/python-nodejs
-FROM nikolaik/python-nodejs:python3.8-nodejs12	
+FROM nikolaik/python-nodejs:python3.8-nodejs12
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
@@ -101,9 +101,13 @@ ENV PAYPAL_PAYEE 'mark@democracylab.org'
 # Press page links (TODO: convert to db entries)
 ENV PRESS_LINKS '[{"date":"March 11, 2019","href":"https://www.washingtontechnology.org/the-pulse-of-tech-for-good-in-seattle/","title":"The Pulse of Tech for Good in Seattle","source":"Washington Technology Industry Association"},{"date":"February 10, 2019","href":"https://www.esal.us/blog/democracylab-empowering-the-civic-tech-movement/","title":"DemocracyLab: Empowering the Civic Tech Movement","source":"Engineers and Scientists Acting Locally"},{"date":"January 22, 2019","href":"https://givingcompass.org/article/untapped-potential-of-civic-technology/","title":"The Untapped Potential of Civic Technology","source":"Giving Compass"},{"date":"January 18, 2019","href":"http://techtalk.seattle.gov/2019/01/18/civic-tech-community-tackles-pressing-issues-with-seattles-open-data/","title":"Civic Tech Community Tackles Pressing Issues with Seattle’s Open Data","source":"Seattle IT Tech Talk Blog"},{"date":"January 9, 2019","href":"https://socrata.com/blog/seattle-hackathon-real-world-impact/","title":"Seattle Hackathon Innovates for ‘Real World Impact’","source":"Socrata Blog"},{"date":"August 8, 2018","href":"https://www.geekwire.com/2018/can-tech-government-innovate-together-social-good-inside-new-effort-change-tide/","title":"Can tech and government innovate together for social good? Inside a new effort to change the tide","source":"GeekWire"}]'
 
-# Google ReCaptcha development (NON PRODUCTION) keys
+# Google ReCaptcha V2 development (NON PRODUCTION) keys
 # These should always result in no captcha and always succeeding the check
 ENV GOOGLE_RECAPTCHA_SECRET_KEY "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
 ENV GOOGLE_RECAPTCHA_SITE_KEY "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+
+# Google ReCaptcha V3 development keys
+ENV GOOGLE_RECAPTCHA_V3_SITE_KEY "6LdRmtwZAAAAAI_WUIFZowtyPfH86P9C-ZRKJ8j7"
+ENV GOOGLE_RECAPTCHA_V3_SECRET_KEY "ASK"
 
 EXPOSE 8000

--- a/civictechprojects/static/css/partials/_recaptcha.scss
+++ b/civictechprojects/static/css/partials/_recaptcha.scss
@@ -1,0 +1,10 @@
+// https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
+.grecaptcha-badge {
+  visibility: hidden;
+}
+
+// display required text
+.grecaptcha-required-text {
+  font-size: 14px;
+  margin: 1rem 0;
+}

--- a/civictechprojects/static/css/styles.scss
+++ b/civictechprojects/static/css/styles.scss
@@ -32,6 +32,7 @@
 @import 'vendor/_react-select.min';
 @import 'vendor/react-datepicker/_react-datepicker';
 @import 'vendor/react-image-crop/ReactCrop';
+@import 'vendor/recaptcha/recaptcha';
 
   //import DemocracyLab component partials
 @import 'partials/AboutGroupDisplay';

--- a/civictechprojects/static/css/vendor/recaptcha/_recaptcha.scss
+++ b/civictechprojects/static/css/vendor/recaptcha/_recaptcha.scss
@@ -1,0 +1,10 @@
+// https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
+.grecaptcha-badge {
+  visibility: hidden;
+}
+
+// display required text
+.grecaptcha-required-text {
+  font-size: 14px;
+  margin: 1rem 0;
+}

--- a/civictechprojects/templates/new_index.html
+++ b/civictechprojects/templates/new_index.html
@@ -73,6 +73,7 @@
       window.PAYPAL_PAYEE = '{{PAYPAL_PAYEE}}';
       window.PRESS_LINKS = '{{PRESS_LINKS}}';
       window.GR_SITEKEY = '{{GR_SITEKEY}}';
+      window.GRV3_SITEKEY = '{{GRV3_SITEKEY}}'
       window.SOCIAL_APPS_VISIBILITY = '{{SOCIAL_APPS_VISIBILITY}}';
       window.HERE_CONFIG = '{{HERE_CONFIG}}';
       window.QIQO_IFRAME_URL = '{{QIQO_IFRAME_URL}}';

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -389,6 +389,7 @@ def index(request):
         'PRESS_LINKS': settings.PRESS_LINKS,
         'organizationSnippet': loader.render_to_string('scripts/org_snippet.txt'),
         'GR_SITEKEY': settings.GR_SITEKEY,
+        'GRV3_SITEKEY': settings.GRV3_SITEKEY,
         'FAVICON_PATH': settings.FAVICON_PATH,
         'BLOG_URL': settings.BLOG_URL,
         'EVENT_URL': settings.EVENT_URL,
@@ -576,7 +577,7 @@ def limited_listings(request):
         # Using CDATA tags (and escaping the close sequence) protects us from XSS attacks when
         # displaying user provided string values.
         return f"<![CDATA[{str.replace(']]>', ']]]]><![CDATA[>')}]]>"
-    
+
     def position_to_job(position):
         project = position.position_project
         roleTag = Tag.get_by_name(position.position_role.first().slug)
@@ -599,7 +600,7 @@ def limited_listings(request):
     approved_projects = ProjectPosition.objects.filter(position_project__is_searchable=True)
     xml_response = f"""<?xml version="1.0" encoding="UTF-8"?>
     <source>
-        <lastBuildDate>{timezone.now().strftime('%a, %d %b %Y %H:%M:%S %Z')}</lastBuildDate> 
+        <lastBuildDate>{timezone.now().strftime('%a, %d %b %Y %H:%M:%S %Z')}</lastBuildDate>
         <publisherUrl>https://www.democracylab.org</publisherUrl>
         <publisher>DemocracyLab</publisher>
         {"".join(map(position_to_job, approved_projects))}
@@ -1285,4 +1286,3 @@ def team(request):
         response['project'] = project.hydrate_to_json()
 
     return JsonResponse(response)
-

--- a/common/components/controllers/ContactUsController.jsx
+++ b/common/components/controllers/ContactUsController.jsx
@@ -9,7 +9,7 @@ class ContactUsController extends React.PureComponent<{||}> {
   componentDidMount() {
     prerender.ready();
   }
-  
+
   _renderHeader(): React$Node {
     const title: string = "DemocracyLab | Contact Us";
     const description: string = "Contact information for DemocracyLab."
@@ -30,6 +30,7 @@ class ContactUsController extends React.PureComponent<{||}> {
            <h1>Contact Us</h1>
            <p>To contact DemocracyLab, please fill out this form to send us a message and we'll get back to you. All fields are required.</p>
            <ContactForm />
+           <p className="grecaptcha-required-text">This site is protected by reCAPTCHA and the Google <a href="https://policies.google.com/privacy">Privacy Policy</a> and <a href="https://policies.google.com/terms">Terms of Service</a> apply.</p>
          </div>
        </React.Fragment>
      )

--- a/common/components/controllers/MainController.jsx
+++ b/common/components/controllers/MainController.jsx
@@ -6,7 +6,9 @@ import UniversalDispatcher from '../stores/UniversalDispatcher.js';
 import React from 'react';
 import MainFooter from "../chrome/MainFooter.jsx";
 import SocialFooter from "../chrome/SocialFooter.jsx";
-import url from '../../components/utils/url.js'
+import url from '../../components/utils/url.js';
+import { GoogleReCaptchaProvider } from 'react-google-recaptcha-v3';
+
 
 type State = {|
   headerHeight: number,
@@ -46,13 +48,24 @@ class MainController extends React.Component<{||}, State> {
     });
   }
 
-  render(): Array<React$Node> {
-    return [
-      <MainHeader key='main_header' onMainHeaderHeightChange={this._mainHeaderHeightChange.bind(this)}/>,
-      <SectionController key='section_controller' headerHeight={this.state.headerHeight}/>,
-      <MainFooter key='main_footer'/>,
-      <SocialFooter key='social_footer'/>
-    ];
+  render() {
+    return (
+      // because the ReCaptcha has to wrap the whole site it's acting as the one element for render() 
+      <GoogleReCaptchaProvider
+        reCaptchaKey={window.GRV3_SITEKEY}
+        useRecaptchaNet
+        scriptProps={{
+          async: true,
+          defer: true,
+          appendTo: "head"
+        }}
+      >
+        <MainHeader key='main_header' onMainHeaderHeightChange={this._mainHeaderHeightChange.bind(this)}/>
+        <SectionController key='section_controller' headerHeight={this.state.headerHeight}/>
+        <MainFooter key='main_footer'/>
+        <SocialFooter key='social_footer'/>
+      </GoogleReCaptchaProvider>
+    );
   }
 }
 

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -250,9 +250,13 @@ GOOGLE_ADS_ID = os.environ.get('GOOGLE_ADS_ID', '')
 GOOGLE_TAGS_ID = os.environ.get('GOOGLE_TAGS_ID', '')
 GOOGLE_CONVERSION_IDS = ast.literal_eval(os.environ.get('GOOGLE_CONVERSION_IDS', 'None'))
 
-#Google ReCaptcha keys - site key is exposed to the front end, secret is not
+#Google ReCaptcha V2 keys - site key is exposed to the front end, secret is not
 GR_SITEKEY = os.environ.get('GOOGLE_RECAPTCHA_SITE_KEY', '')
 GR_SECRETKEY = os.environ.get('GOOGLE_RECAPTCHA_SECRET_KEY', '')
+
+#Google ReCaptcha V3 keys - site is public, secret is not, as with V2
+GRV3_SITEKEY = os.environ.get('GOOGLE_RECAPTCHA_V3_SITE_KEY', '')
+GRV3_SECRETKEY = os.environ.get('GOOGLE_RECAPTCHA_V3_SECRET_KEY', '')
 
 STATIC_CDN_URL = os.environ.get('STATIC_CDN_URL', '')
 

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -91,10 +91,14 @@ export PAYPAL_PAYEE='mark@democracylab.org'
 # Press page links (TODO: convert to db entries)
 export PRESS_LINKS='[{"date":"March 11, 2019","href":"https://www.washingtontechnology.org/the-pulse-of-tech-for-good-in-seattle/","title":"The Pulse of Tech for Good in Seattle","source":"Washington Technology Industry Association"},{"date":"February 10, 2019","href":"https://www.esal.us/blog/democracylab-empowering-the-civic-tech-movement/","title":"DemocracyLab: Empowering the Civic Tech Movement","source":"Engineers and Scientists Acting Locally"},{"date":"January 22, 2019","href":"https://givingcompass.org/article/untapped-potential-of-civic-technology/","title":"The Untapped Potential of Civic Technology","source":"Giving Compass"},{"date":"January 18, 2019","href":"http://techtalk.seattle.gov/2019/01/18/civic-tech-community-tackles-pressing-issues-with-seattles-open-data/","title":"Civic Tech Community Tackles Pressing Issues with Seattle’s Open Data","source":"Seattle IT Tech Talk Blog"},{"date":"January 9, 2019","href":"https://socrata.com/blog/seattle-hackathon-real-world-impact/","title":"Seattle Hackathon Innovates for ‘Real World Impact’","source":"Socrata Blog"},{"date":"August 8, 2018","href":"https://www.geekwire.com/2018/can-tech-government-innovate-together-social-good-inside-new-effort-change-tide/","title":"Can tech and government innovate together for social good? Inside a new effort to change the tide","source":"GeekWire"}]'
 
-# Google ReCaptcha development (NON PRODUCTION) keys
+# Google ReCaptcha v2 development (NON PRODUCTION) keys
 # These should always result in no captcha and always succeeding the check
 export GOOGLE_RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 export GOOGLE_RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+
+# Google ReCaptcha V3 keys - can be used in parallel with v2
+export GOOGLE_RECAPTCHA_V3_SITE_KEY=6LdRmtwZAAAAAI_WUIFZowtyPfH86P9C-ZRKJ8j7
+export GOOGLE_RECAPTCHA_V3_SECRET_KEY='ask'
 
 # Sample OAuth configuration
 # export SOCIAL_APPS='{"github": {"id": 1, "name": "DLab Social Login", "client_id": "CONFIGURE", "secret": "CONFIGURE", "public": True}, "google": {"id": 2,"name": "DLab Social Login","client_id": "CONFIGURE","secret": "CONFIGURE", "public": True}, "linkedin": {"id": 3,"name": "DLab Social Login","client_id": "CONFIGURE","secret": "CONFIGURE", "public": True}, "facebook": {"id": 4,"name": "DLab Social Login","client_id": "CONFIGURE","secret": "CONFIGURE", "public": True}}'

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^16.11.0",
     "react-file-drop": "^0.2.8",
     "react-google-recaptcha": "^1.1.0",
+    "react-google-recaptcha-v3": "^1.7.0",
     "react-helmet": "^5.2.0",
     "react-image-crop": "^8.3.0",
     "react-moment": "^0.7.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,7 +3542,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@3.3.2, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   dependencies:
@@ -6179,6 +6179,13 @@ react-file-drop@^0.2.8:
   resolved "https://registry.yarnpkg.com/react-file-drop/-/react-file-drop-0.2.8.tgz#de1e26cef0f1a5855fa1fb1e0cee32bc03c34466"
   dependencies:
     prop-types "^15.6.1"
+
+react-google-recaptcha-v3@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.7.0.tgz#b072464d4237b8f147beaf28fb833264534dc222"
+  integrity sha512-yV7muvRmeD2T0oa6yFfCuVD9caTWqsFGoQBsFryRw+IMgyB2IXNK25NTEt7KYIeloGaJh94GZbB92xFne5HdEw==
+  dependencies:
+    hoist-non-react-statics "3.3.2"
 
 react-google-recaptcha@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
So that we can set our recaptcha v3 thresholds correctly, this branch adds recaptcha V3 instrumentation, which will allow us to passively collect scoring information before setting thresholds and refactoring our contact form to use V3 over V2 as the anti-spam check.

