### PR TITLE
Event Profile: Sort projects by name by default

### DIFF
--- a/common/components/common/groups/AboutGroupDisplay.jsx
+++ b/common/components/common/groups/AboutGroupDisplay.jsx
@@ -182,9 +182,11 @@ class AboutGroupDisplay extends React.Component<Props, State> {
         type: "INIT",
         findProjectsArgs: {
           group_id: group.group_id,
+          sortField: "-project_date_modified",
         },
         searchSettings: {
           updateUrl: false,
+          defaultSort: "-project_date_modified",
         },
       });
     }

--- a/common/components/componentsBySection/CreateEvent/AboutEventDisplay.jsx
+++ b/common/components/componentsBySection/CreateEvent/AboutEventDisplay.jsx
@@ -219,9 +219,11 @@ class AboutEventDisplay extends React.PureComponent<Props, State> {
         type: "INIT",
         findProjectsArgs: {
           event_id: event.event_id,
+          sortField: "project_name",
         },
         searchSettings: {
           updateUrl: false,
+          defaultSort: "project_name",
         },
       });
     }

--- a/common/components/componentsBySection/FindProjects/ProjectSearchSort.jsx
+++ b/common/components/componentsBySection/FindProjects/ProjectSearchSort.jsx
@@ -16,11 +16,8 @@ type Props = {|
 type State = {|
   sortField: string,
 |};
-
 const sortOptions: $ReadOnlyArray<SelectOption> = [
-  // {value: '", label: "---"},
-  // {value: "project_date_modified", label: "Date Modified - Ascending"},
-  { value: "", label: "Date Modified" },
+  { value: "-project_date_modified", label: "Date Modified" },
   { value: "project_name", label: "Name - Ascending" },
   { value: "-project_name", label: "Name - Descending" },
 ];
@@ -32,11 +29,12 @@ class ProjectSearchSort extends React.Component<Props, State> {
 
   static calculateState(prevState: State): State {
     const sortField = ProjectSearchStore.getSortField();
+    const defaultSort = ProjectSearchStore.getDefaultSortField();
 
     const state = {
-      sortField: sortField
-        ? sortOptions.find(option => option.value === sortField)
-        : sortOptions[0],
+      sortField: sortOptions.find(
+        option => option.value === (sortField || defaultSort)
+      ),
     };
 
     return state;

--- a/common/components/componentsBySection/FindProjects/ResetSearchButton.jsx
+++ b/common/components/componentsBySection/FindProjects/ResetSearchButton.jsx
@@ -11,6 +11,7 @@ import _ from "lodash";
 type State = {|
   keyword: string,
   tags: List<TagDefinition>,
+  defaultSort: string,
   sortField: string,
   location: string,
   locationRadius: LocationRadius,
@@ -25,6 +26,7 @@ class ResetSearchButton extends React.Component<{||}, State> {
     return {
       keyword: ProjectSearchStore.getKeyword() || "",
       tags: ProjectSearchStore.getTags() || [],
+      defaultSort: ProjectSearchStore.getDefaultSortField() || "",
       sortField: ProjectSearchStore.getSortField() || "",
       location: ProjectSearchStore.getLegacyLocation() || "",
       locationRadius: ProjectSearchStore.getLocation() || {},
@@ -40,7 +42,7 @@ class ResetSearchButton extends React.Component<{||}, State> {
             !(
               this.state.keyword ||
               this.state.tags.size > 0 ||
-              this.state.sortField ||
+              this.state.sortField !== this.state.defaultSort ||
               this.state.location ||
               !_.isEmpty(this.state.locationRadius)
             )

--- a/common/components/controllers/FindProjectsController.jsx
+++ b/common/components/controllers/FindProjectsController.jsx
@@ -31,11 +31,15 @@ class FindProjectsController extends React.PureComponent {
       "org",
       "stage",
     ]);
+    if (!args.sortField) {
+      args.sortField = "-project_date_modified";
+    }
     ProjectSearchDispatcher.dispatch({
       type: "INIT",
       findProjectsArgs: !_.isEmpty(args) ? args : null,
       searchSettings: {
         updateUrl: true,
+        defaultSort: "-project_date_modified",
       },
     });
     TagDispatcher.dispatch({ type: "INIT" });

--- a/common/components/stores/ProjectSearchStore.js
+++ b/common/components/stores/ProjectSearchStore.js
@@ -21,6 +21,7 @@ import _ from "lodash";
 
 export type SearchSettings = {|
   updateUrl: boolean,
+  defaultSort: string,
 |};
 
 export type FindProjectsArgs = {|
@@ -119,6 +120,8 @@ export type ProjectSearchActionType =
       projectsResponse: FindProjectsResponse,
     };
 
+const defaultSort = "-project_date_modified";
+
 const DEFAULT_STATE = {
   keyword: "",
   sortField: "",
@@ -129,6 +132,7 @@ const DEFAULT_STATE = {
   projectsData: {},
   searchSettings: {
     updateUrl: false,
+    defaultSort: defaultSort,
   },
   findProjectsArgs: {},
   filterApplied: false,
@@ -174,7 +178,10 @@ class ProjectSearchStore extends ReduceStore<State> {
         );
         initialState = initialState.set(
           "searchSettings",
-          action.searchSettings || { updateUrl: false }
+          action.searchSettings || {
+            updateUrl: false,
+            defaultSort: defaultSort,
+          }
         );
         return this._loadProjects(initialState, true);
       case "ADD_TAG":
@@ -352,7 +359,7 @@ class ProjectSearchStore extends ReduceStore<State> {
 
   _clearFilters(state: State): State {
     state = state.set("keyword", "");
-    state = state.set("sortField", "");
+    state = state.set("sortField", state.searchSettings.defaultSort);
     state = state.set("location", "");
     state = state.set("locationRadius", {});
     state = state.set("tags", List());
@@ -403,6 +410,10 @@ class ProjectSearchStore extends ReduceStore<State> {
 
   getKeyword(): string {
     return this.getState().keyword;
+  }
+
+  getDefaultSortField(): string {
+    return this.getState().searchSettings.defaultSort;
   }
 
   getSortField(): string {


### PR DESCRIPTION
On the Event profile page, we'd like the projects to be sorted in alphabetical order by default rather than last updated date, in order to give a stable view of the project list when presenting at these events.