### PR TITLE
Fixed: Cannot delete a second project/group due to broken confirmation modal

### DIFF
--- a/common/components/controllers/MyGroupsController.jsx
+++ b/common/components/controllers/MyGroupsController.jsx
@@ -43,7 +43,7 @@ class MyGroupsController extends React.PureComponent<{||}, State> {
     this.forceUpdate();
   }
 
-  confirmDeleteProject(confirmedDelete: boolean): void {
+  async confirmDeleteProject(confirmedDelete: boolean): void {
     if (confirmedDelete) {
       const url =
         "/api/groups/delete/" + this.state.groupToDelete.group_id + "/";

--- a/common/components/controllers/MyProjectsController.jsx
+++ b/common/components/controllers/MyProjectsController.jsx
@@ -92,7 +92,7 @@ class MyProjectsController extends React.PureComponent<{||}, State> {
     this.forceUpdate();
   }
 
-  confirmDeleteProject(confirmedDelete: boolean): void {
+  async confirmDeleteProject(confirmedDelete: boolean): void {
     if (confirmedDelete) {
       const url =
         "/api/projects/delete/" + this.state.projectToDelete.project_id + "/";


### PR DESCRIPTION
Adding `async` to the method signature of `comfirmDeleteProject()`  in both `MyProjectController` and `MyGroupsController` allows `ConfirmationModal` to receive the Promise object it expects, clearing a console error and resolving Issue #636  