### PR TITLE
deleted copyright from footer

### DIFF
--- a/common/components/chrome/SiteFooter.jsx
+++ b/common/components/chrome/SiteFooter.jsx
@@ -97,9 +97,6 @@ class SiteFooter extends React.Component {
           </a>
           .
         </p>
-        <p className="overline">
-          &copy; 2006-2022 DemocracyLab | All Rights Reserved
-        </p>
       </div>
     );
   }


### PR DESCRIPTION
Layout appears unaffected at all screen sizes after removing the appropriate **<p>** element from **common/components/chrome/SiteFooter.jsx**

Closes #899 