### PR TITLE
Allow camera and microphone in Live Event iframe

### DIFF
--- a/common/components/controllers/LiveEventController.jsx
+++ b/common/components/controllers/LiveEventController.jsx
@@ -26,7 +26,7 @@ class LiveEventController extends React.Component<{||}, State> {
         ? <LogInController prevPage={Section.LiveEvent}/>
         : (
           <div className="LiveEvent-root">
-            <iframe src={_.unescape(this.state.iframeUrl)} />
+            <iframe src={_.unescape(this.state.iframeUrl)} allow="camera *;microphone *"/>
           </div>
         )
     );


### PR DESCRIPTION
Qiqochat has released a new tool that requires camera and microphone access for the iframe it lives in.