### PR TITLE
897 support heroku redis tls connection

### DIFF
--- a/common/helpers/queue.py
+++ b/common/helpers/queue.py
@@ -7,8 +7,8 @@ from typing import Callable
 from django.conf import settings
 from urllib.parse import urlparse
 
-redis_url = os.getenv('REDIS_URL', 'rediss://:@127.0.0.1:6380/16')
-#redis_url = os.getenv('REDIS_URL','redis://localhost:6379')
+#redis_url = os.getenv('REDIS_URL', 'rediss://localhost:6380/16')
+redis_url = os.getenv('REDIS_URL','redis://localhost:6379')
 url = urlparse(redis_url)
 # Check if the Redis connection is using SSL/TSL
 is_secure = redis_url.startswith('rediss://')

--- a/common/helpers/queue.py
+++ b/common/helpers/queue.py
@@ -2,13 +2,23 @@ import os
 import redis
 import threading
 from rq import Queue
+from ssl import CERT_NONE
 from typing import Callable
 from django.conf import settings
+from urllib.parse import urlparse
 
-redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379')
-conn = redis.from_url(redis_url)
+redis_url = os.getenv('REDIS_URL', 'rediss://:@127.0.0.1:6380/16')
+#redis_url = os.getenv('REDIS_URL','redis://localhost:6379')
+url = urlparse(redis_url)
+# Check if the Redis connection is using SSL/TSL
+is_secure = redis_url.startswith('rediss://')
+
+if is_secure:
+    conn = redis.Redis(host=url.hostname, port=url.port, username=url.username, password=url.password, ssl=True, ssl_cert_reqs=None)
+else:
+    conn = redis.from_url(redis_url)
+
 q = settings.REDIS_ENABLED and Queue(connection=conn)
-
 
 def enqueue(job_func: Callable, *args):
     if settings.REDIS_ENABLED:
@@ -21,3 +31,4 @@ def enqueue(job_func: Callable, *args):
         thread = threading.Thread(target=job_func, args=args)
         thread.daemon = True
         thread.start()
+


### PR DESCRIPTION
Actually, I wrote a test.py in the https://github.com/DemocracyLab/CivicTechExchange/blob/hqd1/test.py
To run the test with REDIS_TLS_URL,  you should install the redis with tls/ssl.
you could run below command to start the redis-server with tls(the '--tls-auth-clients no' is necessary, with this we could use ssl_cert_reqs=None in queue.py) :
sudo redis-server --tls-port 6380 --tls-cert-file /etc/redis/ssl/redis.crt --tls-key-file /etc/redis/ssl/redis.key --tls-ca-cert-file /etc/redis/ssl/redis.crt --tls-auth-clients no --tls-replication yes
Once the server could run, you could comment out redis_url = os.getenv('REDIS_URL','redis://localhost:6379') and uncomment redis_url = os.getenv('REDIS_URL', 'rediss://localhost:6380/16'). By the way, if your tls port isn't 6380, you should change the port.
Thanks, feel free to contact me: qh11@illinois.edu
Qingdong Huang
