### PR TITLE
Companies page PDF link fix

### DIFF
--- a/civictechprojects/static/css/_vars.scss
+++ b/civictechprojects/static/css/_vars.scss
@@ -15,7 +15,7 @@ $color-grey-medium: #dddddd;
 $color-grey-disabled: #cecece; // any item in a disabled state
 $color-disabled-border: #a8a8a8; // for e.g. a disabled state button border
 $color-grey-frame-border: #6b6e70; // from design guide
-$color-cta: #b1d3fb; // call to action button blue, but shouldn't be used outside of $theme-colors in bootstrapoverride.scss
+$color-cta: #b1d3fb; // call to action button blue, is deprecated, should be removed when companies page is updated to remove it
 
 //background colors
 $color-background-default: #f6f7f8; //site body

--- a/civictechprojects/static/css/partials/_CorporateHackathon.scss
+++ b/civictechprojects/static/css/partials/_CorporateHackathon.scss
@@ -167,7 +167,8 @@
     border-bottom: 1px solid $color-orange;
   }
   .corporate-hackathon-stories a,
-  .corporate-sponsorship-impact a {
+  .corporate-sponsorship-impact a,
+  .corporate-learn-link a {
     color: #2caae2;
     &:hover {
       color: #2388b4;
@@ -191,6 +192,17 @@
 .corporate-hr-line {
   display: none;
   width: 45%;
+}
+.corporate-learn-link {
+  width: 100%;
+  text-align: center;
+  a,
+  i {
+    font-size: 21px; // match headline2 font size
+  }
+  i {
+    padding-left: 8px;
+  }
 }
 .corporate-top,
 .corporate-hackathon-saying,
@@ -354,6 +366,12 @@
   .corporate-hr-line {
     display: block;
   }
+  .corporate-learn-link {
+    a,
+    i {
+      font-size: 23px; // match headline2 font size
+    }
+  }
   .corporate-top-overlay {
     h1 {
       padding: 15px;
@@ -383,6 +401,8 @@
     padding-left: 20px;
     align-self: center;
     margin-top: 0;
+    margin-left: auto;
+    margin-right: auto;
   }
   .corporate-sponsorship-stat-container {
     flex-wrap: nowrap;

--- a/common/components/controllers/CorporateHackathonController.jsx
+++ b/common/components/controllers/CorporateHackathonController.jsx
@@ -16,6 +16,7 @@ import IconCircle1 from "../svg/corporatehackathon/corp1circle.svg";
 import IconCircle2 from "../svg/corporatehackathon/corp2circle.svg";
 import IconCircle3 from "../svg/corporatehackathon/corp3circle.svg";
 import type { Dictionary } from "../types/Generics.jsx";
+import { Glyph, GlyphStyles, GlyphSizes } from "../utils/glyphs.js";
 
 type State = {|
   defaultTab: string,
@@ -245,16 +246,15 @@ class CorporateHackathonController extends React.PureComponent<{||}, State> {
             After the event, DemocracyLab reports on the resulting engagement,
             outcomes, and impact.
           </p>
-          <div className="corporate-how-after">
-            <Button
-              variant="cta"
+          <div className="corporate-how-after corporate-learn-link">
+            <a 
               href={cdn.document(
                 "2021+DemocracyLab+Corporate+Hackathon+Prospectus.pdf"
               )}
-              className="corporate-cta-button"
             >
               Learn More
-            </Button>
+              <i className={Glyph(GlyphStyles.PDF, GlyphSizes.X1)}></i>
+            </a>
           </div>
         </div>
         <div className="corporate-hackathon-saying corporate-section col-12">
@@ -385,16 +385,16 @@ class CorporateHackathonController extends React.PureComponent<{||}, State> {
               </p>
             </div>
           </div>
-          <div className="corporate-sponsorship-how-button">
-            <Button
-              variant="cta"
+          <div className="corporate-sponsorship-how-button corporate-learn-link">
+            <a 
               href={cdn.document(
                 "2021+DemocracyLab+Sponsorship+Prospectus.pdf"
               )}
-              className="corporate-cta-button"
             >
               Learn More
-            </Button>
+              <i className={Glyph(GlyphStyles.PDF, GlyphSizes.X1)}></i>
+
+            </a>
           </div>
         </div>
         <div className="corporate-sponsorship-saying corporate-section col-12">


### PR DESCRIPTION
Companies page:
- repositions top section Partner With Us to look better on desktop
- removes "Learn More" buttons leading to PDFs, replaces with links and PDF icon (styled as the "Read more on our blog..." text, so it's internally consistent)

Other fixes:
- updates css vars file with note about deprecated $color-cta
