### PR TITLE
IconLink component layout fixes

### DIFF
--- a/civictechprojects/static/css/partials/_IconLinkDisplay.scss
+++ b/civictechprojects/static/css/partials/_IconLinkDisplay.scss
@@ -8,8 +8,8 @@
   flex-basis: 100%;
   flex-wrap: nowrap;
   min-width: 0; // see https://css-tricks.com/flexbox-truncated-text/
+  text-decoration: none; // we decorate sub-elements to control what does it
 }
-
 
 .IconLink-root p {
   margin: 0;
@@ -46,9 +46,12 @@
     text-overflow: ellipsis;
   }
 }
+.IconLink-right:hover, .IconLink-right:active {
+  text-decoration: underline;
+}
+
 
 .IconLink-topText {
-  color: $color-text-dark;
   font-weight: 600;
   padding-top: 10px;
   padding-left: 8px;

--- a/civictechprojects/static/css/partials/_IconLinkDisplay.scss
+++ b/civictechprojects/static/css/partials/_IconLinkDisplay.scss
@@ -46,7 +46,7 @@
     text-overflow: ellipsis;
   }
 }
-.IconLink-right:hover, .IconLink-right:active {
+.IconLink-root:hover p, .IconLink-root:active p {
   text-decoration: underline;
 }
 

--- a/civictechprojects/static/css/partials/_IconLinkDisplay.scss
+++ b/civictechprojects/static/css/partials/_IconLinkDisplay.scss
@@ -3,6 +3,15 @@
   padding-bottom: 20px;
 }
 
+.IconLink-root a {
+  display: flex;
+  flex-basis: 100%;
+  flex-wrap: nowrap;
+  max-width: 360px; // set this to whatever "never-exceed" value we want, esp. useful for tablets
+  min-width: 0; // see https://css-tricks.com/flexbox-truncated-text/
+}
+
+
 .IconLink-root p {
   margin: 0;
 }
@@ -14,7 +23,6 @@
 }
 
 .IconLink-left {
-  float: left;
   width: 60px;
   height: 64px;
   padding: 15px;
@@ -24,8 +32,7 @@
 }
 
 .IconLink-right {
-  float: right;
-  width: 170px;
+  width: 100%; // makes it "take up all remaining space"
   height: 64px;
   line-height: 23px;
   border-top: 1px solid $color-grey-medium;
@@ -33,10 +40,11 @@
   border-right: 1px solid $color-grey-medium;
   border-bottom-right-radius: 5px;
   border-bottom: 1px solid $color-grey-medium;
-  display: block;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  p {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 }
 
 .IconLink-topText {

--- a/civictechprojects/static/css/partials/_IconLinkDisplay.scss
+++ b/civictechprojects/static/css/partials/_IconLinkDisplay.scss
@@ -40,6 +40,7 @@
   border-right: 1px solid $color-grey-medium;
   border-bottom-right-radius: 5px;
   border-bottom: 1px solid $color-grey-medium;
+  overflow: hidden; // has to be set here and in <p>
   p {
     overflow: hidden;
     white-space: nowrap;

--- a/civictechprojects/static/css/partials/_IconLinkDisplay.scss
+++ b/civictechprojects/static/css/partials/_IconLinkDisplay.scss
@@ -7,7 +7,6 @@
   display: flex;
   flex-basis: 100%;
   flex-wrap: nowrap;
-  max-width: 360px; // set this to whatever "never-exceed" value we want, esp. useful for tablets
   min-width: 0; // see https://css-tricks.com/flexbox-truncated-text/
 }
 

--- a/civictechprojects/static/css/partials/_Profile.scss
+++ b/civictechprojects/static/css/partials/_Profile.scss
@@ -151,7 +151,6 @@
     }
   }
   // fixed width sections prevent long URL overflow issue on group page project cards
-  // TODO: see if https://css-tricks.com/flexbox-truncated-text/ fixes this instead (min-width: 0;)
   .Profile-primary-container {
     width: 590px;
   }

--- a/civictechprojects/static/css/partials/_Profile.scss
+++ b/civictechprojects/static/css/partials/_Profile.scss
@@ -112,9 +112,6 @@
     word-break: break-word;
   }
 }
-.Profile-links .IconLink-right {
-  width: 196px; // fixes issue at 320px
-}
 
 
 @include media-breakpoint-up(lg) {
@@ -154,21 +151,14 @@
     }
   }
   // fixed width sections prevent long URL overflow issue on group page project cards
+  // TODO: see if https://css-tricks.com/flexbox-truncated-text/ fixes this instead (min-width: 0;)
   .Profile-primary-container {
     width: 590px;
   }
   .Profile-secondary-section {
     width: 340px;
   }
-  .Profile-links {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
 
-    h4 {
-      min-width: 260px;
-    }
-  }
 }
 @include media-breakpoint-up(xl) {
   .Profile-primary-container {


### PR DESCRIPTION
- Updates IconLink layout and sizing rules so it'll conform to parent size instead of fixed width (which broke a lot on responsive viewport changes)
- Long titles are truncated instead of wrapping/breaking the element
- Link colors are represented instead of black text with no hover change, so the link part of IconLink look like links


Before:
![image](https://user-images.githubusercontent.com/16870466/123337287-d5931c80-d4fb-11eb-8f81-430947670b71.png)
Fixed width, regardless of available space from parent element

After:
![image](https://user-images.githubusercontent.com/16870466/123480382-21ef6280-d5b7-11eb-9fd9-5e8311d1819e.png)

Scales to fit available space, link colors are consistent with the rest of the site, and fixes a misaligned H4, bonus.

On tablets these links may look a little weird due to stretching full width but why not use the space if it's available, right?