### PR TITLE
PR#870 Refactor Fixes

### DIFF
--- a/civictechprojects/static/css/_bootstrapoverride.scss
+++ b/civictechprojects/static/css/_bootstrapoverride.scss
@@ -73,3 +73,10 @@ $headings-line-height: 1.5; // override the 1.2 default because it seems impervi
 // see _reboot.scss, ~line 182, for implementation
 $link-color: $color-link;
 $link-hover-color: $color-link-hover;
+
+// Button rules (design system buttons, added May 2022)
+//size rules should result in padding + border + line-height = 40px; for a 'borderless' button just set border color to match background
+
+$btn-padding-y: 0.4375rem; // 7px
+$btn-padding-x: 1rem; // 16px;
+$btn-border-radius: 0.25rem; // 4px

--- a/civictechprojects/static/css/_vars.scss
+++ b/civictechprojects/static/css/_vars.scss
@@ -135,6 +135,3 @@ $color-background-success: #a3ffa6; // success messages
 $color-background-error: #ffcfcf; //error messages
 $color-opacity-layer: #231f20; //  overlay opacity, see SplashScreen component. Not used for modals.
 
-// ## Dimensions (outdated? Heights are not accurate. TODO: check if we use these
-$header-height: 50px; //Height of site header
-$footer-height: 50px; //Height of site footer

