### PR TITLE
Require project creators to agree to terms of service

### DIFF
--- a/common/components/common/confirmation/TermsModal.jsx
+++ b/common/components/common/confirmation/TermsModal.jsx
@@ -12,6 +12,11 @@ export const TermsTypes: Dictionary<string> = {
 
 export type TermsType = $Keys<typeof TermsTypes>;
 
+type TermsConfig = {|
+  headerText: string,
+  termsContent: () => React$Node
+|};
+
 type Props = {|
   termsType: TermsType,
   showModal: boolean,
@@ -19,6 +24,7 @@ type Props = {|
 |};
 type State = {|
   showModal: boolean,
+  termsConfigurations: Dictionary<TermsConfig>
 |};
 
 /**
@@ -27,12 +33,12 @@ type State = {|
 class TermsModal extends React.PureComponent<Props, State> {
   constructor(props: Props): void {
     super(props);
-    this.termsDictionary = _.fromPairs([
-      [TermsTypes.UserSignup, this._renderUserSignupTerms],
-      [TermsTypes.OrgSignup, this._renderOrgSignupTerms]
-    ]);
     this.state = {
-      showModal: false
+      showModal: false,
+      termsConfigurations:_.fromPairs([
+        [TermsTypes.UserSignup, {headerText: "Terms of Volunteering", termsContent: this._renderUserSignupTerms}],
+        [TermsTypes.OrgSignup, {headerText: "Terms of Use", termsContent: this._renderOrgSignupTerms}]
+      ])
     }
   }
 
@@ -48,10 +54,11 @@ class TermsModal extends React.PureComponent<Props, State> {
   }
 
   render(): React$Node {
+    const termsConfig = this.state.termsConfigurations[this.props.termsType];
     return (
-      <NotificationModal headerText="Terms of Volunteering" buttonText="Close and Continue" showModal={this.state.showModal} onClickButton={this.confirm.bind(this)}>
+      <NotificationModal headerText={termsConfig.headerText} buttonText="Close and Continue" showModal={this.state.showModal} onClickButton={this.confirm.bind(this)}>
         <div className="Terms-body">
-          {this.termsDictionary[this.props.termsType]()}
+          {termsConfig.termsContent()}
         </div>
       </NotificationModal>
     );

--- a/common/components/common/confirmation/TermsModal.jsx
+++ b/common/components/common/confirmation/TermsModal.jsx
@@ -75,20 +75,40 @@ class TermsModal extends React.PureComponent<Props, State> {
   }
   
   _renderOrgSignupTerms(): React$Node {
-    // TODO: Replace with text
     return (
-      <ul>
-        <li>I am volunteering solely for my personal purposes or pleasure, including for civic, charitable, or humanitarian reasons.</li>
-        <li>I am freely donating my volunteer services and have no expectation of receiving and have not been promised compensation or benefits in exchange for any assistance I provide to project owners.</li>
-        <li>I am donating my volunteer services to the owner of a tech-for-good project, not to DemocracyLab itself, and any associated liability is entirely with that project owner.</li>
-        <li>I release and forever discharge and hold harmless DemocracyLab from any and all liability, claims, and demands related to my volunteering for third-party project owners, use of the DemocracyLab website, and attendance at DemocracyLab events. </li>
-        <li>I understand that if I am responsible for injuries or property damage to project owners or others while acting outside the scope of volunteer assignments, that I may be held personally liable by the injured party.</li>
-        <li>I will perform the project tasks on a temporary, fully-independent basis without significant and ongoing control of work schedules and conditions by the project owner.</li>
-        <li>I am not volunteering for an organization with which I am employed nor am I expecting to receive a job offer from a project owner.</li>
-        <li>I will not perform the type of work an employee would typically perform for a project owner’s customers or clients nor will I supervise employees of a project owner. I will use my own tools and equipment and will not seek reimbursement for any purchases of materials or supplies.</li>
-        <li>I grant DemocracyLab permission to use all photographs, images, video, or audio recordings of me in connection with my attendance at DemocracyLab events or volunteering for project owners.</li>
-        <li>I am at least 18 years old and possess the authority to bind myself to this agreement.</li>
-      </ul>
+      <React.Fragment>
+        <p>As an organization accepting third-party volunteers via DemocracyLab, I agree:</p>
+        <ul>
+          <li>I am volunteering solely for my personal purposes or pleasure, including for civic, charitable, or humanitarian reasons.</li>
+          <li>I am submitting registration information that is truthful and accurate and will update this information if anything changes.</li>
+          <li>
+            I agree not to use DemocracyLab to violate any law or regulation, violate any third-party right, disrupt DemocracyLab services,
+            or to transmit mass unsolicited advertisements via e-mail or other means.
+          </li>
+          <li>
+            I release, forever discharge, hold harmless, and indemnify DemocracyLab from any and all liability, claims,
+            and demands related to my use of DemocracyLab and use of third-party volunteers via DemocracyLab.
+          </li>
+          <li>I am offering volunteering projects that are civic, charitable, or humanitarian in nature.</li>
+          <li>I accept third-party volunteers that are offering their assistance solely for their own personal civic, charitable, or humanitarian reasons.</li>
+          <li>I have not promised and will not provide compensation or benefits to any third-party volunteer in exchange for their services.</li>
+          <li>I am receiving volunteer services directly from each third-party volunteer and any associated liability is entirely with that volunteer, not with DemocracyLab.</li>
+          <li>
+            I acknowledge that third-party volunteers will perform the project tasks on a temporary, fully-independent basis
+            without significant and ongoing control of work schedules and conditions by my organization.
+          </li>
+          <li>I will not accept via DemocracyLab volunteer services from an employee of my organization.</li>
+          <li>
+            I grant DemocracyLab permission to use all photographs, images, video, or audio recordings of my organization and logo
+            in connection with my use of DemocracyLab and attendance at DemocracyLab events.
+          </li>
+          <li>I acknowledge that DemocracyLab may change these terms and may modify or discontinue the site or services at its sole discretion.</li>
+          <li>
+            I agree that DemocracyLab may terminate my membership or use of the site and services without prior notice and remove and discard my content
+            from the site for any reason, including if DemocracyLab believes I have violated these terms.
+          </li>
+        </ul>
+      </React.Fragment>
     );
   }
 }

--- a/common/components/common/confirmation/TermsModal.jsx
+++ b/common/components/common/confirmation/TermsModal.jsx
@@ -2,8 +2,18 @@
 
 import React from 'react';
 import NotificationModal from "../notification/NotificationModal.jsx";
+import type {Dictionary} from "../../types/Generics.jsx";
+import _ from "lodash";
+
+export const TermsTypes: Dictionary<string> = {
+  UserSignup: "UserSignup",
+  OrgSignup: "OrgSignup"
+};
+
+export type TermsType = $Keys<typeof TermsTypes>;
 
 type Props = {|
+  termsType: TermsType,
   showModal: boolean,
   onSelection: () => void
 |};
@@ -17,6 +27,10 @@ type State = {|
 class TermsModal extends React.PureComponent<Props, State> {
   constructor(props: Props): void {
     super(props);
+    this.termsDictionary = _.fromPairs([
+      [TermsTypes.UserSignup, this._renderUserSignupTerms],
+      [TermsTypes.OrgSignup, this._renderOrgSignupTerms]
+    ]);
     this.state = {
       showModal: false
     }
@@ -37,20 +51,44 @@ class TermsModal extends React.PureComponent<Props, State> {
     return (
       <NotificationModal headerText="Terms of Volunteering" buttonText="Close and Continue" showModal={this.state.showModal} onClickButton={this.confirm.bind(this)}>
         <div className="Terms-body">
-          <ul>
-            <li>I am volunteering solely for my personal purposes or pleasure, including for civic, charitable, or humanitarian reasons.</li>
-            <li>I am freely donating my volunteer services and have no expectation of receiving and have not been promised compensation or benefits in exchange for any assistance I provide to project owners.</li>
-            <li>I am donating my volunteer services to the owner of a tech-for-good project, not to DemocracyLab itself, and any associated liability is entirely with that project owner.</li>
-            <li>I release and forever discharge and hold harmless DemocracyLab from any and all liability, claims, and demands related to my volunteering for third-party project owners, use of the DemocracyLab website, and attendance at DemocracyLab events. </li>
-            <li>I understand that if I am responsible for injuries or property damage to project owners or others while acting outside the scope of volunteer assignments, that I may be held personally liable by the injured party.</li>
-            <li>I will perform the project tasks on a temporary, fully-independent basis without significant and ongoing control of work schedules and conditions by the project owner.</li>
-            <li>I am not volunteering for an organization with which I am employed nor am I expecting to receive a job offer from a project owner.</li>
-            <li>I will not perform the type of work an employee would typically perform for a project owner’s customers or clients nor will I supervise employees of a project owner. I will use my own tools and equipment and will not seek reimbursement for any purchases of materials or supplies.</li>
-            <li>I grant DemocracyLab permission to use all photographs, images, video, or audio recordings of me in connection with my attendance at DemocracyLab events or volunteering for project owners.</li>
-            <li>I am at least 18 years old and possess the authority to bind myself to this agreement.</li>
-          </ul>
+          {this.termsDictionary[this.props.termsType]()}
         </div>
       </NotificationModal>
+    );
+  }
+  
+  _renderUserSignupTerms(): React$Node {
+    return (
+      <ul>
+        <li>I am volunteering solely for my personal purposes or pleasure, including for civic, charitable, or humanitarian reasons.</li>
+        <li>I am freely donating my volunteer services and have no expectation of receiving and have not been promised compensation or benefits in exchange for any assistance I provide to project owners.</li>
+        <li>I am donating my volunteer services to the owner of a tech-for-good project, not to DemocracyLab itself, and any associated liability is entirely with that project owner.</li>
+        <li>I release and forever discharge and hold harmless DemocracyLab from any and all liability, claims, and demands related to my volunteering for third-party project owners, use of the DemocracyLab website, and attendance at DemocracyLab events. </li>
+        <li>I understand that if I am responsible for injuries or property damage to project owners or others while acting outside the scope of volunteer assignments, that I may be held personally liable by the injured party.</li>
+        <li>I will perform the project tasks on a temporary, fully-independent basis without significant and ongoing control of work schedules and conditions by the project owner.</li>
+        <li>I am not volunteering for an organization with which I am employed nor am I expecting to receive a job offer from a project owner.</li>
+        <li>I will not perform the type of work an employee would typically perform for a project owner’s customers or clients nor will I supervise employees of a project owner. I will use my own tools and equipment and will not seek reimbursement for any purchases of materials or supplies.</li>
+        <li>I grant DemocracyLab permission to use all photographs, images, video, or audio recordings of me in connection with my attendance at DemocracyLab events or volunteering for project owners.</li>
+        <li>I am at least 18 years old and possess the authority to bind myself to this agreement.</li>
+      </ul>
+    );
+  }
+  
+  _renderOrgSignupTerms(): React$Node {
+    // TODO: Replace with text
+    return (
+      <ul>
+        <li>I am volunteering solely for my personal purposes or pleasure, including for civic, charitable, or humanitarian reasons.</li>
+        <li>I am freely donating my volunteer services and have no expectation of receiving and have not been promised compensation or benefits in exchange for any assistance I provide to project owners.</li>
+        <li>I am donating my volunteer services to the owner of a tech-for-good project, not to DemocracyLab itself, and any associated liability is entirely with that project owner.</li>
+        <li>I release and forever discharge and hold harmless DemocracyLab from any and all liability, claims, and demands related to my volunteering for third-party project owners, use of the DemocracyLab website, and attendance at DemocracyLab events. </li>
+        <li>I understand that if I am responsible for injuries or property damage to project owners or others while acting outside the scope of volunteer assignments, that I may be held personally liable by the injured party.</li>
+        <li>I will perform the project tasks on a temporary, fully-independent basis without significant and ongoing control of work schedules and conditions by the project owner.</li>
+        <li>I am not volunteering for an organization with which I am employed nor am I expecting to receive a job offer from a project owner.</li>
+        <li>I will not perform the type of work an employee would typically perform for a project owner’s customers or clients nor will I supervise employees of a project owner. I will use my own tools and equipment and will not seek reimbursement for any purchases of materials or supplies.</li>
+        <li>I grant DemocracyLab permission to use all photographs, images, video, or audio recordings of me in connection with my attendance at DemocracyLab events or volunteering for project owners.</li>
+        <li>I am at least 18 years old and possess the authority to bind myself to this agreement.</li>
+      </ul>
     );
   }
 }

--- a/common/components/componentsBySection/CreateProject/ProjectOverviewForm.jsx
+++ b/common/components/componentsBySection/CreateProject/ProjectOverviewForm.jsx
@@ -47,7 +47,7 @@ class ProjectOverviewForm extends React.PureComponent<Props,State> {
       project_short_description: project ? project.project_short_description : "",
       project_issue_area: project ? project.project_issue_area : [],
       project_thumbnail: project ? project.project_thumbnail : "",
-      didCheckTerms: false
+      didCheckTerms: !!project
     };
     const validations: $ReadOnlyArray<Validator<FormFields>> = [
       {
@@ -130,18 +130,19 @@ class ProjectOverviewForm extends React.PureComponent<Props,State> {
                     value={this.state.formFields.project_short_description} onChange={this.form.onInput.bind(this, "project_short_description")}></textarea>
         </div>
   
-        {/*TODO: Don't show if project has been created*/}
-        <div>
-          <CheckBox
-            id="didCheckTerms"
-            value={this.state.formFields.didCheckTerms}
-            onCheck={this.form.onSelection.bind(this, "didCheckTerms")}
-          />
-          <span>
+        { !this.props.project &&
+          <div>
+            <CheckBox
+              id="didCheckTerms"
+              value={this.state.formFields.didCheckTerms}
+              onCheck={this.form.onSelection.bind(this, "didCheckTerms")}
+            />
+            <span>
             {" "}I have read and accepted the
-            {" "}<PseudoLink text="Terms of Volunteering" onClick={e => this.setState({termsOpen: true})}/>
-          </span>
-        </div>
+              {" "}<PseudoLink text="Terms of Volunteering" onClick={e => this.setState({termsOpen: true})}/>
+            </span>
+          </div>
+        }
   
         <TermsModal
           termsType={TermsTypes.OrgSignup}

--- a/common/components/componentsBySection/CreateProject/ProjectOverviewForm.jsx
+++ b/common/components/componentsBySection/CreateProject/ProjectOverviewForm.jsx
@@ -60,7 +60,7 @@ class ProjectOverviewForm extends React.PureComponent<Props,State> {
       },
       {
         checkFunc: (formFields: FormFields) => formFields.didCheckTerms,
-        errorMessage: "Agree to terms of service"
+        errorMessage: "Agree to Terms of Use"
       }
     ];
 
