### PR TITLE
change the message

### DIFF
--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -984,8 +984,9 @@ def dismiss_project_volunteer(request, application_id):
         email_template = HtmlEmailTemplate()\
         .paragraph('The owner of {project_name} has removed you from the project for the following reason:'.format(
             project_name=volunteer_relation.project.project_name))\
-        .paragraph('\"{message}\"'.format(message=message))
-        email_subject = 'You have been dismissed from {project_name}'.format(
+        .paragraph('Thank you for contributing to {project_name}. Your volunteer work for the project has ended. \"{message}\"'\
+                   .format(project_name=volunteer_relation.project.project_name, message=message))
+        email_subject = 'Thank you for your work at {project_name}'.format(
             project_name=volunteer_relation.project.project_name)
         send_to_project_volunteer(volunteer_relation=volunteer_relation,
                                subject=email_subject,


### PR DESCRIPTION
I have changed the text for emails sent to volunteers when they have been dismissed from a project.
(https://github.com/DemocracyLab/CivicTechExchange/issues/856)
![d8d848705631557ebfdae13c2f1ef9c](https://user-images.githubusercontent.com/127426375/231294371-84a991ff-3ae2-40d9-8c43-0b1badc9702d.png)
![d66c9d72fd2c77fb608d8e83391e537](https://user-images.githubusercontent.com/127426375/231294402-77e5c91f-5747-4935-a7e0-e35351460705.png)


