### PR TITLE
Fix image cropper for large images

### DIFF
--- a/civictechprojects/static/css/partials/_ImageCropUploadButton.scss
+++ b/civictechprojects/static/css/partials/_ImageCropUploadButton.scss
@@ -17,6 +17,6 @@
     font-weight: bold;
   }
   .ReactCrop__image {
-    height: 100%;
+    max-height: 500px;
   }
 }


### PR DESCRIPTION
We have an image cropper component whose outer frame was capped at 500px high, while the inner image canvas could stretch higher (and out of view).  This change caps the canvas height in line with the frame height, resulting in any images taller than 500px being compressed to fit in the frame.