### PR TITLE
Support multiple videos on Video page

### DIFF
--- a/civictechprojects/helpers/context_preload.py
+++ b/civictechprojects/helpers/context_preload.py
@@ -106,7 +106,8 @@ def videos_preload(context, request):
         print(video_json)
         if video_json:
             context['YOUTUBE_VIDEO_URL'] = video_json['video_url']
-            context['description'] = video_json['video_description']
+            if 'video_description' in video_json:
+                context['description'] = video_json['video_description']
             if 'video_thumbnail' in video_json:
                 context['og_image'] = video_json['video_thumbnail']
     return context

--- a/civictechprojects/helpers/context_preload.py
+++ b/civictechprojects/helpers/context_preload.py
@@ -97,6 +97,21 @@ def my_events_preload(context, request):
     return context
 
 
+def videos_preload(context, request):
+    # TODO: Default to 'overview'
+    context = default_preload(context, request)
+    query_args = url_params(request)
+    video_id = query_args['id']
+    if video_id in settings.VIDEO_PAGES:
+        video_json = settings.VIDEO_PAGES[video_id]
+        print(video_json)
+        context['YOUTUBE_VIDEO_URL'] = video_json['video_url']
+        context['description'] = video_json['video_description']
+        if 'video_thumbnail' in video_json:
+            context['og_image'] = video_json['video_thumbnail']
+    return context
+
+
 def default_preload(context, request):
     context['title'] = 'DemocracyLab'
     context['description'] = 'Everyone has something to contribute to the technical solutions society needs. ' \
@@ -118,7 +133,8 @@ preload_urls = [
     {'section': FrontEndSection.MyEvents.value, 'handler': my_events_preload},
     {'section': FrontEndSection.Donate.value, 'handler': donate_preload},
     {'section': FrontEndSection.AboutGroup.value, 'handler': about_group_preload},
-    {'section': FrontEndSection.Companies.value, 'handler': companies_preload}
+    {'section': FrontEndSection.Companies.value, 'handler': companies_preload},
+    {'section': FrontEndSection.VideoOverview.value, 'handler': videos_preload}
 ]
 
 

--- a/civictechprojects/helpers/context_preload.py
+++ b/civictechprojects/helpers/context_preload.py
@@ -98,17 +98,17 @@ def my_events_preload(context, request):
 
 
 def videos_preload(context, request):
-    # TODO: Default to 'overview'
     context = default_preload(context, request)
-    query_args = url_params(request)
-    video_id = query_args['id']
-    if video_id in settings.VIDEO_PAGES:
-        video_json = settings.VIDEO_PAGES[video_id]
+    if settings.VIDEO_PAGES:
+        query_args = url_params(request)
+        video_id = query_args['id']
+        video_json = settings.VIDEO_PAGES[video_id] if video_id in settings.VIDEO_PAGES else settings.VIDEO_PAGES['overview']
         print(video_json)
-        context['YOUTUBE_VIDEO_URL'] = video_json['video_url']
-        context['description'] = video_json['video_description']
-        if 'video_thumbnail' in video_json:
-            context['og_image'] = video_json['video_thumbnail']
+        if video_json:
+            context['YOUTUBE_VIDEO_URL'] = video_json['video_url']
+            context['description'] = video_json['video_description']
+            if 'video_thumbnail' in video_json:
+                context['og_image'] = video_json['video_thumbnail']
     return context
 
 

--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -369,7 +369,6 @@ def index(request, id='Unused but needed for routing purposes; do not remove!'):
         'EVENT_URL': settings.EVENT_URL,
         'PRIVACY_POLICY_URL': settings.PRIVACY_POLICY_URL,
         'DONATE_PAGE_BLURB': settings.DONATE_PAGE_BLURB,
-        'YOUTUBE_VIDEO_URL': settings.YOUTUBE_VIDEO_URL,
         'HEAP_ANALYTICS_ID': settings.HEAP_ANALYTICS_ID
     }
     if settings.HOTJAR_APPLICATION_ID:

--- a/common/components/urls/urls_v2.json
+++ b/common/components/urls/urls_v2.json
@@ -30,6 +30,6 @@
   {"name": "ThankYou", "pattern": "donate/thankyou"},
   {"name": "Donate", "pattern": "donate"},
   {"name": "ContactUs", "pattern": "contact"},
-  {"name": "VideoOverview", "pattern": "videos/(?P<id>[\\w\\-]+)"},
+  {"name": "VideoOverview", "pattern": "videos/(?P<id>[\\w\\-]*)"},
   {"name": "Error", "pattern": "error"}
 ]

--- a/common/components/urls/urls_v2.json
+++ b/common/components/urls/urls_v2.json
@@ -30,6 +30,6 @@
   {"name": "ThankYou", "pattern": "donate/thankyou"},
   {"name": "Donate", "pattern": "donate"},
   {"name": "ContactUs", "pattern": "contact"},
-  {"name": "VideoOverview", "pattern": "videos/overview"},
+  {"name": "VideoOverview", "pattern": "videos/(?P<id>[\\w\\-]+)"},
   {"name": "Error", "pattern": "error"}
 ]

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -442,7 +442,9 @@ PRIVACY_POLICY_URL = os.environ.get('PRIVACY_POLICY_URL')
 DONATE_PAGE_BLURB = os.environ.get('DONATE_PAGE_BLURB', '')
 
 # Video Link
-YOUTUBE_VIDEO_URL = os.environ.get('YOUTUBE_VIDEO_URL', '')
+VIDEO_PAGES = os.environ.get('VIDEO_PAGES', '')
+if VIDEO_PAGES is not None:
+    VIDEO_PAGES = ast.literal_eval(VIDEO_PAGES)
 
 # Ghost blog configs
 GHOST_URL = os.environ.get('GHOST_URL', '')

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -139,4 +139,5 @@ export CSP_FRAME_ANCESTORS='["qiqochat.com", "*.qiqochat.com", "*.google.com", "
 export THROTTLE_RATE_ANONYMOUS=5/second
 export THROTTLE_RATE_AUTHENTICATED=5/second
 
-# TODO: VIDEO_PAGES
+# Links and metadata for /videos/ page
+export VIDEO_PAGES='{"overview":{"video_url":"https://www.youtube.com/embed/nvIUWtx-nmo"}, "wgu-hack-for-the-future":{"video_url":"https://www.youtube.com/embed/4hujk4liEvw","video_thumbnail":"https://d1agxr2dqkgkuy.cloudfront.net/img/wgu_event_2021.jpeg","video_description":"Western Governors University sponsored this event to give community college students in Alaska, Colorado, Hawaii, Idaho, Montana, Oregon, Utah, Washington, and Wyoming an opportunity to hone their tech skills while contributing to tech-for-good projects."}}'

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -138,3 +138,5 @@ export CSP_FRAME_ANCESTORS='["qiqochat.com", "*.qiqochat.com", "*.google.com", "
 # Max rate for anonymous or authenticated requests. Valid time periods include second, minute, hour or day
 export THROTTLE_RATE_ANONYMOUS=5/second
 export THROTTLE_RATE_AUTHENTICATED=5/second
+
+# TODO: VIDEO_PAGES


### PR DESCRIPTION
We now support multiple videos on the /videos/ page.  The urls and metadata are now controlled by the VIDEO_PAGES environment variable, which is a dictionary of url slugs to video metadata.  The default video is marked by the 'overview' tag, and any urls that don't match any other patterns will map there.

## VIDEO_PAGES Fields ##
 video_url (required): Video embed url
video_thumbnail: Thumbnail that will show up when sharing link to video page
video_description: Video page description