### PR TITLE
GH-915 Heroku deployment fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-black==22.8.0
 boto3==1.4.7
 botocore==1.7.28
 dj-database-url==0.4.1
@@ -21,7 +20,6 @@ docutils==0.14
 gunicorn==19.6.0
 jmespath==0.9.3
 mailchimp==2.0.9
-pre-commit==2.20.0
 psycopg2==2.8.4
 psycopg2-binary==2.8.4
 python-dateutil==2.6.1


### PR DESCRIPTION
### Description
Remove black and pre-commit lib dependencies as they are not necessary for deployment.

### Testing
Rebuilt Docker container and hit website to confirm it was built properly

### Additional Information
- Fixes GH-915