### PR TITLE
Event Profile: Fix issue where private events cannot load projects

### DIFF
--- a/civictechprojects/helpers/context_preload.py
+++ b/civictechprojects/helpers/context_preload.py
@@ -25,7 +25,7 @@ def about_event_preload(context, request):
     context = default_preload(context, request)
     query_args = url_params(request)
     event_id = query_args['id'][0]
-    event = Event.get_by_id_or_slug(event_id, get_request_contributor(request))
+    event = Event.get_by_id_or_slug(event_id)
     event_json = event.hydrate_to_json()
     if event_json is not None:
         context['title'] = event_json['event_name'] + ' | DemocracyLab'

--- a/civictechprojects/models.py
+++ b/civictechprojects/models.py
@@ -434,15 +434,12 @@ class Event(Archived):
         return event
 
     @staticmethod
-    def get_by_id_or_slug(slug, user=None):
+    def get_by_id_or_slug(slug):
         event = None
         if slug is not None:
             _slug = slug.strip().lower()
             if _slug.isnumeric():
                 event = Event.objects.get(id=_slug)
-                if event and event.is_private:
-                    if not user or not user.is_authenticated or not is_creator_or_staff(user, event):
-                        raise PermissionDenied()
             elif len(_slug) > 0:
                 event = Event.objects.filter(event_slug=_slug).first() or NameRecord.get_event(_slug)
 

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -252,7 +252,10 @@ def event_delete(request, event_id):
 
 def get_event(request, event_id):
     try:
-        event = Event.get_by_id_or_slug(event_id, get_request_contributor(request))
+        event = Event.get_by_id_or_slug(event_id)
+        if event_id.isnumeric() and event.is_private and not is_creator_or_staff(get_request_contributor(request), event):
+            # Don't let non-admins/non-owners load a private event by numeric id
+            raise PermissionDenied()
     except PermissionDenied:
         return HttpResponseForbidden()
 


### PR DESCRIPTION
Fixed the issue, and also lifted the check prohibiting private events being loaded by numeric id to the get event endpoint, which is the only place the check is needed.