### PR TITLE
Live Event: Allow admins to impersonate qiqochat users

### DIFF
--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -420,7 +420,7 @@ def index(request, id='Unused but needed for routing purposes; do not remove!'):
         context['lastName'] = contributor.last_name
         context['isStaff'] = contributor.is_staff
         context['volunteeringUpForRenewal'] = contributor.is_up_for_volunteering_renewal()
-        context['QIQO_IFRAME_URL'] = get_user_qiqo_iframe(contributor)
+        context['QIQO_IFRAME_URL'] = get_user_qiqo_iframe(contributor, request)
 
         thumbnail = ProjectFile.objects.filter(file_user=request.user.id,
                                                file_category=FileCategory.THUMBNAIL.value).first()

--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -436,6 +436,7 @@ QIQO_API_KEY = os.environ.get('QIQO_API_KEY', 'democracylab')
 QIQO_API_SECRET = os.environ.get('QIQO_API_SECRET', 'SECRET')
 QIQO_CIRCLE_UUID = os.environ.get('QIQO_CIRCLE_UUID', 'nmitq')
 QIQO_SIGNUP_TIMEOUT_SECONDS = int(os.environ.get('QIQO_SIGNUP_TIMEOUT_SECONDS', 5))
+QIQO_IMPERSONATION_ENABLED = os.environ.get('QIQO_IMPERSONATION_ENABLED', False) == 'True'
 
 BLOG_URL = os.environ.get('BLOG_URL', 'https://blog.democracylab.org')
 


### PR DESCRIPTION
When QIQO_IMPERSONATION_ENABLED=True, users can add uuid and qiqo_uuid to the Live Event page url to impersonate another user inside the qiqochat iframe.

resolves #805 