### PR TITLE
Add rel=canonical links to pages

### DIFF
--- a/civictechprojects/helpers/context_preload.py
+++ b/civictechprojects/helpers/context_preload.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from urllib.parse import urljoin, urlparse
 from civictechprojects.models import Event
 from civictechprojects.caching.cache import ProjectCache, GroupCache
 from common.helpers.constants import FrontEndSection
@@ -95,7 +96,9 @@ def default_preload(context, request):
                              'Volunteer today to connect with other professionals volunteering their time.'
     context['og_type'] = 'website'
     context['og_image'] = settings.STATIC_CDN_URL + '/img/Democracylab_is_a_global_volunteer_tech_for_good_nonprofit.png'
-    context['canonical_url'] = settings.PROTOCOL_DOMAIN + request.get_full_path()
+    url = settings.PROTOCOL_DOMAIN + request.get_full_path()
+    # Remove parameters for canonical urls by default
+    context['canonical_url'] = urljoin(url, urlparse(url).path)
     return context
 
 

--- a/civictechprojects/helpers/context_preload.py
+++ b/civictechprojects/helpers/context_preload.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from civictechprojects.models import Event
 from civictechprojects.caching.cache import ProjectCache, GroupCache
 from common.helpers.constants import FrontEndSection
+from common.helpers.front_end import section_url
 from common.helpers.request_helpers import url_params
-from democracylab.models import get_request_contributor
 
 
 def about_project_preload(context, request):
@@ -32,6 +32,8 @@ def about_event_preload(context, request):
         context['description'] = event_json['event_short_description']
         if 'event_thumbnail' in event_json:
             context['og_image'] = event_json['event_thumbnail']['publicUrl']
+        slug_or_id = event.event_slug or event.id
+        context['canonical_url'] = section_url(FrontEndSection.AboutEvent,  {'id': slug_or_id})
     else:
         print('Failed to preload event info, no cache entry found: ' + event_id)
     return context

--- a/civictechprojects/helpers/context_preload.py
+++ b/civictechprojects/helpers/context_preload.py
@@ -93,6 +93,7 @@ def default_preload(context, request):
                              'Volunteer today to connect with other professionals volunteering their time.'
     context['og_type'] = 'website'
     context['og_image'] = settings.STATIC_CDN_URL + '/img/Democracylab_is_a_global_volunteer_tech_for_good_nonprofit.png'
+    context['canonical_url'] = settings.PROTOCOL_DOMAIN + request.get_full_path()
     return context
 
 

--- a/civictechprojects/templates/new_index.html
+++ b/civictechprojects/templates/new_index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" type="text/css" href="/static/css/main.styles.css"/>
     <link rel="icon" type="image/png" href="{{FAVICON_PATH}}">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" integrity="sha384-B4dIYHKNBt8Bc12p+WXckhzcICo0wtJAoU8YZTY5qE0Id1GSseTk6S+L3BlXeVIU" crossorigin="anonymous">
+    <link rel="canonical" href="{{ canonical_url }}" />
     {{ googleTagsHeadScript }}
     {{ organizationSnippet }}
     {{ hotjarScript }}


### PR DESCRIPTION
To help clear out the old urls that are circulating on search engines, we will start showing rel=canonical links on our pages.  For events, which can be accessed with either id or slug, we will use slug if available.

closes #496