### PR TITLE
Single row nav at desktop resolution

### DIFF
--- a/civictechprojects/static/css/partials/_MainHeader.scss
+++ b/civictechprojects/static/css/partials/_MainHeader.scss
@@ -147,19 +147,14 @@
   }
 }
 
-/* move to a single row at XL breakpoint; this could use some further polish but nested containers make it a bit tricky */
-.MainHeader-nav-flex {
-  flex-direction: column;
-}
-@include media-breakpoint-up(xxl) {
+/* move to a single row at desktop sizes when content allows */
+@include media-breakpoint-up(lg) {
   .MainHeader-nav-flex {
-    flex-direction: row;
-  }
-  .MainHeader-pagenav {
-    order: 1;
+    flex-direction: row-reverse;
+    flex-wrap: wrap;
   }
   .MainHeader-usernav {
-    order: 2;
+    padding-left: 1rem; /* ensures the break between two-row and one happens cleanly */
   }
 }
 

--- a/civictechprojects/static/css/partials/_MainHeader.scss
+++ b/civictechprojects/static/css/partials/_MainHeader.scss
@@ -69,7 +69,8 @@
   .navbar-light .navbar-nav .nav-link:active {
     color: inherit;
   }
-  a:visited, .navbar-light .navbar-nav .nav-link:visited {
+  a:visited,
+  .navbar-light .navbar-nav .nav-link:visited {
     color: inherit;
   }
   .navbar {
@@ -143,6 +144,22 @@
     .dropdown-item {
       font-size: 16px; // match body text size
     }
+  }
+}
+
+/* move to a single row at XL breakpoint; this could use some further polish but nested containers make it a bit tricky */
+.MainHeader-nav-flex {
+  flex-direction: column;
+}
+@include media-breakpoint-up(xxl) {
+  .MainHeader-nav-flex {
+    flex-direction: row;
+  }
+  .MainHeader-pagenav {
+    order: 1;
+  }
+  .MainHeader-usernav {
+    order: 2;
   }
 }
 

--- a/common/components/chrome/MainHeader.jsx
+++ b/common/components/chrome/MainHeader.jsx
@@ -90,7 +90,7 @@ class MainHeader extends React.Component<{||}, State> {
           </Button>
         )}
         <Navbar.Toggle aria-controls="nav-pagenav-container" />
-        <Navbar.Collapse id="nav-pagenav-container" className="flex-column">
+        <Navbar.Collapse id="nav-pagenav-container" className="MainHeader-nav-flex">
           <Nav className="MainHeader-usernav ml-auto">
             {CurrentUser.isLoggedIn()
               ? this._renderUserSection()


### PR DESCRIPTION
Changes the desktop site navigation so that, when space allows, the nav will switch to a single row layout rather than two-row and otherwise operate unchanged. 

Generally, this means changes should only be seen at ~1200px or greater depending on user name length and logged in state. 
