### PR TITLE
Caching Fixes

### DIFF
--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -172,6 +172,7 @@ class EventCreationForm(ModelForm):
             post_change_projects = event.get_linked_projects()
             if post_change_projects: 
                 change_projects += post_change_projects.all()
+            change_projects = list(set(change_projects))
             if change_projects:
                 for project in change_projects:
                     project.recache(recache_linked=False)

--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -163,7 +163,7 @@ class EventCreationForm(ModelForm):
         if is_created_original != event.is_created:
             send_event_creation_notification(event)
 
-        if fields_changed:
+        if fields_changed or project_fields_changed:
             event.recache()
         if project_fields_changed:
             event.update_linked_items()

--- a/civictechprojects/forms.py
+++ b/civictechprojects/forms.py
@@ -166,10 +166,15 @@ class EventCreationForm(ModelForm):
         if fields_changed or project_fields_changed:
             event.recache()
         if project_fields_changed:
-            event.update_linked_items()
+            change_projects = []
             if pre_change_projects:
-                for project in pre_change_projects:
-                    project.recache()
+                change_projects += pre_change_projects
+            post_change_projects = event.get_linked_projects()
+            if post_change_projects: 
+                change_projects += post_change_projects.all()
+            if change_projects:
+                for project in change_projects:
+                    project.recache(recache_linked=False)
 
         return event
 

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -206,11 +206,12 @@ class Project(Archived):
         self.project_date_modified = time or timezone.now()
         self.save()
 
-    def recache(self):
+    def recache(self, recache_linked=True):
         hydrated_project = self._hydrate_to_json()
         ProjectCache.refresh(self, hydrated_project)
         self.generate_full_text()
-        self.update_linked_items()
+        if recache_linked:
+            self.update_linked_items()
 
     def update_linked_items(self):
         # Recache events
@@ -505,7 +506,7 @@ class Event(Archived):
         projects = self.get_linked_projects()
         if projects:
             for project in projects:
-                project.recache()
+                project.recache(recache_linked=False)
 
     def recache(self):
         hydrated_event = self._hydrate_to_json()

--- a/common/management/commands/cache_initialization.py
+++ b/common/management/commands/cache_initialization.py
@@ -5,7 +5,7 @@ def cache_projects():
     from civictechprojects.models import Project
     projects_to_cache = Project.objects.filter(is_searchable=True, deleted=False)
     for project in projects_to_cache:
-        project.recache()
+        project.recache(recache_linked=False)
 
 
 def cache_events():


### PR DESCRIPTION
# Bug Fixes #
## Create Event ##
- Recache event when project-linked fields are updated
## Caching ##
- When recaching projects upon an event update, don't recache the project's linked events
- cache_initialization job: Don't re-cache project linked events since all events are being recached in the same job