### PR TITLE
Bug Fix: Allow full clearing of tag fields

### DIFF
--- a/common/helpers/form_helpers.py
+++ b/common/helpers/form_helpers.py
@@ -65,7 +65,7 @@ def read_form_field_tags(model, form, field_name):
     :return: True if changes to model tag field were made
     """
     form_tags = _read_form_field(form, field_name)
-    if form_tags:
+    if form_tags is not None:
         if is_json_string(form_tags):
             # Convert full tag data to comma-delimited slugs string
             form_tags_json = json.loads(form_tags)


### PR DESCRIPTION
We needed to distinguish from tag fields that were not set and tag fields that were set with a blank value, to determine whether to clear them.

resolves #751