### PR TITLE
Always-underlined href links in blog posts

### DIFF
--- a/civictechprojects/static/css/partials/_LatestBlogPosts.scss
+++ b/civictechprojects/static/css/partials/_LatestBlogPosts.scss
@@ -47,6 +47,9 @@
 .LatestBlogPosts-excerpt {
     margin-top: 0.5rem;
 }
+.LatestBlogPosts-excerpt a { 
+    text-decoration: underline;
+}
 .LatestBlogPosts-bottomrow {
     justify-content: space-between;
 }


### PR DESCRIPTION
<img width="1166" alt="Screen Shot 2023-04-25 at 17 07 34" src="https://user-images.githubusercontent.com/71072255/234434214-9c784dcb-1fdf-41c3-a0ff-f39357db6ff6.png">
Make the href link shows more straightforward and clear.