### PR TITLE
Add CORS domain whitelist

### DIFF
--- a/democracylab/settings.py
+++ b/democracylab/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'django.contrib.sitemaps',
     'django.contrib.staticfiles',
     'rest_framework',
+    'corsheaders',
     'taggit',
     'allauth',
     'allauth.account',
@@ -108,6 +109,7 @@ MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -379,6 +381,10 @@ if CSP_FRAME_ANCESTORS is not None:
 CSP_FRAME_SRC = os.environ.get('CSP_FRAME_SRC', None)
 if CSP_FRAME_SRC is not None:
     CSP_FRAME_SRC = ast.literal_eval(CSP_FRAME_SRC)
+
+CORS_ALLOWED_ORIGIN_PATTERNS = os.environ.get('CORS_ALLOWED_ORIGIN_PATTERNS', None)
+if CORS_ALLOWED_ORIGIN_PATTERNS is not None:
+    CORS_ALLOWED_ORIGIN_REGEXES = ast.literal_eval(CORS_ALLOWED_ORIGIN_PATTERNS)
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ django-appconf==1.0.2
 django-autofixture==0.12.1
 django-compressor==2.1.1
 django-core==1.4.1
+django-cors-headers==3.10.1
 django-csp==3.7
 django-registration==3.1.2
 django-rq==2.4.1


### PR DESCRIPTION
This change adds a CORS whitelist, controlled by the CORS_ALLOWED_ORIGIN_PATTERNS environment variable, to whitelist external domains that we allow to consume our api.

resolves #788 