### PR TITLE
Invite group to project issue #770

### DIFF
--- a/common/components/common/projects/InviteProjectToGroupModal.jsx
+++ b/common/components/common/projects/InviteProjectToGroupModal.jsx
@@ -9,6 +9,7 @@ import ProjectAPIUtils from "../../utils/ProjectAPIUtils.js";
 import ConfirmationModal from "../../common/confirmation/ConfirmationModal.jsx";
 import Selector from "../selection/Selector.jsx";
 import type { MyGroupData } from "../../utils/CurrentUser.js";
+import promiseHelper from "../../utils/promise.js";
 
 type Props = {|
   projectId: number,
@@ -71,11 +72,13 @@ class InviteProjectToGroupModal extends React.PureComponent<Props, State> {
     this.setState({ showConfirmationModal: true });
   }
 
-  receiveSendConfirmation(confirmation: boolean): void {
-    if (confirmation) {
-      this.handleSubmit();
-    }
-    this.setState({ showConfirmationModal: false });
+  receiveSendConfirmation(confirmation: boolean): Promise {
+    return promiseHelper.promisify(() =>{
+      if (confirmation) {
+        this.handleSubmit();
+      }
+      this.setState({ showConfirmationModal: false });
+    });
   }
 
   handleSubmit() {


### PR DESCRIPTION
https://github.com/DemocracyLab/CivicTechExchange/issues/770
The confirmation modal submit function is not returning a promise like the ConfirmationModal expects. 
Used the promiseHelper class and the spinning and unclickable "Yes" button is resolved. 
<img width="1243" alt="Screen Shot 2023-03-27 at 22 45 40" src="https://user-images.githubusercontent.com/71072255/228140021-5fbbfc4b-318b-4287-8bd5-912cea0dadcc.png">