--- a/civictechprojects/static/css/partials/_Global.scss
+++ b/civictechprojects/static/css/partials/_Global.scss
@@ -29,7 +29,7 @@ a[type="button"].btn-footer:active {
 //DemocracyLab button styles (overwrite/extend Bootstrap button rules)
 // in general all buttons have a border, but some use the same color as the button to visually have none
 // padding instead of selecting a specific height is for vertical align, but this could stand a rework later
-// Bootstrap specificity is things like .btn-variantname:not(:disabled):not(.disabled):active, hence !important to bypass it
+// declares base classes first, then conditional active/hovers to manage .btn:not(disabled):not(.disabled) specificity
 
 button,
 .btn {
@@ -37,41 +37,21 @@ button,
   font-weight: 500;
   border-radius: 4px;
 }
+// "focus ring" outline. by default Bootstrap uses customizable box shadow, and we may want to investigate that further, date TBD -- May 25, 2022
 button:focus,
 .btn:focus {
   outline: 3px solid $color-blue-50;
   outline-offset: 1px;
 }
+// default button display rules, overriding the $theme-colors generated bases as needed
 .btn-primary {
   color: $color-neutral-100;
   border-color: $color-brand-70;
-}
-.btn-primary:active,
-.btn-primary:hover {
-  border-color: $color-brand-60 !important;
-  color: $color-neutral-100 !important;
-}
-.btn-primary:hover {
-  background-color: $color-brand-60 !important;
-}
-.btn-primary:active {
-  background-color: $color-brand-45 !important;
 }
 .btn.btn-secondary {
   color: $color-neutral-90;
   border-color: $color-neutral-75;
   background-color: $color-neutral-10;
-}
-.btn-secondary:active,
-.btn-secondary:hover,
-.btn-outline-secondary:active,
-.btn-outline-secondary:hover {
-  background-color: $color-neutral-20 !important;
-  color: $color-neutral-90 !important;
-}
-.btn-success:active,
-.btn-success:hover {
-  background-color: $color-green-100 !important;
 }
 .btn-destructive {
   color: $color-red-80;
@@ -79,24 +59,10 @@ button:focus,
   background-color: $color-background-light;
 }
 .btn-outline-destructive {
-  color: $color-red-80 !important;
-  background-color: transparent !important;
+  color: $color-red-80;
+  background-color: transparent;
 }
-.btn-destructive:active,
-.btn-destructive:hover,
-.btn-outline-destructive:hover,
-.btn-outline-destructive:active {
-  background-color: $color-red-10 !important;
-}
-.btn-destructive:hover,
-.btn-outline-destructive:hover {
-  color: $color-red-80 !important;
-}
-.btn-destructive:active,
-.btn-ouline-destructive:active {
-  color: $color-red-100 !important;
-  border-color: $color-red-100 !important;
-}
+
 .btn-ghost,
 .btn-outline-ghost {
   color: $color-neutral-75;
@@ -105,17 +71,60 @@ button:focus,
   border-color: transparent;
   background-color: transparent;
 }
-.btn-ghost:active,
-.btn-ghost:hover,
-.btn-outline-ghost:hover,
-.btn-outline-ghost:active {
-  border-color: $color-neutral-20;
-  background-color: $color-neutral-20;
+
+//hover, active state rules must also meet the conditional of "not disabled," either psuedoselector or class
+.btn:not(:disabled):not(.disabled) {
+  &.btn-primary:active,
+  &.btn-primary:hover {
+    border-color: $color-brand-60;
+    color: $color-neutral-100;
+  }
+  &.btn-primary:hover {
+    background-color: $color-brand-60;
+  }
+  &.btn-primary:active {
+    background-color: $color-brand-45;
+  }
+  &.btn-secondary:active,
+  &.btn-secondary:hover,
+  &.btn-outline-secondary:active,
+  &.btn-outline-secondary:hover {
+    background-color: $color-neutral-20;
+    color: $color-neutral-90;
+  }
+  &.btn-success:active,
+  &.btn-success:hover {
+    background-color: $color-green-100;
+  }
+  &.btn-destructive:active,
+  &.btn-destructive:hover,
+  &.btn-outline-destructive:hover,
+  &.btn-outline-destructive:active {
+    background-color: $color-red-10;
+  }
+  &.btn-destructive:hover,
+  &.btn-outline-destructive:hover {
+    color: $color-red-80;
+  }
+  &.btn-destructive:active,
+  &.btn-ouline-destructive:active {
+    color: $color-red-100;
+    border-color: $color-red-100;
+  }
+
+  &.btn-ghost:active,
+  &.btn-ghost:hover,
+  &.btn-outline-ghost:hover,
+  &.btn-outline-ghost:active {
+    border-color: $color-neutral-20;
+    background-color: $color-neutral-20;
+  }
+  &.btn-ghost:active,
+  &.btn-outline-ghost:active {
+    color: $color-neutral-100;
+  }
 }
-.btn-ghost:active,
-.btn-outline-ghost:active {
-  color: $color-neutral-100;
-}
+// unlike default bootstrap, we want all disabled buttons to look the same regardless of variant
 button:disabled,
 .btn:disabled {
   background-color: $color-neutral-25 !important;

--- a/civictechprojects/static/css/partials/_Global.scss
+++ b/civictechprojects/static/css/partials/_Global.scss
@@ -33,10 +33,9 @@ a[type="button"].btn-footer:active {
 
 button,
 .btn {
-  padding: 0.4375rem 1rem; // 7px 16px; padding + border + line-height = 40px height button. for borderless buttons just set border color to background color.
   font-weight: 500;
-  border-radius: 4px;
 }
+
 // "focus ring" outline. by default Bootstrap uses customizable box shadow, and we may want to investigate that further, date TBD -- May 25, 2022
 button:focus,
 .btn:focus {

--- a/civictechprojects/static/css/partials/_SplashScreen.scss
+++ b/civictechprojects/static/css/partials/_SplashScreen.scss
@@ -30,8 +30,6 @@
   border: 1px solid $color-orange;
   color: $color-text-dark;
   background-color: $color-orange;
-  border-radius: 5px;
-  padding: 6px 12px;
   min-width: 80px;
 }
 
@@ -39,8 +37,6 @@
   border: 1px solid $color-text-light;
   color: $color-text-light;
   background-color: transparent;
-  border-radius: 5px;
-  padding: 6px 12px;
   cursor: pointer;
   min-width: 80px;
 }

--- a/civictechprojects/static/css/partials/_SplashScreen.scss
+++ b/civictechprojects/static/css/partials/_SplashScreen.scss
@@ -11,7 +11,7 @@
 
 .SplashScreen-fill {
   min-height: calc(
-    100vh - #{$header-height} - #{$footer-height}
+    100vh - 100px
   ); /* use min-height to fix wide but short viewports */
 }
 

--- a/common/components/common/groups/ContactGroupButton.jsx
+++ b/common/components/common/groups/ContactGroupButton.jsx
@@ -101,8 +101,7 @@ class ContactGroupButton extends React.PureComponent<Props, State> {
     const id = { id: this.props.group.group_id };
     return (
       <Button
-        className="AboutGroup-button btn btn-theme clear-button-appearance"
-        type="button"
+        variant="primary"
         disabled={this.state.buttonDisabled}
         title={this.state.buttonTitle}
         href={url.section(Section.CreateGroup, id)}
@@ -115,8 +114,7 @@ class ContactGroupButton extends React.PureComponent<Props, State> {
   _renderContactGroupButton(): React$Node {
     return (
       <Button
-        className="AboutGroup-button btn btn-theme"
-        type="button"
+        variant="primary"
         disabled={this.state.buttonDisabled}
         title={this.state.buttonTitle}
         onClick={this.handleShow}
@@ -129,8 +127,7 @@ class ContactGroupButton extends React.PureComponent<Props, State> {
   _renderLinkToSignInButton(): React$Node {
     return (
       <Button
-        className="AboutGroup-button btn btn-theme clear-button-appearance"
-        type="button"
+        variant="primary"
         disabled={this.state.buttonDisabled}
         title={this.state.buttonTitle}
         href={url.logInThenReturn()}


### PR DESCRIPTION
Code refactoring and cleanup, primarily:
 - removes the dueling !important rules on disabled state buttons by refactoring the rules to cleave a little closer to Bootstrap's initial generation in `civictechprojects\statics\css\vendor\bootstrap\_buttons.scss`. 
 - removes some legacy SASS variables used in SplashScreen, but the end result should be the same
 - removes some legacy button sizing rules in SplashScreen so they conform to the current ruleset
 - fixes some legacy CSS/type declarations on Contact Group buttons
 
