### PR TITLE
After inviting a group to a project, group photo that is too tall overlaps in project profile 

### DIFF
--- a/civictechprojects/static/css/partials/_AboutProject.scss
+++ b/civictechprojects/static/css/partials/_AboutProject.scss
@@ -84,6 +84,7 @@
   i {
     object-fit: contain;
     max-width: 100%;
+    max-height:50px;
   }
   i {
     color: $color-text-dark;


### PR DESCRIPTION
Fixed the following before if the group photo was too tall it would overflow/overlap

![image](https://user-images.githubusercontent.com/3013835/134292330-073ae2b7-60df-4722-9e8e-6b6c021253a7.png)
