### PR TITLE
Peter/donate blurb hotfix

### DIFF
--- a/civictechprojects/static/css/partials/_DonateController.scss
+++ b/civictechprojects/static/css/partials/_DonateController.scss
@@ -2,6 +2,10 @@
   display: flex;
   max-width: 1400px;
   margin: 0 auto;
+  background-color: $color-background-light;
+  h2 {
+    margin-top: 2rem;
+  }
 }
 
 .donate-image img{
@@ -42,7 +46,7 @@
 
 @media (min-width: 900px) {
   .DonateController-text {
-    padding: 50px;
+    padding: 40px 25px;
   }
 
   .PaypalDonationButton {

--- a/common/components/componentsBySection/Donate/DonateBlurb.jsx
+++ b/common/components/componentsBySection/Donate/DonateBlurb.jsx
@@ -16,7 +16,7 @@ class DonateBlurb extends React.Component<{||}, State> {
       blurbType: window.DONATE_PAGE_BLURB
     };
   }
-  
+
   render(): React$Node {
     const showBlurb: boolean = this.state.blurbType in this.blurbs;
     return (
@@ -25,14 +25,14 @@ class DonateBlurb extends React.Component<{||}, State> {
       </React.Fragment>
     );
   }
-  
+
   _givingTuesday(): React$Node {
     return (
       <React.Fragment>
-        <h1>
+        <h2>
           Giving Tuesday 2020 is on Dec. 1st
-        </h1>
-        <p className="donate-bold">
+        </h2>
+        <p>
           <a href="https://www.givingtuesday.org/">Giving Tuesday</a>{" "}
           is a global day of giving - please consider donating to one of the most full-featured, collaborative platforms for developing tech-for-good projects! Given these unprecedented times, your donation is now more important than ever.
         </p>


### PR DESCRIPTION
Minor fixes to the donate page now that we have an optional donate blurb section (Giving Tuesday, etc.)

 - changes page background to white, to match rest of site
 - removes an unused classname
 - changes blurb title to H2, for hierarchy, adds a bit of extra space to separate blurb from the page's regular text a bit more
 - modifies >900px screen size text section padding so the page H1 has a cleaner linebreak

