### PR TITLE
Allow code to be hot-reloaded with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,6 @@ RUN yarn config set ignore-engines true
 RUN yarn --frozen-lockfile --link-duplicates --ignore-scripts
 # Permission issue with node-sass https://github.com/sass/node-sass/issues/1579
 RUN npm rebuild node-sass
-# Copy folders and files whitelisted by .dockerignore.
-COPY . /code/
 
 # Password for account used to send email
 ENV EMAIL_HOST_PASSWORD "betterDemocracyViaTechnology"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,29 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - ./civictechprojects/:/code/civictechprojects/
+      - ./common/:/code/common/
+      - ./democracylab/:/code/democracylab/
+      - ./oauth2/:/code/oauth2/
+      - ./.babelrc:/code/.babelrc
+      - ./manage.py:/code/manage.py
+      - ./webpack.common.js:/code/webpack.common.js
+      - ./webpack.dev.js:/code/webpack.dev.js
   migrate:
     build: .
     command: python manage.py migrate
     depends_on:
       - create_table
+    volumes:
+      - ./civictechprojects/:/code/civictechprojects/
+      - ./common/:/code/common/
+      - ./democracylab/:/code/democracylab/
+      - ./oauth2/:/code/oauth2/
+      - ./.babelrc:/code/.babelrc
+      - ./manage.py:/code/manage.py
+      - ./webpack.common.js:/code/webpack.common.js
+      - ./webpack.dev.js:/code/webpack.dev.js
   web:
     build: .
     command: bash -c 'source ./docker_environment_init.sh || true &&
@@ -34,3 +52,12 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - ./civictechprojects/:/code/civictechprojects/
+      - ./common/:/code/common/
+      - ./democracylab/:/code/democracylab/
+      - ./oauth2/:/code/oauth2/
+      - ./.babelrc:/code/.babelrc
+      - ./manage.py:/code/manage.py
+      - ./webpack.common.js:/code/webpack.common.js
+      - ./webpack.dev.js:/code/webpack.dev.js


### PR DESCRIPTION
We now mount in the source code instead of copying it into the image: this allows us to propagate changes in our host file system to the running Docker container.

Test as follows:

```
$ docker-compose down -v
$ docker-compose up --build
```

And then try changing a random api url path while the containing is running. It should reflect immediately upon hard refresh.

Worked with @glenbraun @marlonkeating 