### PR TITLE
resize homepage section font to fix viewport error

### DIFF
--- a/civictechprojects/static/css/partials/_LandingController.scss
+++ b/civictechprojects/static/css/partials/_LandingController.scss
@@ -47,7 +47,7 @@
   margin-right: auto;
 }
 .LandingController-root .SplashScreen-content h1 {
-  font-size: 3rem;
+  font-size: 2rem; /* at small display sizes 3rem is too big for a single word to fit */
 }
 .LandingController-topsplash .SplashScreen-content h1 {
   font-size: 4rem;
@@ -200,6 +200,9 @@
       flex-basis: 45%;
       min-width: 45%;
     }
+  }
+  .LandingController-root .SplashScreen-content h1 {
+    font-size: 3rem; 
   }
 }
 


### PR DESCRIPTION
Fixes #466.

The word "Accelerating" at the defined font size (3rem / 48px) was too wide for narrow phone viewports, leading to the behavior described above. As we're in the process of redoing the homepage entirely, I just made a narrowly scoped fix and shrunk the font size for this element only on small displays.
