### PR TITLE
Don't use project_thumbnail for full-text search

### DIFF
--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -219,6 +219,8 @@ class Project(Archived):
         del base_json['project_events']
         del base_json['project_groups']
         del base_json['project_commits']
+        # Don't cache files because they contain noise without adequate signal
+        del base_json['project_thumbnail']
         full_text = str(base_json)
         if len(full_text) >= Project._full_text_capacity:
             full_text = full_text[:Project._full_text_capacity - 1]

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -215,12 +215,12 @@ class Project(Archived):
     def generate_full_text(self):
         base_json = self.hydrate_to_json()
         # Don't cache external entities because they take up space and aren't useful in project search
-        del base_json['project_volunteers']
-        del base_json['project_events']
-        del base_json['project_groups']
-        del base_json['project_commits']
+        base_json.pop('project_volunteers', None)
+        base_json.pop('project_events', None)
+        base_json.pop('project_groups', None)
+        base_json.pop('project_commits', None)
         # Don't cache files because they contain noise without adequate signal
-        del base_json['project_thumbnail']
+        base_json.pop('project_thumbnail', None)
         full_text = str(base_json)
         if len(full_text) >= Project._full_text_capacity:
             full_text = full_text[:Project._full_text_capacity - 1]

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -216,11 +216,13 @@ class Project(Archived):
         base_json = self.hydrate_to_json()
         # Don't cache external entities because they take up space and aren't useful in project search
         base_json.pop('project_volunteers', None)
+        base_json.pop('project_owners', None)
         base_json.pop('project_events', None)
         base_json.pop('project_groups', None)
         base_json.pop('project_commits', None)
         # Don't cache files because they contain noise without adequate signal
         base_json.pop('project_thumbnail', None)
+        base_json.pop('project_files', None)
         full_text = str(base_json)
         if len(full_text) >= Project._full_text_capacity:
             full_text = full_text[:Project._full_text_capacity - 1]

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -215,14 +215,11 @@ class Project(Archived):
     def generate_full_text(self):
         base_json = self.hydrate_to_json()
         # Don't cache external entities because they take up space and aren't useful in project search
-        base_json.pop('project_volunteers', None)
-        base_json.pop('project_owners', None)
-        base_json.pop('project_events', None)
-        base_json.pop('project_groups', None)
-        base_json.pop('project_commits', None)
+        omit_fields = ['project_volunteers', 'project_owners', 'project_events', 'project_groups', 'project_commits']
         # Don't cache files because they contain noise without adequate signal
-        base_json.pop('project_thumbnail', None)
-        base_json.pop('project_files', None)
+        omit_fields += ['project_thumbnail', 'project_files']
+        for field in omit_fields:
+            base_json.pop(field, None)
         full_text = str(base_json)
         if len(full_text) >= Project._full_text_capacity:
             full_text = full_text[:Project._full_text_capacity - 1]

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -218,6 +218,12 @@ class Project(Archived):
         omit_fields = ['project_volunteers', 'project_owners', 'project_events', 'project_groups', 'project_commits']
         # Don't cache files because they contain noise without adequate signal
         omit_fields += ['project_thumbnail', 'project_files']
+        # Don't cache boolean fields
+        omit_fields += ['project_claimed', 'project_approved']
+        # Don't cache numeric fields
+        omit_fields += ['project_id', 'project_creator', 'project_latitude', 'project_longitude']
+        # Don't cache date fields
+        omit_fields += ['project_date_modified']
         for field in omit_fields:
             base_json.pop(field, None)
         full_text = str(base_json)


### PR DESCRIPTION
We are currently searching the contents of the project_thumbnail file entry in projects, and this has caused some search issues (most significantly, trying to search for 'DemocracyLab', which is present in the s3 file url and so causes nearly every project to come up for the query). 