### PR TITLE
Profile link regexes #652

### DIFF
--- a/common/components/constants/LinkConstants.js
+++ b/common/components/constants/LinkConstants.js
@@ -12,7 +12,7 @@ export type LinkSourceDisplayConfig = {|
   +iconClass: string,
 |};
 
-const httpsWwwPrefix = "^https?://w*.?";
+const httpsWwwPrefix = "^https?://\\w*\\.?";
 
 export const LinkDisplayConfigurationByUrl: $ReadOnlyArray<LinkSourceDisplayConfig> = [
   {

--- a/common/components/constants/LinkConstants.js
+++ b/common/components/constants/LinkConstants.js
@@ -12,7 +12,7 @@ export type LinkSourceDisplayConfig = {|
   +iconClass: string,
 |};
 
-const httpWwwPrefix = /^http:s?\/\/w*\.?/;
+const httpsWwwPrefix = "^http:s?\/\/w*\.?";
 
 export const LinkDisplayConfigurationByUrl: $ReadOnlyArray<LinkSourceDisplayConfig> = [
   {

--- a/common/components/constants/LinkConstants.js
+++ b/common/components/constants/LinkConstants.js
@@ -11,7 +11,9 @@ export type LinkSourceDisplayConfig = {|
   +sourceTypeDisplayName: string,
   +iconClass: string,
 |};
-const httpWwwPrefix = '^http:s?\/\/w*\.?';
+
+const httpWwwPrefix = /^http:s?\/\/w*\.?/;
+
 export const LinkDisplayConfigurationByUrl: $ReadOnlyArray<LinkSourceDisplayConfig> = [
   {
     sourceUrlPattern: new RegExp(httpsWwwPrefix + "github.com", "i"),

--- a/common/components/constants/LinkConstants.js
+++ b/common/components/constants/LinkConstants.js
@@ -12,7 +12,7 @@ export type LinkSourceDisplayConfig = {|
   +iconClass: string,
 |};
 
-const httpsWwwPrefix = "^http:s?\/\/w*\.?";
+const httpsWwwPrefix = "^https?://w*.?";
 
 export const LinkDisplayConfigurationByUrl: $ReadOnlyArray<LinkSourceDisplayConfig> = [
   {

--- a/common/components/constants/LinkConstants.js
+++ b/common/components/constants/LinkConstants.js
@@ -11,55 +11,55 @@ export type LinkSourceDisplayConfig = {|
   +sourceTypeDisplayName: string,
   +iconClass: string,
 |};
-
+const httpWwwPrefix = '^http:s?\/\/w*\.?';
 export const LinkDisplayConfigurationByUrl: $ReadOnlyArray<LinkSourceDisplayConfig> = [
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?github.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "github.com", "i"),
     sourceDisplayName: "GitHub",
     iconClass: GlyphStyles.Github,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?meetup.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "meetup.com", "i"),
     sourceDisplayName: "Meetup",
     iconClass: GlyphStyles.Meetup,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?slack.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "slack.com", "i"),
     sourceDisplayName: "Slack",
     iconClass: GlyphStyles.Slack,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?figma.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "figma.com", "i"),
     sourceDisplayName: "Figma",
     iconClass: GlyphStyles.Figma,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?trello.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "trello.com", "i"),
     sourceDisplayName: "Trello",
     iconClass: GlyphStyles.Trello,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?drive.google.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "drive.google.com", "i"),
     sourceDisplayName: "Google Drive",
     iconClass: GlyphStyles.GoogleDrive,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?facebook.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "facebook.com", "i"),
     sourceDisplayName: "Facebook",
     iconClass: GlyphStyles.FacebookSquare,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?twitter.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "twitter.com", "i"),
     sourceDisplayName: "Twitter",
     iconClass: GlyphStyles.TwitterSquare,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?linkedin.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "linkedin.com", "i"),
     sourceDisplayName: "LinkedIn",
     iconClass: GlyphStyles.LinkedIn,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?youtube.com/i,
+    sourceUrlPattern: new RegExp(httpsWwwPrefix + "youtube.com", "i"),
     sourceDisplayName: "YouTube",
     iconClass: GlyphStyles.YouTube,
   },

