### PR TITLE
Filter out valid project URL path with invalid arguments to canonical url

### DIFF
--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -36,7 +36,7 @@ from democracylab.emails import send_to_project_owners, send_to_project_voluntee
     notify_project_owners_project_approved, contact_democracylab_email, send_to_group_owners, send_group_project_invitation_email, \
     notify_group_owners_group_approved, notify_event_owners_event_approved
 from civictechprojects.helpers.context_preload import context_preload
-from common.helpers.front_end import section_url, get_page_section, get_clean_url, redirect_from_deprecated_url
+from common.helpers.front_end import section_url, get_page_section, get_clean_url, redirect_from_deprecated_url, clean_invalid_args
 from django.views.decorators.cache import cache_page
 import requests
 
@@ -338,12 +338,16 @@ def index(request, id='Unused but needed for routing purposes; do not remove!'):
         account = SocialAccount.objects.filter(user=request.user).first()
         return redirect(section_url(FrontEndSection.AddUserDetails, {'provider': account.provider}))
 
-    # Valid project URL path with invalid arguments should show page with canonical url
     page_url = request.get_full_path()
-    if (page_url.find('?') != -1):
-        clean_url = page_url[:page_url.find('?')]
-        print('Redirecting {old_url} to {new_url}'.format(old_url=page_url, new_url=clean_url))
-        return redirect(clean_url)
+    # Valid project URL path with invalid arguments should show page with canonical url
+    url_args = request.GET.urlencode()
+    clean_url_args = clean_invalid_args(url_args)
+    if url_args != "" and clean_url_args != url_args:
+        clean_url_valid_args = request.path
+        if clean_url_args != "":
+            clean_url_valid_args += '?' + clean_url_args
+        print('Redirecting {old_url} to {new_url}'.format(old_url=page_url, new_url=clean_url_valid_args))
+        return redirect(clean_url_valid_args)
 
     page_url = request.get_full_path()
     clean_url = get_clean_url(page_url)

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -338,6 +338,13 @@ def index(request, id='Unused but needed for routing purposes; do not remove!'):
         account = SocialAccount.objects.filter(user=request.user).first()
         return redirect(section_url(FrontEndSection.AddUserDetails, {'provider': account.provider}))
 
+    # Valid project URL path with invalid arguments should show page with canonical url
+    page_url = request.get_full_path()
+    if (page_url.find('?') != -1):
+        clean_url = page_url[:page_url.find('?')]
+        print('Redirecting {old_url} to {new_url}'.format(old_url=page_url, new_url=clean_url))
+        return redirect(clean_url)
+
     page_url = request.get_full_path()
     clean_url = get_clean_url(page_url)
     if clean_url != page_url:

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -342,10 +342,8 @@ def index(request, id='Unused but needed for routing purposes; do not remove!'):
     # Valid project URL path with invalid arguments should show page with canonical url
     url_args = request.GET.urlencode()
     clean_url_args = clean_invalid_args(url_args)
-    if url_args != "" and clean_url_args != url_args:
-        clean_url_valid_args = request.path
-        if clean_url_args != "":
-            clean_url_valid_args += '?' + clean_url_args
+    if url_args != "" and clean_url_args != '?' + url_args:
+        clean_url_valid_args = request.path + clean_url_args
         print('Redirecting {old_url} to {new_url}'.format(old_url=page_url, new_url=clean_url_valid_args))
         return redirect(clean_url_valid_args)
 

--- a/common/helpers/front_end.py
+++ b/common/helpers/front_end.py
@@ -51,21 +51,27 @@ def get_page_path_parameters(url, page_section_generator=None):
     return match.groupdict()
 
 def clean_invalid_args(url_args):
+    """Filter out invalid query string arguments from old url system
+        Extract args dictionary
+        Remove id and section from dictionary
+        Reconstruct url from dictionary using args_dict_to_string
+
+    Args:
+        url_args(str) : URL query string arguments
+    
+    Returns:
+        str: clean URL query string arguments
+    """
     # Sanity check
     if url_args == "":
         return url_args
     from urllib import parse as urlparse
     # The format of url_args_dict is {'a': ['1'], 'b': ['2']}
     url_args_dict = urlparse.parse_qs(url_args, keep_blank_values=0, strict_parsing=0)
