### PR TITLE
Added coverage for js on host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Pipfile
 Pipfile.lock
 
 # Unit test / coverage reports
+coverage/
 htmlcov/
 .tox/
 .coverage

--- a/coverage-js.sh
+++ b/coverage-js.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npm run test-cover

--- a/coverage-js.sh
+++ b/coverage-js.sh
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 npm run test-cover

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - ./democracylab/:/code/democracylab/
       - ./oauth2/:/code/oauth2/
       - ./.babelrc:/code/.babelrc
+      - ./coverage-js.sh:/code/coverage-js.sh
       - ./manage.py:/code/manage.py
       - ./webpack.common.js:/code/webpack.common.js
       - ./webpack.dev.js:/code/webpack.dev.js

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "postinstall": "webpack --config webpack.dev.js && npm run buildtask:collectstatic",
     "watch": "webpack --mode development --watch",
     "buildtask:collectstatic": "python manage.py collectstatic --noinput -i *.scss",
-    "test": "jest"
+    "test": "jest",
+    "test-cover": "npm test -- --coverage"
   },
   "engines": {
     "node": "14.15.x"


### PR DESCRIPTION
To calculate the corverage run the script coverage-js.sh on unix environment, or alternatively this command:
`npm run test-cover`

to do: add documentation