### PR TITLE
Companies Page: Learn More links point to prospectus

### DIFF
--- a/common/components/controllers/CorporateHackathonController.jsx
+++ b/common/components/controllers/CorporateHackathonController.jsx
@@ -248,7 +248,9 @@ class CorporateHackathonController extends React.PureComponent<{||}, State> {
           <div className="corporate-how-after">
             <Button
               variant="cta"
-              href="#contact"
+              href={cdn.document(
+                "2021+DemocracyLab+Corporate+Hackathon+Prospectus.pdf"
+              )}
               className="corporate-cta-button"
             >
               Learn More
@@ -386,7 +388,9 @@ class CorporateHackathonController extends React.PureComponent<{||}, State> {
           <div className="corporate-sponsorship-how-button">
             <Button
               variant="cta"
-              href="#contact"
+              href={cdn.document(
+                "2021+DemocracyLab+Sponsorship+Prospectus.pdf"
+              )}
               className="corporate-cta-button"
             >
               Learn More

--- a/common/components/utils/cdn.js
+++ b/common/components/utils/cdn.js
@@ -22,6 +22,10 @@ class cdn {
       backgroundImage: `url(${pathAndFile})`,
     };
   }
+
+  static document(fileName: string): string {
+    return window.STATIC_CDN_URL + "/documents/" + fileName;
+  }
 }
 
 export default cdn;


### PR DESCRIPTION
A simple change to direct the 'Learn More' links on the Companies page to prospectus pdf files.