-    new_url_args = ""
-    for key, value in url_args_dict.items():
-        if key == 'section' or key == 'Section':
-            continue
-        if key == 'id' or key == 'Id':
-            continue
-        new_url_args += key + '=' + value[0] + '&'
-
-    return new_url_args[:-1] if new_url_args != "" else new_url_args
+    url_args_dict.pop('section', None)
+    url_args_dict.pop('id', None)
+    url_args_dict = {key : value[0] for key, value in url_args_dict.items()}
+    return args_dict_to_string(url_args_dict)
 
 def get_clean_url(url):
     clean_url = unescape(url)

--- a/common/helpers/front_end.py
+++ b/common/helpers/front_end.py
@@ -50,6 +50,22 @@ def get_page_path_parameters(url, page_section_generator=None):
     match = page_section_generator['regex'].search(url)
     return match.groupdict()
 
+def clean_invalid_args(url_args):
+    # Sanity check
+    if url_args == "":
+        return url_args
+    from urllib import parse as urlparse
+    # The format of url_args_dict is {'a': ['1'], 'b': ['2']}
+    url_args_dict = urlparse.parse_qs(url_args, keep_blank_values=0, strict_parsing=0)
+    new_url_args = ""
+    for key, value in url_args_dict.items():
+        if key == 'section' or key == 'Section':
+            continue
+        if key == 'id' or key == 'Id':
+            continue
+        new_url_args += key + '=' + value[0] + '&'
+
+    return new_url_args[:-1] if new_url_args != "" else new_url_args
 
 def get_clean_url(url):
     clean_url = unescape(url)

--- a/common/tests/test_helpers.py
+++ b/common/tests/test_helpers.py
@@ -48,10 +48,16 @@ class FrontEndHelperTests(TestCase):
 
     def test_clean_invalid_args(self):
         expected = ['', '?embedded=1', '?sortField=-project_date_modified&issues=education']
+        self.assertEqual(expected[0], clean_invalid_args('id=486'))
+        self.assertEqual(expected[0], clean_invalid_args('section=AboutProject'))
         self.assertEqual(expected[0], clean_invalid_args('section=AboutProject&id=486'))
         self.assertEqual(expected[1], clean_invalid_args('embedded=1'))
         self.assertEqual(expected[2], clean_invalid_args('sortField=-project_date_modified&issues=education'))
-
+        self.assertEqual(expected[2], clean_invalid_args('id=678&sortField=-project_date_modified&issues=education'))
+        self.assertEqual(expected[2], clean_invalid_args('section=AboutGroup&sortField=-project_date_modified&issues=education'))
+        self.assertEqual(expected[2], clean_invalid_args('sortField=-project_date_modified&id=678&issues=education'))
+        self.assertEqual(expected[2], clean_invalid_args('sortField=-project_date_modified&section=AboutProject&issues=education'))
+        
     def test_get_page_section(self):
         expected = 'AboutEvent'
         self.assertEqual(expected, get_page_section('/events/test-slug'))

--- a/common/tests/test_helpers.py
+++ b/common/tests/test_helpers.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from common.helpers.caching import is_sitemap_url
 from common.helpers.constants import FrontEndSection
 from common.helpers.dictionaries import merge_dicts, keys_subset
-from common.helpers.front_end import section_path, section_url, get_page_section, get_clean_url
+from common.helpers.front_end import section_path, section_url, get_page_section, get_clean_url, clean_invalid_args
 from civictechprojects.sitemaps import SitemapPages
 
 
@@ -45,6 +45,12 @@ class FrontEndHelperTests(TestCase):
     def test_get_clean_url(self):
         expected = '&clean'
         self.assertEqual(expected, get_clean_url('&amp;clean'))
+
+    def test_clean_invalid_args(self):
+        expected = ['', '?embedded=1', '?sortField=-project_date_modified&issues=education']
+        self.assertEqual(expected[0], clean_invalid_args('section=AboutProject&id=486'))
+        self.assertEqual(expected[1], clean_invalid_args('embedded=1'))
+        self.assertEqual(expected[2], clean_invalid_args('sortField=-project_date_modified&issues=education'))
 
     def test_get_page_section(self):
         expected = 'AboutEvent'


### PR DESCRIPTION
I was exploring how our URL system worked, and I think I have got some ideas, credits to @marlonkeating.  We have two versions of the URL system, which the new one contains only the path argument URL but the old one has both. 
The view function for our new URL system is the index function in civictechprojects/views.py. Since the new URL system has only the path argument URL, I filter out all the arguments, started with the '?' mark,  at the beginning of the index function. Tested it with my local machine.

resolve #603 