### PR TITLE
Shorten long file names with ...

### DIFF
--- a/civictechprojects/static/css/partials/_FileUploadList.scss
+++ b/civictechprojects/static/css/partials/_FileUploadList.scss
@@ -1,0 +1,15 @@
+.FileUploadList-item {
+    display: flex;
+    align-items: center;
+    i {
+        margin-left: 1rem;
+    }
+    a {
+        max-width: calc(100% - 40px);
+        display: inline-block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+}

--- a/civictechprojects/static/css/styles.scss
+++ b/civictechprojects/static/css/styles.scss
@@ -97,3 +97,4 @@
 @import "partials/PositionList";
 @import "partials/LinkList";
 @import "partials/Video";
+@import "partials/FileUploadList";

--- a/common/components/forms/FileUploadList.jsx
+++ b/common/components/forms/FileUploadList.jsx
@@ -136,7 +136,7 @@ class FileUploadList extends React.PureComponent<Props, State> {
   _renderFiles(): Array<React$Node> {
     return this.state.files.map((file, i) => (
       <div key={i}>
-        <a href={file.publicUrl} target="_blank" rel="noopener noreferrer">
+        <a style={{maxWidth: '35%', display: 'inline-block', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'}} href={file.publicUrl} target="_blank" rel="noopener noreferrer">
           {file.fileName}
         </a>
         <i

--- a/common/components/forms/FileUploadList.jsx
+++ b/common/components/forms/FileUploadList.jsx
@@ -135,8 +135,8 @@ class FileUploadList extends React.PureComponent<Props, State> {
 
   _renderFiles(): Array<React$Node> {
     return this.state.files.map((file, i) => (
-      <div key={i}>
-        <a style={{maxWidth: '35%', display: 'inline-block', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'}} href={file.publicUrl} target="_blank" rel="noopener noreferrer">
+      <div className="FileUploadList-item" key={i}>
+        <a href={file.publicUrl} target="_blank" rel="noopener noreferrer">
           {file.fileName}
         </a>
         <i


### PR DESCRIPTION
Shortens long file names that are larger than 35% of card width and ends it with "...". Only changes display of file name not file name itself.