### PR TITLE
implemented branch code coverage for python

### DIFF
--- a/coverage-python.sh
+++ b/coverage-python.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+coverage run --branch --source='.' manage.py test &&\
+coverage report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - ./democracylab/:/code/democracylab/
       - ./oauth2/:/code/oauth2/
       - ./.babelrc:/code/.babelrc
+      - ./coverage-python.sh:/code/coverage-python.sh
       - ./manage.py:/code/manage.py
       - ./webpack.common.js:/code/webpack.common.js
       - ./webpack.dev.js:/code/webpack.dev.js

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3==1.4.7
 botocore==1.7.28
+coverage==6.2
 dj-database-url==0.4.1
 Django==3.1.14
 django-allauth==0.44


### PR DESCRIPTION
To calculate the corverage run the script coverage-python.sh on unix environment, or alternatively these two commands:
`coverage run --branch --source='.' manage.py test`
`coverage report`

to do: add documentation