### PR TITLE
hotfix: project profile files list fixes

### DIFF
--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -336,6 +336,13 @@
   font-size: 14px;
   margin-top: 16px;
 }
+.AboutProjects-file-link {
+  /* if a file has a very long filename, it overflows the container and if a project has many files the list is hard to read */
+  margin: 12px 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
 
 @media (max-width: 1000px) {
   // buttons will align below "-description"

--- a/common/components/common/projects/AboutProjectDisplay.jsx
+++ b/common/components/common/projects/AboutProjectDisplay.jsx
@@ -459,7 +459,7 @@ class AboutProjectDisplay extends React.PureComponent<Props, State> {
       project &&
       project.project_files &&
       project.project_files.map((file, i) => (
-        <div key={i}>
+        <div key={i} className="AboutProjects-file-link">
           <a href={file.publicUrl} target="_blank" rel="noopener noreferrer">
             {file.fileName}
           </a>


### PR DESCRIPTION
If a project has a large number of files, and/or if a project has files with very long filenames, the list of files on the project profile page is both hard to read and can overflow its container. 

This hotfix should fix both issues by forcing files to take one line only, the overflow is handled with an ellipsis, and there's vertical margin between each item. It should also only take effect on the project profile page, to keep scope down.


![image](https://user-images.githubusercontent.com/16870466/105897587-365e0d80-5fcd-11eb-95c8-949145bc6135.png)
