### PR TITLE
Add hackathon image to homepage splash image rotation.

### DIFF
--- a/common/components/componentsBySection/FindProjects/SplashScreen.jsx
+++ b/common/components/componentsBySection/FindProjects/SplashScreen.jsx
@@ -30,6 +30,7 @@ const heroImages: $ReadOnlyArray<string> = [
   HeroImage.TopLanding,
   "CodeForGood_072719_MSReactor-074.jpg",
   HeroImage.FindEvents,
+  "CodeForGood_072719_MSReactor-003.jpg",
 ];
 
 class SplashScreen extends React.PureComponent<Props> {


### PR DESCRIPTION
This pull request is to solve issue#464. Thanks to @marlonkeating, I found the source file to which I should make a change. I have tested it with docker containers running on my local laptop. Please take a look, thank you very much.

Closes #464 