### PR TITLE
Don't show un-approved group/project relationships

### DIFF
--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -274,7 +274,9 @@ class Group(Archived):
         thumbnail_files = list(files.filter(file_category=FileCategory.THUMBNAIL.value))
         other_files = list(files.filter(file_category=FileCategory.ETC.value))
         links = ProjectLink.objects.filter(link_group=self.id)
-        project_relationships = ProjectRelationship.objects.filter(relationship_group=self.id, relationship_project__is_searchable=True)
+        project_relationships = ProjectRelationship.objects\
+            .filter(relationship_group=self.id, relationship_project__is_searchable=True)\
+            .filter(is_approved=True)
 
         group = {
             'group_creator': self.group_creator.id,

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -388,7 +388,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
     }
   
   _renderGroups(project: ?ProjectDetailsAPIData): ?Array<React$Node> {
-    const groups: ?$ReadOnlyArray<MyGroupData> = project && project.project_groups && project.project_groups.filter((group) => group.relationship_is_approved);
+    const groups: ?$ReadOnlyArray<MyGroupData> = project && project.project_groups && project.project_groups.filter((group) => group.isApproved && group.relationship_is_approved);
     return !_.isEmpty(groups) &&
       (
         <React.Fragment>

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -25,6 +25,7 @@ import url from "../../utils/url.js";
 import Section from "../../enums/Section.js";
 import {Glyph, GlyphStyles, GlyphSizes} from '../../utils/glyphs.js';
 import EventCardsListings from "../../componentsBySection/FindEvents/EventCardsListings.jsx";
+import type {MyGroupData} from "../../stores/MyGroupsStore.js";
 
 
 
@@ -156,23 +157,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
             </React.Fragment>
           }
 
-          {project && !_.isEmpty(project.project_groups) &&
-            <React.Fragment>
-              <div className='AboutProjects-groups'>
-                <h4>Groups</h4>
-                <ul>
-                  {
-                    project.project_groups.map((group, i) => {
-                      return <li key={i}>{this._renderGroupIcon(group)} <a href={url.section(Section.AboutGroup, {id: group.group_id})}>{group.group_name}</a></li>
-                    })
-                  }
-                </ul>
-              </div>
-
-            </React.Fragment>
-          }
-
-          {/*TODO: Groups section*/}
+          {this._renderGroups(project)}
 
           <div className='AboutProjects-team'>
             {
@@ -401,6 +386,25 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
         />;
       });
     }
+  
+  _renderGroups(project: ?ProjectDetailsAPIData): ?Array<React$Node> {
+    const groups: ?$ReadOnlyArray<MyGroupData> = project && project.project_groups && project.project_groups.filter((group) => group.relationship_is_approved);
+    return !_.isEmpty(groups) &&
+      (
+        <React.Fragment>
+          <div className='AboutProjects-groups'>
+            <h4>Groups</h4>
+            <ul>
+              {
+                project.project_groups.map((group, i) => {
+                  return <li key={i}>{this._renderGroupIcon(group)} <a href={url.section(Section.AboutGroup, {id: group.group_id})}>{group.group_name}</a></li>
+                })
+              }
+            </ul>
+          </div>
+        </React.Fragment>
+      );
+  }
 
     _renderGroupIcon(group): ?Array<React$Node> {
       return (


### PR DESCRIPTION
Currently, if a group/project relationship is un-approved (either hasn't been approved or the approval has been revoked), the group profile still shows the project listed, and the project profile still lists the group.