### PR TITLE
897 support heroku redis tls connection

### DIFF
--- a/common/helpers/queue.py
+++ b/common/helpers/queue.py
@@ -7,8 +7,8 @@ from typing import Callable
 from django.conf import settings
 from urllib.parse import urlparse
 
-redis_url = os.getenv('REDIS_URL', 'rediss://:@127.0.0.1:6380/16')
-#redis_url = os.getenv('REDIS_URL','redis://localhost:6379')
+#redis_url = os.getenv('REDIS_URL', 'rediss://localhost:6380/16')
+redis_url = os.getenv('REDIS_URL','redis://localhost:6379')
 url = urlparse(redis_url)
 # Check if the Redis connection is using SSL/TSL
 is_secure = redis_url.startswith('rediss://')

--- a/common/helpers/queue.py
+++ b/common/helpers/queue.py
@@ -7,7 +7,7 @@ from typing import Callable
 from django.conf import settings
 from urllib.parse import urlparse
 
-#redis_url = os.getenv('REDIS_URL', 'rediss://localhost:6380/16')
+
 redis_url = os.getenv('REDIS_URL','redis://localhost:6379')
 url = urlparse(redis_url)
 # Check if the Redis connection is using SSL/TSL

--- a/common/helpers/queue.py
+++ b/common/helpers/queue.py
@@ -2,13 +2,23 @@ import os
 import redis
 import threading
 from rq import Queue
+from ssl import CERT_NONE
 from typing import Callable
 from django.conf import settings
+from urllib.parse import urlparse
 
-redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379')
-conn = redis.from_url(redis_url)
+redis_url = os.getenv('REDIS_URL', 'rediss://:@127.0.0.1:6380/16')
+#redis_url = os.getenv('REDIS_URL','redis://localhost:6379')
+url = urlparse(redis_url)
+# Check if the Redis connection is using SSL/TSL
+is_secure = redis_url.startswith('rediss://')
+
+if is_secure:
+    conn = redis.Redis(host=url.hostname, port=url.port, username=url.username, password=url.password, ssl=True, ssl_cert_reqs=None)
+else:
+    conn = redis.from_url(redis_url)
+
 q = settings.REDIS_ENABLED and Queue(connection=conn)
-
 
 def enqueue(job_func: Callable, *args):
     if settings.REDIS_ENABLED:
@@ -21,3 +31,4 @@ def enqueue(job_func: Callable, *args):
         thread = threading.Thread(target=job_func, args=args)
         thread.daemon = True
         thread.start()
+


### PR DESCRIPTION
This pr is to solve the issue 897 support heroku redis tls connection. 
This branch has been update based on the new version. I have rebase rebase this branch on top of master.
I have done two tests.

First test: test the job could be enqueue or not
![d4a58f798121dbbe0d5be187f40332f](https://user-images.githubusercontent.com/127426375/235406534-044aaf1b-1480-4758-9e1b-9c06287bf9d1.png)


Second test: open the democracylab website, login the test account, and then send the email to the volunteer. If the job is enqueued correctly, the rqworker could handle the job. And finally, you could see the email in the rqworker windows rather than the windows you ran python manage.py runserver.
![b95b0c915448f9f646d6ec6901e4fcd](https://user-images.githubusercontent.com/127426375/235406549-070576fd-7494-47a2-85b7-b5785e82ccea.png)

First test's steps:
1. sudo apt install redis-server
2. sudo apt install openssl
3. sudo mkdir /etc/redis/ssl
4. Generate the private key and self-signed certificate using the following command:
    sudo openssl req -x509 -newkey rsa:4096 -keyout /etc/redis/ssl/redis.key -out /etc/redis/ssl/redis.crt -days 365 -nodes
5. Edit the Redis configuration file: sudo nano /etc/redis/redis.conf
    Add: port 6379
             tls-port 6380
             tls-cert-file /etc/redis/ssl/redis.crt
             tls-key-file /etc/redis/ssl/redis.key
             tls-ca-cert-file /etc/redis/ssl/redis.crt
6. Add two environment variables in the 
   export REDIS_ENABLED='True'
   export REDIS_URL='rediss://localhost:6380/0?ssl_cert_reqs=none&ssl_ca_certs=/etc/redis/ssl/redis.crt'
7. write a test.py( I have deleted it from this branch)
8. restart the vm
   open a window and run: 
      source ~/Desktop/democracylab_environment_variables.sh
      source ~/git/virtualenv/bin/activate
      sudo -E redis-server --tls-port 6380 --tls-cert-file /etc/redis/ssl/redis.crt --tls-key-file /etc/redis/ssl/redis.key --tls-ca-cert-file /etc/redis/ssl/redis.crt --tls-auth-clients no --tls-replication yes
   open another window and run:
      source ~/Desktop/democracylab_environment_variables.sh
      source ~/git/virtualenv/bin/activate
      cd ~/git/CivicTechExchange
      python manage.py rqworker
   open third window and run:
      source ~/Desktop/democracylab_environment_variables.sh
      source ~/git/virtualenv/bin/activate
      python manage.py test

Second test's steps:
1-5 steps in first test's step
6. Add an environment variable:
   export REDIS_ENABLED='True'
7. restart the vm
   open a window and run: 
      source ~/Desktop/democracylab_environment_variables.sh
      source ~/git/virtualenv/bin/activate
      sudo -E redis-server --tls-port 6380 --tls-cert-file /etc/redis/ssl/redis.crt --tls-key-file /etc/redis/ssl/redis.key --tls-ca-cert-file /etc/redis/ssl/redis.crt --tls-auth-clients no --tls-replication yes
   open another window and run:
      source ~/Desktop/democracylab_environment_variables.sh
      source ~/git/virtualenv/bin/activate
      cd ~/git/CivicTechExchange
      python manage.py rqworker
   open third window and run:
      source ~/Desktop/democracylab_environment_variables.sh
      source ~/git/virtualenv/bin/activate
      python manage.py runserver
8. open the website and send an email(contact the volunteer)
