### PR TITLE
Bootstrap Cleanup

### DIFF
--- a/civictechprojects/static/css/_bootstrapoverride.scss
+++ b/civictechprojects/static/css/_bootstrapoverride.scss
@@ -16,11 +16,11 @@ $grid-breakpoints: (
 );
 
 $container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1140px,
-  xxl: 1400px
+  sm: 540px, // 12 col @ 45px/ea inc. gutters
+  md: 720px, // 12 col @ 60px/ea inc. gutters
+  lg: 960px, // 12 col @ 80px/ea inc. gutters
+  xl: 1140px, // 12 col @ 95px/ea inc. gutters
+  xxl: 1392px, // 12 col @ 116px/ea inc. gutters
 );
 
 //define our font stack

--- a/civictechprojects/static/css/partials/_Global.scss
+++ b/civictechprojects/static/css/partials/_Global.scss
@@ -8,39 +8,44 @@ body {
   background-color: $color-background-light;
   color: $color-text-dark;
 }
-.btn-footer a, .btn-footer a[type="button"] {
+.btn-footer a,
+.btn-footer a[type="button"] {
   color: $color-text-dark;
   text-decoration: none;
 }
-.btn-footer:hover, .btn-footer:active {
+.btn-footer:hover,
+.btn-footer:active {
   background-color: $color-orange-light;
   color: $color-text-dark;
   border-color: $color-orange-dark;
 }
-a.btn-footer:hover, a.btn-footer:active, a[type="button"].btn-footer:hover, a[type="button"].btn-footer:active  {
+a.btn-footer:hover,
+a.btn-footer:active,
+a[type="button"].btn-footer:hover,
+a[type="button"].btn-footer:active {
   text-decoration: none;
 }
 
 //Sets button states to be our specific values instead of default computed by Bootstrap
 //I don't think we're going to call these colors manually at any point so no vars here
-.btn-success:active, .btn-success:hover {
+.btn-success:active,
+.btn-success:hover {
   background-color: #395e00;
 }
-.btn-danger:active, .btn-danger:hover {
+.btn-danger:active,
+.btn-danger:hover {
   background-color: #b20000;
 }
-.btn-info:active, .btn-info:hover {
+.btn-info:active,
+.btn-info:hover {
   background-color: #025d87;
 }
-
 
 //Global override of disabled state input elements
 input[type="submit"]:disabled {
   background: $color-grey-disabled;
   border: $color-disabled-border;
 }
-
-
 
 //for on-page actions we want to appear as links
 .pseudo-link {
@@ -54,6 +59,9 @@ input[type="submit"]:disabled {
 }
 
 // .bounded-content should be used inside a .container-fluid; letting us have full width background with .container width content */
+.bounded-content {
+  margin: auto;
+}
 @include media-breakpoint-up(sm) {
   .bounded-content {
     width: 540px;
@@ -77,7 +85,7 @@ input[type="submit"]:disabled {
 }
 @include media-breakpoint-up(xxl) {
   .bounded-content {
-    width: 1400px;
+    width: 1392px;
   }
 }
 

--- a/common/components/common/groups/AboutGroupDisplay.jsx
+++ b/common/components/common/groups/AboutGroupDisplay.jsx
@@ -123,7 +123,7 @@ class AboutGroupDisplay extends React.PureComponent<Props, State> {
               </div>
               }
             </div>
-            <div className="container-fluid AboutGroup-card-container">
+            <div className="AboutGroup-card-container">
               <div className="row">
                 {this.state.approvedProjects && this._renderProjectList()}
               </div>

--- a/common/components/componentsBySection/CreateEvent/AboutEventDisplay.jsx
+++ b/common/components/componentsBySection/CreateEvent/AboutEventDisplay.jsx
@@ -1,62 +1,66 @@
 // @flow
 
-import React from 'react';
-import type Moment from 'moment';
-import datetime, {DateFormat} from "../../utils/datetime.js";
-import Button from 'react-bootstrap/Button';
+import React from "react";
+import type Moment from "moment";
+import datetime, { DateFormat } from "../../utils/datetime.js";
+import Button from "react-bootstrap/Button";
 import CurrentUser from "../../utils/CurrentUser.js";
-import {EventData} from "../../utils/EventAPIUtils.js";
+import { EventData } from "../../utils/EventAPIUtils.js";
 import urlHelper from "../../utils/url.js";
 import Section from "../../enums/Section";
 import ProjectCardsContainer from "../FindProjects/ProjectCardsContainer.jsx";
 import ProjectSearchDispatcher from "../../stores/ProjectSearchDispatcher.js";
 import _ from "lodash";
 
-
 type Props = {|
   event: ?EventData,
-  viewOnly: boolean
+  viewOnly: boolean,
 |};
 
 type State = {|
-  event: ?EventData
+  event: ?EventData,
 |};
 
 class AboutEventDisplay extends React.PureComponent<Props, State> {
-  constructor(props: Props): void{
+  constructor(props: Props): void {
     super();
     this.state = {
-      event: props.event
+      event: props.event,
     };
 
-    if(this.state.event) {
+    if (this.state.event) {
       this.filterProjectsByOrgTag();
     }
- }
+  }
 
   componentWillReceiveProps(nextProps: Props): void {
-    if(nextProps.event !== this.props.event) {
-      this.setState({
-        event: nextProps.event
-      }, this.filterProjectsByOrgTag);
+    if (nextProps.event !== this.props.event) {
+      this.setState(
+        {
+          event: nextProps.event,
+        },
+        this.filterProjectsByOrgTag
+      );
     }
   }
 
   render(): ?$React$Node {
-    const event:EventData = this.state.event;
+    const event: EventData = this.state.event;
     const startDate: Moment = datetime.parse(event.event_date_start);
     const endDate: Moment = datetime.parse(event.event_date_end);
-    const isSingleDayEvent: boolean = datetime.isOnSame('day', startDate, endDate);
+    const isSingleDayEvent: boolean = datetime.isOnSame(
+      "day",
+      startDate,
+      endDate
+    );
     return !event ? null : (
       <div className="AboutEvent-root container">
-
         <div className="AboutEvent-title row">
           <div className="col-12 AboutEvent-header">
-          {
-            !this.props.viewOnly
-            && (CurrentUser.userID() === this.state.event.event_creator || CurrentUser.isStaff())
-            && this._renderEditButton()
-          }
+            {!this.props.viewOnly &&
+              (CurrentUser.userID() === this.state.event.event_creator ||
+                CurrentUser.isStaff()) &&
+              this._renderEditButton()}
             <div className="AboutEvent-title-date">
               {startDate.format(DateFormat.MONTH_DATE_YEAR)}
             </div>
@@ -76,36 +80,44 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
                     <p>{this.state.event.event_organizers_text}</p>
                   </div>
                 </React.Fragment>
-              )
-              }
-              
-              {isSingleDayEvent ? this._renderDateTimeSections(startDate, endDate) : this._renderDatesSection(startDate, endDate)}
-              
+              )}
+
+              {isSingleDayEvent
+                ? this._renderDateTimeSections(startDate, endDate)
+                : this._renderDatesSection(startDate, endDate)}
+
               <h5 className="AboutEvent-info-header">Location</h5>
               <div className="AboutEvent-location">
                 <p>{this.state.event.event_location}</p>
               </div>
 
               {this.state.event.event_rsvp_url && this._renderRSVPButton()}
-              {!this.props.viewOnly && event.event_live_id && this._renderJoinLiveEventButton()}
+              {!this.props.viewOnly &&
+                event.event_live_id &&
+                this._renderJoinLiveEventButton()}
             </div>
           </div>
           <div className="col-xs-12 col-lg-8 AboutEvent-splash">
-              <img src={event.event_thumbnail && event.event_thumbnail.publicUrl} />
+            <img
+              src={event.event_thumbnail && event.event_thumbnail.publicUrl}
+            />
           </div>
         </div>
 
-        <div className="AboutEvent-details col-12">
-          <h3>Details</h3>
-          <p>{event.event_description}</p>
-          <h3>What We Will Do</h3>
-          <p>{event.event_agenda}</p>
+        <div className="AboutEvent-details row">
+          <div className="col-12">
+            <h3>Details</h3>
+            <p>{event.event_description}</p>
+            <h3>What We Will Do</h3>
+            <p>{event.event_agenda}</p>
+          </div>
         </div>
-        {!_.isEmpty(event.event_legacy_organization) && this._renderProjectList()}
+        {!_.isEmpty(event.event_legacy_organization) &&
+          this._renderProjectList()}
       </div>
-    )
+    );
   }
-  
+
   _renderDatesSection(startDate: Moment, endDate: Moment): $React$Node {
     return (
       <React.Fragment>
@@ -116,15 +128,19 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
       </React.Fragment>
     );
   }
-  
+
   _renderDateTimeSections(startDate: Moment, endDate: Moment): $React$Node {
     return (
       <React.Fragment>
         <h5 className="AboutEvent-info-header">Date</h5>
         <p>{startDate.format(DateFormat.DAY_MONTH_DATE_YEAR)}</p>
-  
+
         <h5 className="AboutEvent-info-header">Time</h5>
-        <p>{startDate.format(DateFormat.TIME) + " - " + endDate.format(DateFormat.TIME_TIMEZONE)}</p>
+        <p>
+          {startDate.format(DateFormat.TIME) +
+            " - " +
+            endDate.format(DateFormat.TIME_TIMEZONE)}
+        </p>
       </React.Fragment>
     );
   }
@@ -135,7 +151,9 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
         variant="primary"
         className="AboutEvent-edit-btn"
         type="button"
-        href={urlHelper.section(Section.CreateEvent, {id: this.state.event.event_id})}
+        href={urlHelper.section(Section.CreateEvent, {
+          id: this.state.event.event_id,
+        })}
       >
         Edit Event
       </Button>
@@ -143,9 +161,12 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
   }
 
   _renderRSVPButton(): ?$React$Node {
-    const eventbriteTest = new RegExp("eventbrite\.com", "i");
-    const url: string = urlHelper.appendHttpIfMissingProtocol(this.state.event.event_rsvp_url);
-    const text: string = "RSVP" + (eventbriteTest.test(url) ? " on Eventbrite" : "");
+    const eventbriteTest = new RegExp("eventbrite.com", "i");
+    const url: string = urlHelper.appendHttpIfMissingProtocol(
+      this.state.event.event_rsvp_url
+    );
+    const text: string =
+      "RSVP" + (eventbriteTest.test(url) ? " on Eventbrite" : "");
     return (
       <Button
         variant="primary"
@@ -161,11 +182,13 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
   _renderJoinLiveEventButton(): ?$React$Node {
     let text: string = "";
     let url: string = "";
-    if(CurrentUser.isLoggedIn()) {
+    if (CurrentUser.isLoggedIn()) {
       //TODO: Handle un-verified users
       text = "Join Event";
       //TODO: Incorporate live event id into Live Event page
-      url = urlHelper.section(Section.LiveEvent, {id: this.props.event.event_live_id});
+      url = urlHelper.section(Section.LiveEvent, {
+        id: this.props.event.event_live_id,
+      });
     } else {
       text = "Log In to Join Event";
       url = urlHelper.logInThenReturn();
@@ -192,11 +215,12 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
         type: "INIT",
         findProjectsArgs: {
           org: event.event_legacy_organization[0].tag_name,
-          sortField: "project_name"
+          sortField: "project_name",
         },
         searchSettings: {
-          updateUrl: false
-        }});
+          updateUrl: false,
+        },
+      });
     }
   }
 

--- a/common/components/componentsBySection/CreateEvent/AboutEventDisplay.jsx
+++ b/common/components/componentsBySection/CreateEvent/AboutEventDisplay.jsx
@@ -230,7 +230,6 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
         <ProjectCardsContainer
           showSearchControls={false}
           staticHeaderText="Participating Projects"
-          fullWidth={true}
           selectableCards={false}
         />
       </div>

--- a/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
+++ b/common/components/componentsBySection/FindEvents/EventCardsContainer.jsx
@@ -1,33 +1,31 @@
 // @flow
 
-import React from 'react';
-import type {ReduceStore} from 'flux/utils';
-import {Container} from 'flux/utils';
-import {List} from 'immutable'
+import React from "react";
+import type { ReduceStore } from "flux/utils";
+import { Container } from "flux/utils";
+import { List } from "immutable";
 import EventSearchStore from "../../stores/EventSearchStore.js";
 import EventSearchDispatcher from "../../stores/EventSearchDispatcher.js";
 import EventCardsListings from "./EventCardsListings.jsx";
-import type {LocationRadius} from "../../stores/ProjectSearchStore.js";
-import type {EventTileAPIData} from "../../utils/EventAPIUtils.js";
+import type { LocationRadius } from "../../stores/ProjectSearchStore.js";
+import type { EventTileAPIData } from "../../utils/EventAPIUtils.js";
 import utils from "../../utils/utils.js";
-import _ from 'lodash';
+import _ from "lodash";
 
 type Props = {|
   showSearchControls: ?boolean,
   staticHeaderText: ?string,
-  fullWidth: ?boolean,
-|}
+|};
 
 type State = {|
   events: List<EventTileAPIData>,
   event_pages: number,
   current_page: number,
   event_count: number,
-  location: LocationRadius
+  location: LocationRadius,
 |};
 
 class EventCardsContainer extends React.Component<Props, State> {
-
   static getStores(): $ReadOnlyArray<ReduceStore> {
     return [EventSearchStore];
   }
@@ -40,33 +38,31 @@ class EventCardsContainer extends React.Component<Props, State> {
       event_count: EventSearchStore.getNumberOfEvents(),
       current_page: EventSearchStore.getCurrentPage(),
       events_loading: EventSearchStore.getEventsLoading(),
-      keyword: EventSearchStore.getKeyword() || ''
+      keyword: EventSearchStore.getKeyword() || "",
     };
   }
 
   render(): React$Node {
-    
     return (
-      <div className={`ProjectCardContainer col-12 ${this.props.fullWidth ? '' : 'col-md-8 col-lg-9 p-lg-0 m-lg-0'}`}>
-        <div className="container-fluid">
-          {
-            this.props.showSearchControls
-            ? (
-              <React.Fragment>
-                {/*<EventSearchSort/>*/}
-                {/*<EventTagContainer/>*/}
-              </React.Fragment>
-              )
-            : null
-          }
-          <div className="row EventCards-card-container">
-            {/*{!_.isEmpty(this.state.events) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}*/}
-            {!_.isEmpty(this.state.events) && <EventCardsListings events={this.state.events} showMessageForNoFutureEvents={true}/>}
-          </div>
-          {/*<div>
+      <div className="ProjectCardContainer col">
+        {this.props.showSearchControls ? (
+          <React.Fragment>
+            {/*<EventSearchSort/>*/}
+            {/*<EventTagContainer/>*/}
+          </React.Fragment>
+        ) : null}
+        <div className="row EventCards-card-container">
+          {/*{!_.isEmpty(this.state.events) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}*/}
+          {!_.isEmpty(this.state.events) && (
+            <EventCardsListings
+              events={this.state.events}
+              showMessageForNoFutureEvents={true}
+            />
+          )}
+        </div>
+        {/*<div>
             {this._renderPagination()}
           </div> */}
-        </div>
       </div>
     );
   }
@@ -75,52 +71,58 @@ class EventCardsContainer extends React.Component<Props, State> {
     if (this.props.staticHeaderText) {
       return this.props.staticHeaderText;
     } else if (this.state.keyword) {
-      return this.state.event_count + " " + utils.pluralize("event", "events", this.state.event_count) + " found";
+      return (
+        this.state.event_count +
+        " " +
+        utils.pluralize("event", "events", this.state.event_count) +
+        " found"
+      );
     } else {
-      return 'Find events that match your interests'
-    };
+      return "Find events that match your interests";
+    }
   }
 
   _handleFetchNextPage(e: object): void {
     e.preventDefault();
 
-    const nextPage = this.state.current_page + 1 <= this.state.event_pages
-      ? this.state.current_page + 1
-      : this.state.current_page;
+    const nextPage =
+      this.state.current_page + 1 <= this.state.event_pages
+        ? this.state.current_page + 1
+        : this.state.current_page;
 
-    this.setState({current_page: nextPage }, function () {
+    this.setState({ current_page: nextPage }, function() {
       EventSearchDispatcher.dispatch({
-        type: 'SET_PAGE',
+        type: "SET_PAGE",
         page: this.state.current_page,
       });
     });
   }
 
   _renderPagination(): ?React$Node {
-    if ((this.state.current_page === this.state.event_pages) && !this.state.events_loading ) {
+    if (
+      this.state.current_page === this.state.event_pages &&
+      !this.state.events_loading
+    ) {
       return null;
     }
     if (!_.isEmpty(this.state.events) && this.state.events_loading) {
       return (
         <div className="page_selection_footer">
-          <button className="btn btn-primary disabled">
-            Loading...
-          </button>
+          <button className="btn btn-primary disabled">Loading...</button>
         </div>
-      )
+      );
     }
-    return (
-      this.state.events && this.state.events.size !== 0
-      ? <div className="page_selection_footer">
-        <button className="btn btn-primary" onClick={this._handleFetchNextPage.bind(this)}>
+    return this.state.events && this.state.events.size !== 0 ? (
+      <div className="page_selection_footer">
+        <button
+          className="btn btn-primary"
+          onClick={this._handleFetchNextPage.bind(this)}
+        >
           More Events...
         </button>
       </div>
-      : null
-    );
+    ) : null;
   }
 }
-
-
 
 export default Container.create(EventCardsContainer);

--- a/common/components/componentsBySection/FindGroups/GroupCardsContainer.jsx
+++ b/common/components/componentsBySection/FindGroups/GroupCardsContainer.jsx
@@ -1,30 +1,27 @@
 // @flow
 
-
-import React from 'react';
-import type {ReduceStore} from 'flux/utils';
+import React from "react";
+import type { ReduceStore } from "flux/utils";
 import GroupSearchSort from "./GroupSearchSort.jsx";
 import GroupTagContainer from "./GroupTagContainer.jsx";
-import {Container} from 'flux/utils';
-import {List} from 'immutable'
+import { Container } from "flux/utils";
+import { List } from "immutable";
 import GroupCard from "./GroupCard.jsx";
 import GroupSearchStore from "../../stores/GroupSearchStore.js";
 import GroupSearchDispatcher from "../../stores/GroupSearchDispatcher.js";
-import LoadingMessage from '../../chrome/LoadingMessage.jsx';
+import LoadingMessage from "../../chrome/LoadingMessage.jsx";
 import prerender from "../../utils/prerender.js";
-import type {LocationRadius} from "../../stores/ProjectSearchStore.js";
-import {Dictionary, createDictionary} from "../../types/Generics.jsx";
-import type {TagDefinition} from "../../utils/ProjectAPIUtils.js";
-import type {GroupTileAPIData} from "../../utils/GroupAPIUtils.js";
+import type { LocationRadius } from "../../stores/ProjectSearchStore.js";
+import { Dictionary, createDictionary } from "../../types/Generics.jsx";
+import type { TagDefinition } from "../../utils/ProjectAPIUtils.js";
+import type { GroupTileAPIData } from "../../utils/GroupAPIUtils.js";
 import utils from "../../utils/utils.js";
-import _ from 'lodash';
-
+import _ from "lodash";
 
 type Props = {|
   showSearchControls: ?boolean,
   staticHeaderText: ?string,
-  fullWidth: ?boolean,
-|}
+|};
 
 type State = {|
   groups: List<GroupTileAPIData>,
@@ -32,11 +29,10 @@ type State = {|
   current_page: number,
   group_count: number,
   location: LocationRadius,
-  tagDictionary: Dictionary<TagDefinition>
+  tagDictionary: Dictionary<TagDefinition>,
 |};
 
 class GroupCardsContainer extends React.Component<Props, State> {
-
   static getStores(): $ReadOnlyArray<ReduceStore> {
     return [GroupSearchStore];
   }
@@ -48,35 +44,31 @@ class GroupCardsContainer extends React.Component<Props, State> {
       group_count: GroupSearchStore.getNumberOfGroups(),
       current_page: GroupSearchStore.getCurrentPage(),
       groups_loading: GroupSearchStore.getGroupsLoading(),
-      keyword: GroupSearchStore.getKeyword() || '',
+      keyword: GroupSearchStore.getKeyword() || "",
       tags: GroupSearchStore.getSelectedTags() || [],
-      location: GroupSearchStore.getLocation() || '',
-      tagDictionary: GroupSearchStore.getAllTags() || []
+      location: GroupSearchStore.getLocation() || "",
+      tagDictionary: GroupSearchStore.getAllTags() || [],
     };
   }
 
   render(): React$Node {
     return (
-      <div className={`ProjectCardContainer col-12 ${this.props.fullWidth ? '' : 'col-md-8 col-lg-9 p-0 m-0'}`}>
-        <div className="container-fluid">
-          {
-            this.props.showSearchControls
-            ? (
-              <React.Fragment>
-                <GroupSearchSort/>
-                <GroupTagContainer/>
-              </React.Fragment>
-              )
-            : null
-          }
-          <div className="row">
-            {!_.isEmpty(this.state.groups) && <h2 className="ProjectCardContainer-header">{this._renderCardHeaderText()}</h2>}
-            {this._renderCards()}
-          </div>
-          <div>
-            {this._renderPagination()}
-          </div>
+      <div className="ProjectCardContainer col">
+        {this.props.showSearchControls ? (
+          <React.Fragment>
+            <GroupSearchSort />
+            <GroupTagContainer />
+          </React.Fragment>
+        ) : null}
+        <div className="row">
+          {!_.isEmpty(this.state.groups) && (
+            <h2 className="ProjectCardContainer-header">
+              {this._renderCardHeaderText()}
+            </h2>
+          )}
+          {this._renderCards()}
         </div>
+        <div>{this._renderPagination()}</div>
       </div>
     );
   }
@@ -84,72 +76,85 @@ class GroupCardsContainer extends React.Component<Props, State> {
   _renderCardHeaderText(): React$Node {
     if (this.props.staticHeaderText) {
       return this.props.staticHeaderText;
-    } else if (this.state.keyword || this.state.tags.size > 0 || (this.state.location && this.state.location.latitude && this.state.location.longitude)) {
-      return this.state.group_count + " " + utils.pluralize("group", "groups", this.state.group_count) + " found";
+    } else if (
+      this.state.keyword ||
+      this.state.tags.size > 0 ||
+      (this.state.location &&
+        this.state.location.latitude &&
+        this.state.location.longitude)
+    ) {
+      return (
+        this.state.group_count +
+        " " +
+        utils.pluralize("group", "groups", this.state.group_count) +
+        " found"
+      );
     } else {
-      return 'Find groups that match your interests'
+      return "Find groups that match your interests";
     }
   }
 
   _renderCards(): React$Node {
-    return !this.state.groups
-      ? <LoadingMessage message="Loading groups..." />
-      : this.state.groups.size === 0
-        ? 'No Groups match the provided criteria. Try a different set of filters or search term.'
-        : this.state.groups.map(
-          (group: GroupTileAPIData, index: number) =>
-            <div className="col-sm-12 col-lg-6">
-              <GroupCard
-                group={group}
-                key={index}
-                maxTextLength={140}
-                maxIssuesCount={4}
-                tagDictionary={this.state.tagDictionary}
-              />
-            </div>
-      );
-    }
+    return !this.state.groups ? (
+      <LoadingMessage message="Loading groups..." />
+    ) : this.state.groups.size === 0 ? (
+      "No Groups match the provided criteria. Try a different set of filters or search term."
+    ) : (
+      this.state.groups.map((group: GroupTileAPIData, index: number) => (
+        <div className="col-sm-12 col-lg-6">
+          <GroupCard
+            group={group}
+            key={index}
+            maxTextLength={140}
+            maxIssuesCount={4}
+            tagDictionary={this.state.tagDictionary}
+          />
+        </div>
+      ))
+    );
+  }
 
   _handleFetchNextPage(e: object): void {
     e.preventDefault();
 
-    const nextPage = this.state.current_page + 1 <= this.state.group_pages
-      ? this.state.current_page + 1
-      : this.state.current_page;
+    const nextPage =
+      this.state.current_page + 1 <= this.state.group_pages
+        ? this.state.current_page + 1
+        : this.state.current_page;
 
-    this.setState({current_page: nextPage }, function () {
+    this.setState({ current_page: nextPage }, function() {
       GroupSearchDispatcher.dispatch({
-        type: 'SET_PAGE',
+        type: "SET_PAGE",
         page: this.state.current_page,
       });
     });
   }
 
   _renderPagination(): ?React$Node {
-    if ((this.state.current_page === this.state.group_pages) && !this.state.groups_loading ) {
+    if (
+      this.state.current_page === this.state.group_pages &&
+      !this.state.groups_loading
+    ) {
       return null;
     }
     if (!_.isEmpty(this.state.groups) && this.state.groups_loading) {
       return (
         <div className="page_selection_footer">
-          <button className="btn btn-primary disabled">
-            Loading...
-          </button>
+          <button className="btn btn-primary disabled">Loading...</button>
         </div>
-      )
+      );
     }
-    return (
-      this.state.groups && this.state.groups.size !== 0
-      ? <div className="page_selection_footer">
-        <button className="btn btn-primary" onClick={this._handleFetchNextPage.bind(this)}>
+    return this.state.groups && this.state.groups.size !== 0 ? (
+      <div className="page_selection_footer">
+        <button
+          className="btn btn-primary"
+          onClick={this._handleFetchNextPage.bind(this)}
+        >
           More Groups...
         </button>
       </div>
-      : null
-    );
+    ) : null;
   }
 }
-
-
 
 export default Container.create(GroupCardsContainer);

--- a/common/components/componentsBySection/FindProjects/ProjectCardsContainer.jsx
+++ b/common/components/componentsBySection/FindProjects/ProjectCardsContainer.jsx
@@ -19,7 +19,6 @@ import type {LocationRadius} from "../../stores/ProjectSearchStore.js";
 type Props = {|
   showSearchControls: ?boolean,
   staticHeaderText: ?string,
-  fullWidth: ?boolean,
   onSelectProject: ?Function,
   selectableCards: ?boolean,
   alreadySelectedProjects: ?List<string>, // todo: proper state management

--- a/common/components/componentsBySection/FindProjects/ProjectCardsContainer.jsx
+++ b/common/components/componentsBySection/FindProjects/ProjectCardsContainer.jsx
@@ -58,8 +58,7 @@ class ProjectCardsContainer extends React.Component<Props, State> {
 
   render(): React$Node {
     return (
-      <div className={`ProjectCardContainer col-12 ${this.props.fullWidth ? '' : 'col-md-8 col-lg-9 p-0 m-0'}`}>
-        <div className="container-fluid">
+      <div className="ProjectCardContainer col">
           {
             this.props.showSearchControls
             ? (
@@ -77,7 +76,6 @@ class ProjectCardsContainer extends React.Component<Props, State> {
           <div>
             {this._renderPagination()}
           </div>
-        </div>
       </div>
     );
   }

--- a/common/components/controllers/EditProfileController.jsx
+++ b/common/components/controllers/EditProfileController.jsx
@@ -1,30 +1,30 @@
 // @flow
 
-import React from 'react'
-import DjangoCSRFToken from 'django-react-csrftoken'
+import React from "react";
+import DjangoCSRFToken from "django-react-csrftoken";
 import UserAPIUtils from "../utils/UserAPIUtils.js";
-import type {UserAPIData} from "../utils/UserAPIUtils.js";
-import {CountrySelector} from "../common/selection/CountrySelector.jsx";
-import {CountryData, DefaultCountry} from "../constants/Countries.js";
+import type { UserAPIData } from "../utils/UserAPIUtils.js";
+import { CountrySelector } from "../common/selection/CountrySelector.jsx";
+import { CountryData, DefaultCountry } from "../constants/Countries.js";
 import TagCategory from "../common/tags/TagCategory.jsx";
 import TagSelector from "../common/tags/TagSelector.jsx";
 import LinkList from "../forms/LinkList.jsx";
-import {LinkInfo} from "../forms/LinkInfo.jsx";
-import {FileInfo} from "../common/FileInfo.jsx";
+import { LinkInfo } from "../forms/LinkInfo.jsx";
+import { FileInfo } from "../common/FileInfo.jsx";
 import ImageCropUploadFormElement from "../forms/ImageCropUploadFormElement.jsx";
 import FileUploadList from "../forms/FileUploadList.jsx";
-import FormValidation, {Validator} from "../forms/FormValidation.jsx";
+import FormValidation, { Validator } from "../forms/FormValidation.jsx";
 import formHelper from "../utils/forms.js";
 import urlHelper from "../utils/url.js";
 import metrics from "../utils/metrics.js";
 import CurrentUser from "../utils/CurrentUser.js";
-import _ from 'lodash';
+import _ from "lodash";
 import url from "../utils/url.js";
 
-const UserLinkNames = ['link_linkedin'];
+const UserLinkNames = ["link_linkedin"];
 
 const UserFileTypes = {
-  RESUME: "RESUME"
+  RESUME: "RESUME",
 };
 
 type FormFields = {|
@@ -45,13 +45,13 @@ type State = {|
   userId: number,
   formFields: FormFields,
   formIsValid: boolean,
-  validations: $ReadOnlyArray<Validator>
+  validations: $ReadOnlyArray<Validator>,
 |};
 
 /**
  * Encapsulates form for editing projects
  */
-class EditProfileController extends React.PureComponent<{||},State> {
+class EditProfileController extends React.PureComponent<{||}, State> {
   constructor(props: {||}): void {
     super(props);
     const formFields: FormFields = {
@@ -65,35 +65,42 @@ class EditProfileController extends React.PureComponent<{||},State> {
       postal_code: "",
       country: DefaultCountry.ISO_2,
       user_links: [],
-      user_files: []
+      user_files: [],
     };
     const validations: $ReadOnlyArray<Validator<FormFields>> = [
       {
-        checkFunc: (formFields: FormFields) => 
+        checkFunc: (formFields: FormFields) =>
           urlHelper.isEmptyStringOrValidUrl(formFields["link_linkedin"]),
-        errorMessage: "Please enter a valid LinkedIn URL."
-      }
+        errorMessage: "Please enter a valid LinkedIn URL.",
+      },
     ];
     const formIsValid: boolean = FormValidation.isValid(
-      formFields, validations);
+      formFields,
+      validations
+    );
     this.state = {
-      userId: (CurrentUser.isStaff() && url.argument("id")) || window.DLAB_GLOBAL_CONTEXT.userID,
+      userId:
+        (CurrentUser.isStaff() && url.argument("id")) ||
+        window.DLAB_GLOBAL_CONTEXT.userID,
       formFields: formFields,
       formIsValid: formIsValid,
-      validations: validations
+      validations: validations,
     };
     this.form = formHelper.setup();
   }
 
   componentDidMount(): void {
     // TODO: Show error message on failure to load
-    UserAPIUtils.fetchUserDetails(this.state.userId, this.loadUserDetails.bind(this));
+    UserAPIUtils.fetchUserDetails(
+      this.state.userId,
+      this.loadUserDetails.bind(this)
+    );
     this.form.doValidation.bind(this)();
   }
 
   onValidationCheck(formIsValid: boolean): void {
-    if(formIsValid !== this.state.formIsValid) {
-      this.setState({formIsValid});
+    if (formIsValid !== this.state.formIsValid) {
+      this.setState({ formIsValid });
     }
   }
 
@@ -107,10 +114,14 @@ class EditProfileController extends React.PureComponent<{||},State> {
         postal_code: user.postal_code,
         country: user.country || DefaultCountry.ISO_2,
         user_technologies: user.user_technologies,
-        user_resume_file: user.user_files.filter((file: FileInfo) => file.fileCategory === UserFileTypes.RESUME),
-        user_files: user.user_files.filter((file: FileInfo) => file.fileCategory !== UserFileTypes.RESUME),
-        user_thumbnail: user.user_thumbnail
-      }
+        user_resume_file: user.user_files.filter(
+          (file: FileInfo) => file.fileCategory === UserFileTypes.RESUME
+        ),
+        user_files: user.user_files.filter(
+          (file: FileInfo) => file.fileCategory !== UserFileTypes.RESUME
+        ),
+        user_thumbnail: user.user_thumbnail,
+      },
     });
 
     //this will set formFields.user_links and formFields.links_*
@@ -118,7 +129,10 @@ class EditProfileController extends React.PureComponent<{||},State> {
     metrics.logUserProfileEditEntry(CurrentUser.userID());
   }
 
-  onFormFieldChange(formFieldName: string, event: SyntheticInputEvent<HTMLInputElement>): void {
+  onFormFieldChange(
+    formFieldName: string,
+    event: SyntheticInputEvent<HTMLInputElement>
+  ): void {
     this.state.formFields[formFieldName] = event.target.value;
     this.forceUpdate();
   }
@@ -130,31 +144,34 @@ class EditProfileController extends React.PureComponent<{||},State> {
   handleCountrySelection(selectedValue: CountryData): void {
     let formFields: FormFields = this.state.formFields;
     formFields.country = selectedValue.ISO_2;
-    this.setState({formFields: formFields}, function() {
+    this.setState({ formFields: formFields }, function() {
       this.forceUpdate();
     });
   }
 
   onSubmit(): void {
     // create input array
-    var eLinks = UserLinkNames.map(name => ({linkName: name, linkUrl: this.state.formFields[name]}))
+    var eLinks = UserLinkNames.map(name => ({
+      linkName: name,
+      linkUrl: this.state.formFields[name],
+    }));
     //create output array
     var eLinksArray = [];
     //create objects for project_links array, skipping empty fields
     eLinks.forEach(function(item) {
-      if(!_.isEmpty(item.linkUrl)) {
+      if (!_.isEmpty(item.linkUrl)) {
         item.linkUrl = urlHelper.appendHttpIfMissingProtocol(item.linkUrl);
         eLinksArray.push({
           linkName: item.linkName,
           linkUrl: item.linkUrl,
           visibility: "PUBLIC",
-        })
+        });
       }
     });
     //combine arrays prior to sending to backend
     let formFields = this.state.formFields;
     formFields.user_links = formFields.user_links.concat(eLinksArray);
-    this.setState({ formFields: formFields});
+    this.setState({ formFields: formFields });
     this.forceUpdate();
     metrics.logUserProfileEditSave(CurrentUser.userID());
   }
@@ -171,7 +188,7 @@ class EditProfileController extends React.PureComponent<{||},State> {
       linkState[item.linkName] = item.linkUrl;
     });
     //add the other links to state copy
-    linkState['user_links'] = array;
+    linkState["user_links"] = array;
 
     //TODO: see if there's a way to do this without the forceUpdate - passing by reference problem?
     this.setState({ formFields: linkState });
@@ -181,11 +198,14 @@ class EditProfileController extends React.PureComponent<{||},State> {
   render(): React$Node {
     return (
       <React.Fragment>
-      <div className="wrapper-gray">
         <div className="container">
-          <form action={`/api/user/edit/${this.state.userId}/`} method="post">
-            <div className="EditProjectForm-root create-form white-bg">
-              <DjangoCSRFToken/>
+          <form
+            action={`/api/user/edit/${this.state.userId}/`}
+            method="post"
+            className="row"
+          >
+            <div className="EditProjectForm-root create-form white-bg col-12">
+              <DjangoCSRFToken />
 
               <div className="form-group text-right">
                 <input
@@ -198,39 +218,67 @@ class EditProfileController extends React.PureComponent<{||},State> {
               </div>
 
               <div className="form-group">
-                <ImageCropUploadFormElement form_id="user_thumbnail_location"
-                                        buttonText="Upload Your Picture"
-                                        currentImage={this.state.formFields.user_thumbnail}
-                                        aspect={1/1}/>
+                <ImageCropUploadFormElement
+                  form_id="user_thumbnail_location"
+                  buttonText="Upload Your Picture"
+                  currentImage={this.state.formFields.user_thumbnail}
+                  aspect={1 / 1}
+                />
               </div>
 
               <div className="form-group">
-                <label>
-                  ABOUT ME
-                </label>
+                <label>ABOUT ME</label>
                 <div className="character-count">
-                  { (this.state.formFields.about_me || "").length} / 2000
+                  {(this.state.formFields.about_me || "").length} / 2000
                 </div>
-                <textarea className="form-control" id="about_me" name="about_me" rows="6" maxLength="2000"
-                          value={this.state.formFields.about_me} onChange={this.onFormFieldChange.bind(this, "about_me")}/>
+                <textarea
+                  className="form-control"
+                  id="about_me"
+                  name="about_me"
+                  rows="6"
+                  maxLength="2000"
+                  value={this.state.formFields.about_me}
+                  onChange={this.onFormFieldChange.bind(this, "about_me")}
+                />
               </div>
 
               <div className="form-group">
                 <label>First Name</label>
-                <input type="text" className="form-control" id="first_name" name="first_name" maxLength="30"
-                       value={this.state.formFields.first_name} onChange={this.onFormFieldChange.bind(this, "first_name")}/>
+                <input
+                  type="text"
+                  className="form-control"
+                  id="first_name"
+                  name="first_name"
+                  maxLength="30"
+                  value={this.state.formFields.first_name}
+                  onChange={this.onFormFieldChange.bind(this, "first_name")}
+                />
               </div>
 
               <div className="form-group">
                 <label>Last Name</label>
-                <input type="text" className="form-control" id="last_name" name="last_name" maxLength="30"
-                       value={this.state.formFields.last_name} onChange={this.onFormFieldChange.bind(this, "last_name")}/>
+                <input
+                  type="text"
+                  className="form-control"
+                  id="last_name"
+                  name="last_name"
+                  maxLength="30"
+                  value={this.state.formFields.last_name}
+                  onChange={this.onFormFieldChange.bind(this, "last_name")}
+                />
               </div>
 
               <div className="form-group">
                 <label htmlFor="link_linkedin">LinkedIn</label>
-                <input type="text" className="form-control" id="link_linkedin" name="link_linkedin" maxLength="2075"
-                       value={this.state.formFields.link_linkedin} onChange={this.onFormFieldChange.bind(this, "link_linkedin")}/>
+                <input
+                  type="text"
+                  className="form-control"
+                  id="link_linkedin"
+                  name="link_linkedin"
+                  maxLength="2075"
+                  value={this.state.formFields.link_linkedin}
+                  onChange={this.onFormFieldChange.bind(this, "link_linkedin")}
+                />
               </div>
 
               <div className="form-group">
@@ -238,7 +286,8 @@ class EditProfileController extends React.PureComponent<{||},State> {
                   elementid="user_resume_file"
                   title="Upload Resume"
                   singleFileOnly={true}
-                  files={this.state.formFields.user_resume_file}/>
+                  files={this.state.formFields.user_resume_file}
+                />
               </div>
 
               <div className="form-group">
@@ -262,19 +311,32 @@ class EditProfileController extends React.PureComponent<{||},State> {
 
               <div className="form-group">
                 <label htmlFor="postal_code">Zip/Postal Code</label>
-                <input type="text" className="form-control" id="postal_code" name="postal_code" maxLength="10"
-                       value={this.state.formFields.postal_code} onChange={this.onFormFieldChange.bind(this, "postal_code")}/>
+                <input
+                  type="text"
+                  className="form-control"
+                  id="postal_code"
+                  name="postal_code"
+                  maxLength="10"
+                  value={this.state.formFields.postal_code}
+                  onChange={this.onFormFieldChange.bind(this, "postal_code")}
+                />
               </div>
 
               <div className="form-group">
-                <LinkList elementid="user_links"
-                          title="Links"
-                          hiddenLinkNames={["link_linkedin"]}
-                          links={this.state.formFields.user_links}/>
+                <LinkList
+                  elementid="user_links"
+                  title="Links"
+                  hiddenLinkNames={["link_linkedin"]}
+                  links={this.state.formFields.user_links}
+                />
               </div>
 
               <div className="form-group">
-                <FileUploadList elementid="user_files" title="Files" files={this.state.formFields.user_files}/>
+                <FileUploadList
+                  elementid="user_files"
+                  title="Files"
+                  files={this.state.formFields.user_files}
+                />
               </div>
 
               <FormValidation
@@ -292,16 +354,12 @@ class EditProfileController extends React.PureComponent<{||},State> {
                   onClick={this.onSubmit.bind(this)}
                 />
               </div>
-
             </div>
           </form>
         </div>
-      </div>
       </React.Fragment>
     );
   }
-
-
 }
 
 export default EditProfileController;


### PR DESCRIPTION
This PR does some cleanup on our existing use of Bootstrap so we have a stronger base for moving forward both in terms of code consistency and design team documentation.

### Fixes
 - set XXL container width to 1392px for 12-col grid consistency (Fixes #512) - note this is going to require a spot check of nearly every page on the site at that viewport
 - review all existing uses of Bootstrap container classes
 - clean up some container class mess with the ProjectCardContainer component, deprecating the need for a fullWidth prop
 - fixes container/row classes on Edit Profile page
 - fixes Create workflow step-bar section positioning (at very large resolutions, the step bar should stay above the form rather than staying fixed on the left edge of the window) 

### Exceptions (not fixed in this PR)
 - consistently handle full-width-background behind bounded width content (top section of About Us page, Corporate Hackathon, Press page) -- About Us is buggy, Hackathon isn't reusable. We've got most of the pieces in place (see something like bounded-content class used in Create) but it's not pulled together yet.
 - in global.scss, `.bounded-content` rules should pull from $container-max-widths rather than redeclaring them