### PR TITLE
Add meta image property to mirror og:image property

### DIFF
--- a/civictechprojects/templates/new_index.html
+++ b/civictechprojects/templates/new_index.html
@@ -10,6 +10,7 @@
     <meta name="og:description" content="{{ description }}" />
     <meta name="og:type" content="{{ og_type }}" />
     <meta name="og:image" content="{{ og_image }}" />
+    <meta name="image" property="og:image" content="{{ og_image }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="/static/js/runtime.bundle.js" defer></script>
     <script src="/static/js/main.bundle.js" defer></script>


### PR DESCRIPTION
Some OpenGraph providers read the 'image' meta tag rather than the 'og:image' tag, so this change adds that.

closes #568 