### PR TITLE
Add 2020 annual report

### DIFF
--- a/common/components/controllers/AboutUsController.jsx
+++ b/common/components/controllers/AboutUsController.jsx
@@ -238,8 +238,8 @@ class AboutUsController extends React.PureComponent<{||}, State> {
             <h3>Annual Report</h3>
             <p>
               Please review our{" "}
-              <a href="https://d1agxr2dqkgkuy.cloudfront.net/documents/2019%20DemocracyLab%20Annual%20Report.pdf">
-                2019 Annual Report
+              <a href="https://d1agxr2dqkgkuy.cloudfront.net/documents/2020%20DemocracyLab%20Annual%20Report.pdf">
+                2020 Annual Report
               </a>{" "}
               to learn about the impact of our programs and platform last year.
             </p>


### PR DESCRIPTION
This change just updates the reference to DemocracyLab's 2020 annual report.