### PR TITLE
Add Project Details section headers, conditionally render

### DIFF
--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -185,6 +185,9 @@
 .AboutProjects-details-description {
     white-space: pre-wrap;
 }
+.AboutProjects-details-sectionheader {
+    font-size: 1.25rem;
+}
 
 .AboutProjects-skills-container {
   display: flex;

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -242,11 +242,14 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
           <div className='AboutProjects-details AboutProjects-details-description'>
             <div className="position-relative"><a className="position-absolute AboutProjects-jumplink" id="project-details" name="project-details"></a></div>
             <div>
+              {!_.isEmpty(project.project_description_solution || project.project_description.actions) && 
+                <h3 className="AboutProjects-details-sectionheader">Problem</h3>
+              }
               {project.project_description}
               {!_.isEmpty(project.project_description_solution) &&
                 <React.Fragment>
-                  <div>
-                    <br></br>
+                  <div>                    
+                    <h3 className="AboutProjects-details-sectionheader pt-4">Solution</h3>
                     {project.project_description_solution}
                   </div>
                 </React.Fragment>
@@ -254,7 +257,8 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
               {!_.isEmpty(project.project_description_actions) &&
                 <React.Fragment>
                   <div>
-                    <br></br>
+                    
+                    <h3 className="AboutProjects-details-sectionheader pt-4">Action</h3>
                     {project.project_description_actions}
                   </div>
                 </React.Fragment>


### PR DESCRIPTION
On a given project profile page, this should render the "Problem/Solution/Action" headers (mirroring the Create Project workflow, which asks for these) as follows:

If a project has only the "Problem" field, it will not have a header.
If a project has Problem _and_ Solution or Action, the Problem section will have a header.
If Solution exists, it will always have a header.
If Action exists, it will always have a header.

Headers are styled to match similar headers on the rest of the profile page.