### PR TITLE
 Used cached project data to render project cards

### DIFF
--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -10,7 +10,7 @@ from taggit.managers import TaggableManager
 from taggit.models import TaggedItemBase
 from civictechprojects.caching.cache import ProjectCache, EventCache
 from common.helpers.form_helpers import is_json_field_empty, is_creator_or_staff
-from common.helpers.dictionaries import merge_dicts
+from common.helpers.dictionaries import merge_dicts, keys_subset
 from common.helpers.collections import flatten, count_occurrences
 
 # Without the following classes, the following error occurs:
@@ -162,30 +162,12 @@ class Project(Archived):
         return project
 
     def hydrate_to_tile_json(self):
-        files = ProjectFile.objects.filter(file_project=self.id)
-        thumbnail_files = list(files.filter(file_category=FileCategory.THUMBNAIL.value))
-        positions = ProjectPosition.objects.filter(position_project=self.id)
+        keys = [
+            'project_id', 'project_name', 'project_creator', 'project_description', 'project_url', 'project_location', 'project_country', 
+            'project_state', 'project_city', 'project_issue_area', 'project_stage', 'project_positions', 'project_date_modified', 'project_thumbnail'
+        ]
 
-        project = {
-            'project_id': self.id,
-            'project_name': self.project_name,
-            'project_creator': self.project_creator.id,
-            'project_description': self.project_short_description if self.project_short_description else self.project_description,
-            'project_url': self.project_url,
-            'project_location': self.project_location,
-            'project_country': self.project_country,
-            'project_state': self.project_state,
-            'project_city': self.project_city,
-            'project_issue_area': Tag.hydrate_to_json(self.id, list(self.project_issue_area.all().values())),
-            'project_stage': Tag.hydrate_to_json(self.id, list(self.project_stage.all().values())),
-            'project_positions': list(map(lambda position: position.to_json(), positions)),
-            'project_date_modified': self.project_date_modified.__str__()
-        }
-
-        if len(thumbnail_files) > 0:
-            project['project_thumbnail'] = thumbnail_files[0].to_json()
-
-        return project
+        return keys_subset(self.hydrate_to_json(), keys)
 
     def hydrate_to_list_json(self):
         project = {

--- a/common/helpers/dictionaries.py
+++ b/common/helpers/dictionaries.py
@@ -8,3 +8,11 @@ def merge_dicts(*dict_args):
     for dictionary in dict_args:
         result.update(dictionary)
     return result
+
+
+def keys_subset(base_dict, keys):
+    """
+    Generate a dictionary that contains a subset of the entries of the base dictionary
+    with the given keys
+    """
+    return dict((k, base_dict[k]) for k in keys if k in base_dict) 

--- a/common/tests/test_helpers.py
+++ b/common/tests/test_helpers.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.test import TestCase
 from common.helpers.caching import is_sitemap_url
 from common.helpers.constants import FrontEndSection
+from common.helpers.dictionaries import merge_dicts, keys_subset
 from common.helpers.front_end import section_path, section_url, get_page_section, get_clean_url
 from civictechprojects.sitemaps import SitemapPages
 
@@ -37,4 +38,14 @@ class FrontEndHelperTests(TestCase):
     def test_get_page_section(self):
         expected = 'AboutEvent'
         self.assertEqual(expected, get_page_section('/index/?section=AboutEvent&id=test-slug'))
-        
+
+
+class DictionaryHelperTests(TestCase):
+    def test_merge_dicts(self):
+        dict_a = {'a': 1, 'b': 2}
+        dict_b = {'b': 2, 'c': 3}
+        self.assertEqual({'a': 1, 'b': 2, 'c': 3}, merge_dicts(dict_a, dict_b))
+
+    def test_keys_subset(self):
+        dict_a = {'a': 1, 'b': 2, 'c': 3}
+        self.assertEqual({'a': 1, 'c': 3}, keys_subset(dict_a, ['a', 'c']))


### PR DESCRIPTION
To fix performance issues on the Find Project page. we now leverage the already-cached project json (which includes the thumbnail), and this greatly improves the rendering performance.

Addresses #522

## Other Changes ##
- Added unit tests for dictionary helpers