@@ -139,7 +139,7 @@ class ProjectOverviewForm extends React.PureComponent<Props,State> {
             />
             <span>
             {" "}I have read and accepted the
-              {" "}<PseudoLink text="Terms of Volunteering" onClick={e => this.setState({termsOpen: true})}/>
+              {" "}<PseudoLink text="Terms of Use" onClick={e => this.setState({termsOpen: true})}/>
             </span>
           </div>
         }

--- a/common/components/componentsBySection/CreateProject/ProjectOverviewForm.jsx
+++ b/common/components/componentsBySection/CreateProject/ProjectOverviewForm.jsx
@@ -10,6 +10,9 @@ import FormValidation from "../../../components/forms/FormValidation.jsx";
 import type {Validator} from "../../../components/forms/FormValidation.jsx";
 import type {TagDefinition, ProjectDetailsAPIData} from "../../../components/utils/ProjectAPIUtils.js";
 import formHelper, {FormPropsBase, FormStateBase} from "../../utils/forms.js";
+import TermsModal, {TermsTypes} from "../../common/confirmation/TermsModal.jsx";
+import PseudoLink from "../../chrome/PseudoLink.jsx";
+import CheckBox from "../../common/selection/CheckBox.jsx";
 import _ from "lodash";
 
 
@@ -18,6 +21,7 @@ type FormFields = {|
   project_short_description: ?string,
   project_issue_area?: Array<TagDefinition>,
   project_thumbnail?: FileInfo,
+  didCheckTerms: boolean
 |};
 
 type Props = {|
@@ -26,6 +30,7 @@ type Props = {|
 |} & FormPropsBase<FormFields>;
 
 type State = {|
+  termsOpen: boolean,
   formIsValid: boolean,
   validations: $ReadOnlyArray<Validator>
 |} & FormStateBase<FormFields>;
@@ -41,7 +46,8 @@ class ProjectOverviewForm extends React.PureComponent<Props,State> {
       project_name: project ? project.project_name : "",
       project_short_description: project ? project.project_short_description : "",
       project_issue_area: project ? project.project_issue_area : [],
-      project_thumbnail: project ? project.project_thumbnail : ""
+      project_thumbnail: project ? project.project_thumbnail : "",
+      didCheckTerms: false
     };
     const validations: $ReadOnlyArray<Validator<FormFields>> = [
       {
@@ -51,6 +57,10 @@ class ProjectOverviewForm extends React.PureComponent<Props,State> {
       {
         checkFunc: (formFields: FormFields) => !_.isEmpty(formFields["project_short_description"]),
         errorMessage: "Please enter Project Description"
+      },
+      {
+        checkFunc: (formFields: FormFields) => formFields.didCheckTerms,
+        errorMessage: "Agree to terms of service"
       }
     ];
 
@@ -58,7 +68,8 @@ class ProjectOverviewForm extends React.PureComponent<Props,State> {
     this.state = {
       formIsValid: formIsValid,
       formFields: formFields,
-      validations: validations
+      validations: validations,
+      termsOpen: false
     };
     props.readyForSubmit(formIsValid);
     this.form = formHelper.setup();
@@ -118,6 +129,25 @@ class ProjectOverviewForm extends React.PureComponent<Props,State> {
                     placeholder="Give a one-sentence description of this project" rows="2" maxLength="140"
                     value={this.state.formFields.project_short_description} onChange={this.form.onInput.bind(this, "project_short_description")}></textarea>
         </div>
+  
+        {/*TODO: Don't show if project has been created*/}
+        <div>
+          <CheckBox
+            id="didCheckTerms"
+            value={this.state.formFields.didCheckTerms}
+            onCheck={this.form.onSelection.bind(this, "didCheckTerms")}
+          />
+          <span>
+            {" "}I have read and accepted the
+            {" "}<PseudoLink text="Terms of Volunteering" onClick={e => this.setState({termsOpen: true})}/>
+          </span>
+        </div>
+  
+        <TermsModal
+          termsType={TermsTypes.OrgSignup}
+          showModal={this.state.termsOpen}
+          onSelection={() => this.setState({termsOpen: false})}
+        />
 
         <FormValidation
           validations={this.state.validations}

--- a/common/components/controllers/SignUpController.jsx
+++ b/common/components/controllers/SignUpController.jsx
@@ -10,7 +10,7 @@ import _ from 'lodash';
 import Headers from "../common/Headers.jsx";
 import PseudoLink from "../chrome/PseudoLink.jsx";
 import SocialMediaSignupSection from "../common/integrations/SocialMediaSignupSection.jsx";
-import TermsModal from "../common/confirmation/TermsModal.jsx";
+import TermsModal,{TermsTypes} from "../common/confirmation/TermsModal.jsx";
 
 type Props = {|
   +errors: {+[key: string]: $ReadOnlyArray<string>},
@@ -185,7 +185,11 @@ class SignUpController extends React.Component<Props, State> {
             
           </div>
           
-          <TermsModal showModal={this.state.termsOpen} onSelection={() => this.setState({termsOpen: false})}/>
+          <TermsModal
+            termsType={TermsTypes.UserSignup}
+            showModal={this.state.termsOpen}
+            onSelection={() => this.setState({termsOpen: false})}
+          />
 
           {/* TODO: Replace with visible forms, or modify backend. */}
           <input name="username" value={this.state.email} type="hidden" />


### PR DESCRIPTION
# Overview # 
Besides users agreeing to terms of service (that primarily governs their activities as a volunteer), we want project owners to agree to  certain terms as well.

## Create Project Page ##
- Require creator to check box signifying they agree with terms of service
- Provide link to modal that shows organization terms of service