### PR TITLE
Users supplies missing first/last name when signing up via OAuth

### DIFF
--- a/civictechprojects/static/css/partials/_LogInController.scss
+++ b/civictechprojects/static/css/partials/_LogInController.scss
@@ -9,6 +9,10 @@
   overflow: auto;
 }
 
+.LogInController-root b {
+  font-weight: bold;
+}
+
 .LogInController-input {
   border: solid 1px $color-grey-frame-border;
   height: 40px;

--- a/civictechprojects/static/css/partials/_LogInController.scss
+++ b/civictechprojects/static/css/partials/_LogInController.scss
@@ -1,16 +1,11 @@
 .LogInController-root {
   background-color: $color-background-light;
   border: solid 1px $color-grey-frame-border;
-  font-weight: 300;
   width: 90%;
   max-width: 800px;
   margin: 76px auto;
   padding: 58px 5% 30px 5%;
   overflow: auto;
-}
-
-.LogInController-root b {
-  font-weight: bold;
 }
 
 .LogInController-input {

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -327,7 +327,12 @@ def approve_event(request, event_id):
 
 @ensure_csrf_cookie
 @xframe_options_exempt
-def index(request, id=None):
+def index(request):
+    page = get_page_section(request.get_full_path())
+    # Redirect to AddUserDetails page if First/Last name hasn't been entered yet
+    if page != FrontEndSection.AddUserDetails.value and request.user.is_authenticated and (not request.user.first_name or not request.user.last_name):
+        return redirect(section_url(FrontEndSection.AddUserDetails))
+
     page_url = request.get_full_path()
     clean_url = get_clean_url(page_url)
     if clean_url != page_url:
@@ -359,7 +364,6 @@ def index(request, id=None):
                                                           {'HOTJAR_APPLICATION_ID': settings.HOTJAR_APPLICATION_ID})
 
     GOOGLE_CONVERSION_ID = None
-    page = get_page_section(request.get_full_path())
     context = context_preload(page, request, context)
     if page and settings.GOOGLE_CONVERSION_IDS and page in settings.GOOGLE_CONVERSION_IDS:
         GOOGLE_CONVERSION_ID = settings.GOOGLE_CONVERSION_IDS[page]

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -332,8 +332,8 @@ def index(request):
     # Redirect to AddUserDetails page if First/Last name hasn't been entered yet
     if page != FrontEndSection.AddUserDetails.value and request.user.is_authenticated and (not request.user.first_name or not request.user.last_name):
         from allauth.socialaccount.models import SocialAccount
-        provider = SocialAccount.objects.filter(user=request.user).first()
-        return redirect(section_url(FrontEndSection.AddUserDetails, {'provider': provider.provider}))
+        account = SocialAccount.objects.filter(user=request.user).first()
+        return redirect(section_url(FrontEndSection.AddUserDetails, {'provider': account.provider}))
 
     page_url = request.get_full_path()
     clean_url = get_clean_url(page_url)

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -331,7 +331,9 @@ def index(request):
     page = get_page_section(request.get_full_path())
     # Redirect to AddUserDetails page if First/Last name hasn't been entered yet
     if page != FrontEndSection.AddUserDetails.value and request.user.is_authenticated and (not request.user.first_name or not request.user.last_name):
-        return redirect(section_url(FrontEndSection.AddUserDetails))
+        from allauth.socialaccount.models import SocialAccount
+        provider = SocialAccount.objects.filter(user=request.user).first()
+        return redirect(section_url(FrontEndSection.AddUserDetails, {'provider': provider.provider}))
 
     page_url = request.get_full_path()
     clean_url = get_clean_url(page_url)

--- a/common/components/controllers/AddSignUpDetails.jsx
+++ b/common/components/controllers/AddSignUpDetails.jsx
@@ -50,8 +50,8 @@ class AddSignUpDetails extends React.Component<{||}, State> {
         <div className="LogInController-root">
           <div className="LogInController-greeting">
             <p>
-              We were not able to obtain your <b>First Name</b> and{" "}
-              <b>Last Name</b> from {this.state.service}.
+              We were not able to obtain your <strong>First Name</strong> and{" "}
+              <strong>Last Name</strong> from {this.state.service}.
             </p>
             <p>Please update the missing information.</p>
           </div>

--- a/common/components/controllers/AddSignUpDetails.jsx
+++ b/common/components/controllers/AddSignUpDetails.jsx
@@ -1,0 +1,101 @@
+// @flow
+
+import DjangoCSRFToken from "django-react-csrftoken";
+import React from "react";
+import type { Validator } from "../forms/FormValidation.jsx";
+import FormValidation from "../forms/FormValidation.jsx";
+import _ from "lodash";
+import SocialMediaSignupSection from "../common/integrations/SocialMediaSignupSection.jsx";
+
+type State = {|
+  service: string,
+  firstName: string,
+  lastName: string,
+  validations: $ReadOnlyArray<Validator>,
+  isValid: boolean,
+|};
+
+class AddSignUpDetails extends React.Component<{||}, State> {
+  constructor(): void {
+    super();
+
+    this.state = {
+      service: "[TODO: Insert Service Here]",
+      firstName: "",
+      lastName: "",
+      isValid: false,
+      validations: [
+        {
+          checkFunc: (state: State) => !_.isEmpty(state.firstName),
+          errorMessage: "Please enter First Name",
+        },
+        {
+          checkFunc: (state: State) => !_.isEmpty(state.lastName),
+          errorMessage: "Please enter Last Name",
+        },
+      ],
+    };
+  }
+
+  onValidationCheck(isValid: boolean): void {
+    if (isValid !== this.state.isValid) {
+      this.setState({ isValid });
+    }
+  }
+
+  render(): React$Node {
+    return (
+      <React.Fragment>
+        <div className="LogInController-root">
+          <div className="LogInController-greeting">
+            <p>
+              We were not able to obtain your full name from{" "}
+              {this.state.service}.
+            </p>
+            <p>Please update the missing information.</p>
+          </div>
+          <form action="/api/signup/add/" method="post">
+            <DjangoCSRFToken />
+            <div>First Name:</div>
+            <div>
+              <input
+                className="LogInController-input"
+                name="first_name"
+                onChange={e => this.setState({ firstName: e.target.value })}
+                type="text"
+              />
+            </div>
+            <div>Last Name:</div>
+            <div>
+              <input
+                className="LogInController-input"
+                name="last_name"
+                onChange={e => this.setState({ lastName: e.target.value })}
+                type="text"
+              />
+            </div>
+
+            <FormValidation
+              validations={this.state.validations}
+              onValidationCheck={this.onValidationCheck.bind(this)}
+              formState={this.state}
+            />
+
+            <button
+              className="LogInController-signInButton"
+              disabled={!this.state.isValid}
+              type="submit"
+            >
+              Create Account
+            </button>
+          </form>
+          <div className="SignUpController-socialSection">
+            <SocialMediaSignupSection />
+          </div>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+export default AddSignUpDetails;

--- a/common/components/controllers/AddSignUpDetails.jsx
+++ b/common/components/controllers/AddSignUpDetails.jsx
@@ -4,8 +4,9 @@ import DjangoCSRFToken from "django-react-csrftoken";
 import React from "react";
 import type { Validator } from "../forms/FormValidation.jsx";
 import FormValidation from "../forms/FormValidation.jsx";
-import _ from "lodash";
 import SocialMediaSignupSection from "../common/integrations/SocialMediaSignupSection.jsx";
+import url from "../utils/url.js";
+import _ from "lodash";
 
 type State = {|
   service: string,
@@ -20,7 +21,7 @@ class AddSignUpDetails extends React.Component<{||}, State> {
     super();
 
     this.state = {
-      service: "[TODO: Insert Service Here]",
+      service: url.argument("provider"),
       firstName: "",
       lastName: "",
       isValid: false,

--- a/common/components/controllers/AddSignUpDetails.jsx
+++ b/common/components/controllers/AddSignUpDetails.jsx
@@ -50,8 +50,8 @@ class AddSignUpDetails extends React.Component<{||}, State> {
         <div className="LogInController-root">
           <div className="LogInController-greeting">
             <p>
-              We were not able to obtain your full name from{" "}
-              {this.state.service}.
+              We were not able to obtain your <b>First Name</b> and{" "}
+              <b>Last Name</b> from {this.state.service}.
             </p>
             <p>Please update the missing information.</p>
           </div>

--- a/common/components/controllers/SectionController.jsx
+++ b/common/components/controllers/SectionController.jsx
@@ -38,6 +38,7 @@ import FindGroupsController from "./FindGroupsController.jsx";
 import FindEventsController from "./FindEventsController.jsx";
 import CoroporateHackathonController from "./CorporateHackathonController.jsx";
 import MyEventsController from "./MyEventsController.jsx";
+import AddSignUpDetails from "./AddSignUpDetails.jsx";
 
 type State = {|
   section: SectionType,
@@ -128,6 +129,8 @@ class SectionController extends React.Component<{||}, State> {
         return <CoroporateHackathonController />;
       case Section.Error:
         return <ErrorController />;
+      case Section.AddUserDetails:
+        return <AddSignUpDetails />;
       default:
         return <div>Section not yet implemented: {this.state.section}</div>;
     }

--- a/common/components/enums/Section.js
+++ b/common/components/enums/Section.js
@@ -29,6 +29,7 @@ const Section = {
   LiveEvent: "LiveEvent",
   CorporateEvent: "CorporateEvent",
   Error: "Error",
+  AddUserDetails: "AddUserDetails",
 };
 
 export type SectionType = $Keys<typeof Section>;

--- a/common/components/urls/urls_v2.json
+++ b/common/components/urls/urls_v2.json
@@ -20,6 +20,7 @@
   {"name": "FindGroups", "pattern": "groups"},
   {"name": "Profile", "pattern": "user/(?P<id>[\\w\\-]+)"},
   {"name": "SignedUp", "pattern": "signup/verify"},
+  {"name": "AddUserDetails", "pattern": "signup/finish"},
   {"name": "EmailVerified", "pattern": "signup/done"},
   {"name": "SignUp", "pattern": "signup"},
   {"name": "LogIn", "pattern": "login"},

--- a/common/helpers/constants.py
+++ b/common/helpers/constants.py
@@ -44,3 +44,4 @@ class FrontEndSection(Enum):
     MyGroups = 'MyGroups'
     MyEvents = 'MyEvents'
     CorporateEvent = 'CorporateEvent'
+    AddUserDetails = 'AddUserDetails'

--- a/democracylab/forms.py
+++ b/democracylab/forms.py
@@ -1,4 +1,5 @@
 import json
+from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.core.exceptions import PermissionDenied
 from .models import Contributor
@@ -59,3 +60,11 @@ class DemocracyLabUserCreationForm(UserCreationForm):
             user.update_linked_items()
 
         SubscribeUserToQiqoChat(user)
+
+
+class DemocracyLabUserAddDetailsForm(forms.Form):
+    first_name = forms.CharField()
+    last_name = forms.CharField()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/democracylab/urls.py
+++ b/democracylab/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     url(r'^accounts/', include('oauth2.providers.linkedin.urls')),
     url(r'^accounts/', include('oauth2.providers.facebook.urls')),
     url(r'^accounts/', include('allauth.urls')),
+    url(r'^api/signup/add/$', views.add_signup_details, name='add_signup_details'),
     url(r'^api/signup/$', views.signup, name='signup'),
     url(r'^api/login/$', views.login_view, name='login_view'),
     url(r'^api/login/(?P<provider>\w+)', views.login_view, name='login_view'),

--- a/oauth2/adapter.py
+++ b/oauth2/adapter.py
@@ -58,12 +58,6 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         first_name = data.get('first_name')
         last_name = data.get('last_name')
 
-        if full_name is None and first_name is None:
-            missing_fields = ['name', 'first_name', 'last_name']
-            msg = 'Social login Failed for {provider}.  Missing fields: {fields}'\
-                .format(provider=provider.name, fields=missing_fields)
-            raise MissingOAuthFieldError(msg, provider.name, "Full Name")
-
         sociallogin.user.first_name = first_name or full_name.split()[0]
         sociallogin.user.last_name = last_name or ' '.join(full_name.split()[1:])
         # Set username to lowercase email

--- a/oauth2/adapter.py
+++ b/oauth2/adapter.py
@@ -58,8 +58,9 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         first_name = data.get('first_name')
         last_name = data.get('last_name')
 
-        sociallogin.user.first_name = first_name or full_name.split()[0]
-        sociallogin.user.last_name = last_name or ' '.join(full_name.split()[1:])
+        if full_name or (first_name and last_name):
+            sociallogin.user.first_name = first_name or full_name.split()[0]
+            sociallogin.user.last_name = last_name or ' '.join(full_name.split()[1:])
         # Set username to lowercase email
         sociallogin.user.username = sociallogin.user.email.lower()
 


### PR DESCRIPTION
When users sign up using an OAuth provider that doesn't require users to provide their full names (such as Github), the signup currently fails if their full name was not set.  This change introduces a new page that lets users in this scenario enter their first and last names before they can proceed on browsing the site.