### PR TITLE
Add request throttling for anonymous and authenticated users

### DIFF
--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -39,6 +39,8 @@ from civictechprojects.helpers.context_preload import context_preload
 from common.helpers.front_end import section_url, get_page_section, get_clean_url, redirect_from_deprecated_url
 from common.helpers.redirectors import redirect_by, InvalidArgumentsRedirector, DirtyUrlsRedirector, DeprecatedUrlsRedirector
 from django.views.decorators.cache import cache_page
+from rest_framework.decorators import api_view, throttle_classes
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 import requests
 
 
@@ -329,6 +331,8 @@ def approve_event(request, event_id):
 
 @ensure_csrf_cookie
 @xframe_options_exempt
+@api_view()
+@throttle_classes([AnonRateThrottle, UserRateThrottle])
 def index(request, id='Unused but needed for routing purposes; do not remove!'):
     page = get_page_section(request.get_full_path())
     # TODO: Add to redirectors.py

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -184,11 +184,21 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+THROTTLE_RATE_ANONYMOUS = os.environ.get('THROTTLE_RATE_ANONYMOUS', '5/second')
+THROTTLE_RATE_AUTHENTICATED = os.environ.get('THROTTLE_RATE_AUTHENTICATED', '5/second')
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAdminUser',
+        'rest_framework.permissions.AllowAny',
     ],
-    'PAGE_SIZE': 10
+    'PAGE_SIZE': 10,
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle'
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': THROTTLE_RATE_ANONYMOUS,
+        'user': THROTTLE_RATE_AUTHENTICATED
+    }
 }
 
 

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -137,3 +137,7 @@ export QIQO_API_KEY=democracylab
 #Add CSP variable examples
 export CSP_FRAME_SRC='["qiqochat.com", "*.qiqochat.com", "*.google.com", "*.youtube.com", "democracylab.org", "democracy-lab-prod-mirror.herokuapp.com", "democracy-lab-dev.herokuapp.com", "democracy-lab-staging.herokuapp.com"]'
 export CSP_FRAME_ANCESTORS='["qiqochat.com", "*.qiqochat.com", "*.google.com", "*.youtube.com", "democracylab.org", "democracy-lab-prod-mirror.herokuapp.com", "democracy-lab-dev.herokuapp.com", "democracy-lab-staging.herokuapp.com"]'
+
+# Max rate for anonymous or authenticated requests. Valid time periods include second, minute, hour or day
+export THROTTLE_RATE_ANONYMOUS=5/second
+export THROTTLE_RATE_AUTHENTICATED=5/second


### PR DESCRIPTION
This change adds a configurable rate limit to our main page view, in order to mitigate against bot traffic surges.

## Environment Variables ##
Note: Format is '#/time period'. Valid time periods include second, minute, hour or day
THROTTLE_RATE_ANONYMOUS: Max allowable rate for unauthenticated requests
THROTTLE_RATE_AUTHENTICATED: Max allowable rate for logged in users

closes #710 