### PR TITLE
Crop profile pic #896

### DIFF
--- a/common/components/common/FileInfo.jsx
+++ b/common/components/common/FileInfo.jsx
@@ -1,3 +1,5 @@
+//@flow
+
 export type FileInfo = {|
   id: ?number,
   key: string,

--- a/common/components/common/upload/ImageCropUploadButton.jsx
+++ b/common/components/common/upload/ImageCropUploadButton.jsx
@@ -16,22 +16,24 @@ type Props = {|
   aspect: ?number,
   currentImage: FileInfo,
   isCropping: boolean,
-  onIsCroppingChanged: (boolean) => void,
+  _onIsCroppingChanged: (boolean) => void,
 |};
 
 type State = {|
   s3Key: string,
+  src: string,
   croppedImageUrl: ?string,
+  crop: any
 |};
 
-let lastFileUploadUrl: string = null;
+let lastFileUploadUrl: string = "";
 
 class ImageCropUploadButton extends React.PureComponent<Props, State> {
   constructor(props): void {
     super(props);
     this.state = {
       s3Key: "",
-      src: null,
+      src: "",
       croppedImageUrl: "",
       crop: this.initializeCropSettings(),
     };
@@ -41,8 +43,7 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
     const previewImage =
       this.state.croppedImageUrl ||
       (this.props.currentImage && this.props.currentImage.publicUrl);
-      console.log("Rendering ImageCropUploadButton. Value of isCropping is " + this.props.isCropping);
-    return (
+      return (
       <div className="ImageCropUploadButton-root">
         {this.state.src && this.props.isCropping && (
           <div className="ImageCropUploadButton-cropper">
@@ -83,7 +84,7 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
 
   _handleDoneCropping(): void {
     this.setState({ crop: this.initializeCropSettings() });
-    this.props.onIsCroppingChanged(false);
+    this.props._onIsCroppingChanged(false);
     if (this.fileBlob) {
       this.launchPresignedUploadToS3(this.fileBlob);
     }
@@ -101,7 +102,7 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
         croppedImageUrl: this.props.currentImage,
       });
     }
-    this.props.onIsCroppingChanged(false);
+    this.props._onIsCroppingChanged(false);
   }
 
   _onCropChange(crop): void {
@@ -119,7 +120,7 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
 
   _handleFileSelection(file): void {
     this.setState({ src: file});
-    this.props.onIsCroppingChanged(true);
+    this.props._onIsCroppingChanged(true);
   }
 
   makeClientCrop(crop) {

--- a/common/components/common/upload/ImageCropUploadButton.jsx
+++ b/common/components/common/upload/ImageCropUploadButton.jsx
@@ -15,6 +15,8 @@ type Props = {|
   iconClass: string,
   aspect: ?number,
   currentImage: FileInfo,
+  isCropping: boolean,
+  onIsCroppingChanged: (boolean) => void,
 |};
 
 type State = {|
@@ -30,7 +32,6 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
     this.state = {
       s3Key: "",
       src: null,
-      isCropping: false,
       croppedImageUrl: "",
       crop: this.initializeCropSettings(),
     };
@@ -40,9 +41,10 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
     const previewImage =
       this.state.croppedImageUrl ||
       (this.props.currentImage && this.props.currentImage.publicUrl);
+      console.log("Rendering ImageCropUploadButton. Value of isCropping is " + this.props.isCropping);
     return (
       <div className="ImageCropUploadButton-root">
-        {this.state.src && this.state.isCropping && (
+        {this.state.src && this.props.isCropping && (
           <div className="ImageCropUploadButton-cropper">
             <ReactCrop
               src={this.state.src}
@@ -65,7 +67,7 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
             </div>
           </div>
         )}
-        {!this.state.isCropping && (
+        {!this.props.isCropping && (
           <FileSelectButton
             hasImagePreview="true"
             previewImage={previewImage}
@@ -80,7 +82,8 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
   }
 
   _handleDoneCropping(): void {
-    this.setState({ isCropping: false, crop: this.initializeCropSettings() });
+    this.setState({ crop: this.initializeCropSettings() });
+    this.props.onIsCroppingChanged(false);
     if (this.fileBlob) {
       this.launchPresignedUploadToS3(this.fileBlob);
     }
@@ -89,17 +92,16 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
   _handleCancelCropping(): void {
     if (lastFileUploadUrl) {
       this.setState({
-        isCropping: false,
         crop: this.initializeCropSettings(),
         croppedImageUrl: lastFileUploadUrl,
       });
     } else {
       this.setState({
-        isCropping: false,
         crop: this.initializeCropSettings(),
         croppedImageUrl: this.props.currentImage,
       });
     }
+    this.props.onIsCroppingChanged(false);
   }
 
   _onCropChange(crop): void {
@@ -116,7 +118,7 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
   }
 
   _handleFileSelection(file): void {
-    this.setState({ src: file, isCropping: true });
+    this.props.onIsCroppingChanged(true);
   }
 
   makeClientCrop(crop) {

--- a/common/components/common/upload/ImageCropUploadButton.jsx
+++ b/common/components/common/upload/ImageCropUploadButton.jsx
@@ -118,6 +118,7 @@ class ImageCropUploadButton extends React.PureComponent<Props, State> {
   }
 
   _handleFileSelection(file): void {
+    this.setState({ src: file});
     this.props.onIsCroppingChanged(true);
   }
 

--- a/common/components/common/upload/S3Data.jsx
+++ b/common/components/common/upload/S3Data.jsx
@@ -1,3 +1,5 @@
+//@flow
+
 export type S3Data = {|
   url: string,
   fields: {

--- a/common/components/componentsBySection/AboutUser/EditUserModal.jsx
+++ b/common/components/componentsBySection/AboutUser/EditUserModal.jsx
@@ -95,7 +95,7 @@ class EditUserModal extends React.Component<Props, State> {
 
   render(): React$Node {
     const submitEnabled: boolean =
-      !this.state.isProcessing && this.state.isValid
+      !this.state.isProcessing && this.state.isValid;
     return (
       <ModalWrapper
         showModal={this.state.showModal}

--- a/common/components/componentsBySection/AboutUser/EditUserModal.jsx
+++ b/common/components/componentsBySection/AboutUser/EditUserModal.jsx
@@ -95,7 +95,7 @@ class EditUserModal extends React.Component<Props, State> {
 
   render(): React$Node {
     const submitEnabled: boolean =
-      !this.state.isProcessing && this.state.isValid;
+      !this.state.isProcessing && this.state.isValid
     return (
       <ModalWrapper
         showModal={this.state.showModal}

--- a/common/components/componentsBySection/AboutUser/EditUserThumbnailModal.jsx
+++ b/common/components/componentsBySection/AboutUser/EditUserThumbnailModal.jsx
@@ -21,6 +21,7 @@ type Props = {|
 type State = {|
   showModal: boolean,
   user_thumbnail: FileInfo,
+  isCropping: boolean,
 |};
 
 type FormFields = {|
@@ -37,6 +38,7 @@ class EditUserThumbnailModal extends React.Component<Props, State> {
     this.state = {
       showModal: false,
       user_thumbnail: null,
+      isCropping: false,
     };
   }
 
@@ -48,6 +50,10 @@ class EditUserThumbnailModal extends React.Component<Props, State> {
     let state: State = _.clone(prevState) || {};
     state.user_thumbnail = FormFieldsStore.getFormFieldValue("user_thumbnail");
     return state;
+  }
+  
+  setIsCropping(isCropping) {
+    this.setState({isCropping});
   }
 
   componentWillReceiveProps(nextProps: Props): void {
@@ -72,11 +78,14 @@ class EditUserThumbnailModal extends React.Component<Props, State> {
         user={this.props.user}
         fields={["user_thumbnail"]}
         onEditClose={this.props.onEditClose}
+	isInvalid={this.state.isCropping}
       >
         <ImageCropUploadFormElement
           form_id="user_thumbnail"
           buttonText="Upload Your Picture"
           aspect={1 / 1}
+          isCropping={this.state.isCropping}
+	  onIsCroppingChanged={this.setIsCropping.bind(this)}
         />
       </EditUserModal>
     );

--- a/common/components/componentsBySection/AboutUser/EditUserThumbnailModal.jsx
+++ b/common/components/componentsBySection/AboutUser/EditUserThumbnailModal.jsx
@@ -85,7 +85,7 @@ class EditUserThumbnailModal extends React.Component<Props, State> {
           buttonText="Upload Your Picture"
           aspect={1 / 1}
           isCropping={this.state.isCropping}
-	  onIsCroppingChanged={this.setIsCropping.bind(this)}
+	  _onIsCroppingChanged={this.setIsCropping.bind(this)}
         />
       </EditUserModal>
     );

--- a/common/components/forms/ImageCropUploadFormElement.jsx
+++ b/common/components/forms/ImageCropUploadFormElement.jsx
@@ -17,12 +17,14 @@ type Props = {|
   onSelection: ?(FileInfo) => void,
   aspect: number,
   isCropping: boolean,
-  onIsCroppingChanged: (boolean) => void,
+  _onIsCroppingChanged: (boolean) => void,
 |};
 
 type State = {|
   currentImage: FileInfo,
   initialized: boolean,
+  buttonText: string,
+  currentImage: string
 |};
 
 class ImageCropUploadFormElement extends React.Component<Props, State> {
@@ -76,7 +78,7 @@ class ImageCropUploadFormElement extends React.Component<Props, State> {
           buttonText={this.props.buttonText || "Upload Image"}
           onFileUpload={this._handleFileSelection.bind(this)}
           isCropping={this.props.isCropping}
-	  onIsCroppingChanged={this.props.onIsCroppingChanged}
+	  _onIsCroppingChanged={this.props._onIsCroppingChanged}
         />
         {/*TODO: Use HiddenFormField component*/}
         <input

--- a/common/components/forms/ImageCropUploadFormElement.jsx
+++ b/common/components/forms/ImageCropUploadFormElement.jsx
@@ -16,6 +16,8 @@ type Props = {|
   currentImage: FileInfo,
   onSelection: ?(FileInfo) => void,
   aspect: number,
+  isCropping: boolean,
+  onIsCroppingChanged: (boolean) => void,
 |};
 
 type State = {|
@@ -73,6 +75,8 @@ class ImageCropUploadFormElement extends React.Component<Props, State> {
           aspect={this.props.aspect}
           buttonText={this.props.buttonText || "Upload Image"}
           onFileUpload={this._handleFileSelection.bind(this)}
+          isCropping={this.props.isCropping}
+	  onIsCroppingChanged={this.props.onIsCroppingChanged}
         />
         {/*TODO: Use HiddenFormField component*/}
         <input


### PR DESCRIPTION
To disable the "Save" button until the user clicks "Done Cropping", I lifted the state variable "isCropping" up from ImageCropUploadButton to EditUserThumbnailModal, and added an _onIsCroppingChanged handler function to EditUserThumbnailModal. This appears to work as expected with no console errors unwanted side effects.

Note that VSCode complains about the type declarations and function binding in many of the .jsx files. I improved this in a few of the files I touched, but addressing this further feels like a separate issue. 