### PR TITLE
Find Projects: added text-break bootstrap class to Organization Type

### DIFF
--- a/common/components/componentsBySection/FindProjects/ProjectDetails.jsx
+++ b/common/components/componentsBySection/FindProjects/ProjectDetails.jsx
@@ -67,7 +67,7 @@ class ProjectDetails extends React.PureComponent<Props, State> {
         {this.state.projectOrganizationType && (
           <div className="AboutProjects-icon-row">
             <i className={Glyph(GlyphStyles.University, GlyphSizes.LG)} />
-            <p className="AboutProjects-icon-text">
+            <p className="AboutProjects-icon-text text-break">
               {this.state.projectOrganizationType}
             </p>
           </div>


### PR DESCRIPTION
As the title describes, I addressed Issue #519 by adding a text-break class to the projectOrganizationType. Thank you for allowing me to contribute! 