### PR TITLE
fixed issue #468; find projects filters now work properly

### DIFF
--- a/common/components/stores/EntitySearchStore.js
+++ b/common/components/stores/EntitySearchStore.js
@@ -492,7 +492,9 @@ class EntitySearchStore extends ReduceStore<State> {
     state = this._updateFindProjectArgs(state);
     if (state.filterApplied) {
       state = state.set("page", 1);
-      state = state.set("projectsData", {});
+      //cleaning project data but not tag data
+      const allTags = state.projectsData.allTags;
+      state = state.set("projectsData", {allTags}); 
       state = state.set("filterApplied", false);
     }
     if (state.searchSettings.updateUrl && !noUpdateUrl) {


### PR DESCRIPTION
Resolves issue #468. Load projects was clearing and refilling all project data, including filters, which don't need to be refreshed. 