### PR TITLE
Add canonical url to header metadata

### DIFF
--- a/civictechprojects/templates/new_index.html
+++ b/civictechprojects/templates/new_index.html
@@ -10,6 +10,7 @@
     <meta name="og:description" content="{{ description }}" />
     <meta name="og:type" content="{{ og_type }}" />
     <meta name="og:image" content="{{ og_image }}" />
+    <meta name="og:url" content="{{ canonical_url }}" />
     <meta name="image" property="og:image" content="{{ og_image }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="/static/js/runtime.bundle.js" defer></script>


### PR DESCRIPTION
I have added the "og:url" metadata tag in the header. 
Tested by verifying the url getting formed in the browser inspect.