--- a/common/components/constants/LinkConstants.js
+++ b/common/components/constants/LinkConstants.js
@@ -15,52 +15,52 @@ export type LinkSourceDisplayConfig = {|
 
 export const LinkDisplayConfigurationByUrl: $ReadOnlyArray<LinkSourceDisplayConfig> = [
   {
-    sourceUrlPattern: new RegExp("github.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?github.com/,
     sourceDisplayName: "GitHub",
     iconClass: GlyphStyles.Github,
   },
   {
-    sourceUrlPattern: new RegExp("meetup.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?meetup.com/,
     sourceDisplayName: "Meetup",
     iconClass: GlyphStyles.Meetup,
   },
   {
-    sourceUrlPattern: new RegExp("slack.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?slack.com/,
     sourceDisplayName: "Slack",
     iconClass: GlyphStyles.Slack,
   },
   {
-    sourceUrlPattern: new RegExp("figma.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?figma.com/,
     sourceDisplayName: "Figma",
     iconClass: GlyphStyles.Figma,
   },
   {
-    sourceUrlPattern: new RegExp("trello.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?trello.com/,
     sourceDisplayName: "Trello",
     iconClass: GlyphStyles.Trello,
   },
   {
-    sourceUrlPattern: new RegExp("drive.google.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?drive.google.com/,
     sourceDisplayName: "Google Drive",
     iconClass: GlyphStyles.GoogleDrive,
   },
   {
-    sourceUrlPattern: new RegExp("facebook.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?facebook.com/,
     sourceDisplayName: "Facebook",
     iconClass: GlyphStyles.FacebookSquare,
   },
   {
-    sourceUrlPattern: new RegExp("twitter.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?twitter.com/,
     sourceDisplayName: "Twitter",
     iconClass: GlyphStyles.TwitterSquare,
   },
   {
-    sourceUrlPattern: new RegExp("linkedin.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?linkedin.com/,
     sourceDisplayName: "LinkedIn",
     iconClass: GlyphStyles.LinkedIn,
   },
   {
-    sourceUrlPattern: new RegExp("youtube.com", "i"),
+    sourceUrlPattern: /^http:s?\/\/w*\.?youtube.com/,
     sourceDisplayName: "YouTube",
     iconClass: GlyphStyles.YouTube,
   },

--- a/common/components/constants/LinkConstants.js
+++ b/common/components/constants/LinkConstants.js
@@ -5,7 +5,6 @@ import type { Dictionary, KeyValuePair } from "../types/Generics.jsx";
 import _ from "lodash";
 import stringHelper from "../utils/string.js";
 
-
 export type LinkSourceDisplayConfig = {|
   +sourceUrlPattern: ?RegExp,
   +sourceDisplayName: ?string,

--- a/common/components/constants/LinkConstants.js
+++ b/common/components/constants/LinkConstants.js
@@ -15,52 +15,52 @@ export type LinkSourceDisplayConfig = {|
 
 export const LinkDisplayConfigurationByUrl: $ReadOnlyArray<LinkSourceDisplayConfig> = [
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?github.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?github.com/i,
     sourceDisplayName: "GitHub",
     iconClass: GlyphStyles.Github,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?meetup.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?meetup.com/i,
     sourceDisplayName: "Meetup",
     iconClass: GlyphStyles.Meetup,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?slack.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?slack.com/i,
     sourceDisplayName: "Slack",
     iconClass: GlyphStyles.Slack,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?figma.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?figma.com/i,
     sourceDisplayName: "Figma",
     iconClass: GlyphStyles.Figma,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?trello.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?trello.com/i,
     sourceDisplayName: "Trello",
     iconClass: GlyphStyles.Trello,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?drive.google.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?drive.google.com/i,
     sourceDisplayName: "Google Drive",
     iconClass: GlyphStyles.GoogleDrive,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?facebook.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?facebook.com/i,
     sourceDisplayName: "Facebook",
     iconClass: GlyphStyles.FacebookSquare,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?twitter.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?twitter.com/i,
     sourceDisplayName: "Twitter",
     iconClass: GlyphStyles.TwitterSquare,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?linkedin.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?linkedin.com/i,
     sourceDisplayName: "LinkedIn",
     iconClass: GlyphStyles.LinkedIn,
   },
   {
-    sourceUrlPattern: /^http:s?\/\/w*\.?youtube.com/,
+    sourceUrlPattern: /^http:s?\/\/w*\.?youtube.com/i,
     sourceDisplayName: "YouTube",
     iconClass: GlyphStyles.YouTube,
   },


### PR DESCRIPTION
**LINK SOURCE DETECTION REGEXES:** Social media logos now only render if the platform name immediately follows _"http://"_, _"https://"_ and an optional _"www."_ I also replaced the Regexp constructor syntax with regex literal syntax. According to Mozilla, literals compile when the script loads rather than at runtime, and are therefore more efficient assuming you don't expect the regexes to be altered. 

**OTHER NOTES ON LINK DETECTION BEHAVIOR:** The default social media links for new projects (Facebook, Twitter, and LinkedIn) display logos by default and ignore regexes. This means that if you type any random url they will still display the respective logos. Also it appears that depending on whether _"http"_ or _"https"_ is used, these links are displayed as just the name, or with a  _".com"_. For example, if _"http://facebook.com"_ is supplied, the name of the link appears as _"Facebook"_, if _"https://facebook.com"_ is used, it will display as _"Facebook.com"_.

Closes #652 