### PR TITLE
Pre-commit: Add prettier support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,9 @@ repos:
     rev: 22.8.0
     hooks:
     -   id: black
+-   repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1 # Use the sha or tag you want to point at
+    hooks:
+      - id: prettier
+        types_or: [css, javascript]
+        args: [--config=.prettierrc.json]


### PR DESCRIPTION
### Description
Pre-commit will now also run prettier on CSS and JS files.

### Implementation Notes
1. prettier will only run on CSS and JS files. Let me know if you'd like to include JSX files as well
2. This will use the prettier configs specified in  `.prettierrc.json`

### Additional Information