### PR TITLE
Designsystem/linkcolor

### DIFF
--- a/civictechprojects/static/css/_bootstrapoverride.scss
+++ b/civictechprojects/static/css/_bootstrapoverride.scss
@@ -60,3 +60,8 @@ $h1-font-size: $font-size-base * 1.6875; // 27px, headline1
 $h2-font-size: $font-size-base * 1.3125; // 21px, headline2
 $h3-font-size: $font-size-base * 1.0625; // 17px, subtitle1
 $h4-font-size: $font-size-base * 0.9375; // 15px, subtitle2
+
+// design system link colors (October 6, 2021)
+// see _reboot.scss, ~line 182, for implementation
+$link-color: $color-link;
+$link-hover-color: $color-link-hover;

--- a/civictechprojects/static/css/_vars.scss
+++ b/civictechprojects/static/css/_vars.scss
@@ -1,7 +1,8 @@
-//pattern for variable names: generic-to-specific.
-//when possible name variables after function
+// DemocracyLab Colors
+// SASS Variables for styling our brand and colors
+// do not declare these manually in CSS, always use the variable
 
-//colors
+//## colors (NOT design system implementation yet; all these may require review)
 $color-orange: #f79e02; // brand
 $color-orange-dark: #de8e01; // accent/button borders
 $color-orange-light: #f7cf88; // footer button hover
@@ -17,9 +18,16 @@ $color-grey-disabled: #cecece; // any item in a disabled state
 $color-disabled-border: #a8a8a8; // for e.g. a disabled state button border
 $color-grey-frame-border: #6b6e70; // from design guide
 $color-grey-unselected: #585858; // unselected item color
-$color-cta: #b1d3fb; // call to action button blue, is deprecated, should be removed when companies page is updated to remove it
+$color-cta: #b1d3fb; // deprecated -- TODO: remove when companies page is updated, remove bootstrapoverride variant cta also
 
-//background colors
+// ## link colors (design system "Secondary Colors - Blue Color Scheme - used for text links across dlab, implemented October 6, 2021)
+// note that these are also in _bootstrapoverride, overriding $link-color and $link-hover-color 
+$color-link: #0362cd; // primary link color, info color
+$color-link-hover: #024fa6; // use with underline
+$color-link-active: #02438c; // when something in a pressed state, also use underline
+$color-link-visited: #662d91; 
+
+// ## background colors
 $color-background-default: #f6f7f8; //site body
 $color-background-light: #ffffff; //individual components
 $color-background-dark: #222629; //nav bar, footer
@@ -28,6 +36,6 @@ $color-background-success: #a3ffa6; // success messages
 $color-background-error: #ffcfcf; //error messages
 $color-opacity-layer: #231f20; //  overlay opacity
 
-//Dimensions
+// ## Dimensions (outdated? Heights are not accurate. TODO: check if we use these
 $header-height: 50px; //Height of site header
 $footer-height: 50px; //Height of site footer

--- a/civictechprojects/static/css/partials/_CorporateHackathon.scss
+++ b/civictechprojects/static/css/partials/_CorporateHackathon.scss
@@ -83,14 +83,6 @@
     border: 1px solid $color-text-dark;
     border-bottom: 1px solid $color-orange;
   }
-  .corporate-hackathon-stories a,
-  .corporate-sponsorship-impact a,
-  .corporate-learn-link a {
-    color: #2caae2;
-    &:hover {
-      color: #2388b4;
-    }
-  }
   .carousel-blog-root {
     margin-bottom: 2rem;
   }

--- a/civictechprojects/static/css/partials/_Global.scss
+++ b/civictechprojects/static/css/partials/_Global.scss
@@ -47,11 +47,6 @@ input[type="submit"]:disabled {
   border: $color-disabled-border;
 }
 
-//for on-page actions we want to appear as links
-.pseudo-link {
-  color: $color-orange;
-  text-decoration: underline;
-}
 
 //class-based toggle of background color
 .background-light {
@@ -210,4 +205,21 @@ h4,
   // font-size: 16px;
   // font-weight: 600;
   // }
+}
+
+// design system link colors are in _vars.scss and _bootstrapoverride, but we have some psuedoselectors here
+//for on-page actions we want to appear as links (e.g. js onclick events)
+// use pseudo-link as sparingly as possible - links should be links, doubly so since these won't respect :visited, etc
+.pseudo-link {
+  @extend a
+}
+a:active, .psuedo-link:active {
+  color: $color-link-active;
+  text-decoration: underline;
+}
+a:visited {
+  color: $color-link-visited;
+}
+a.btn:visited {
+  color: inherit; // buttons acting as links should not take visited color
 }

--- a/civictechprojects/static/css/partials/_Global.scss
+++ b/civictechprojects/static/css/partials/_Global.scss
@@ -220,6 +220,6 @@ a:active, .psuedo-link:active {
 a:visited {
   color: $color-link-visited;
 }
-a.btn:visited {
-  color: inherit; // buttons acting as links should not take visited color
+a.btn:visited, .btn:visited, button:visited {
+  color: inherit; // buttons acting as links should not take visited color -- we'll have to revisit this when buttons are implemented from DS
 }

--- a/civictechprojects/static/css/partials/_IconLinkDisplay.scss
+++ b/civictechprojects/static/css/partials/_IconLinkDisplay.scss
@@ -49,6 +49,12 @@
 .IconLink-root:hover p, .IconLink-root:active p {
   text-decoration: underline;
 }
+.IconLink-root:hover .IconLink-topText {
+  color: $color-link-hover;
+}
+.IconLink-root:active .IconLink-topText {
+  color: $color-link-active;
+}
 
 
 .IconLink-topText {

--- a/civictechprojects/static/css/partials/_MainHeader.scss
+++ b/civictechprojects/static/css/partials/_MainHeader.scss
@@ -70,6 +70,9 @@
   .navbar-light .navbar-nav .nav-link:active {
     color: inherit;
   }
+  a:visited, .navbar-light .navbar-nav .nav-link:visited {
+    color: inherit;
+  }
   .navbar {
     padding: 0.25rem; //override entire navbar padding values, set our own later
   }


### PR DESCRIPTION
Changes link colors sitewide to match design system, closes #777 

### Notes
- navigation colors are unchanged at the moment because nav hover/active/visited states needs design system input
- button :visited states are going to be a little chaotic until button styles from design system are implemented