### PR TITLE
remove looks good

### DIFF
--- a/common/components/controllers/LogInController.jsx
+++ b/common/components/controllers/LogInController.jsx
@@ -78,7 +78,7 @@ class LogInController extends React.Component<Props, State> {
               placeholder="Email"
               onChange={e => this.setState({ username: e.target.value })}
             />
-            <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
+            
             <Form.Control.Feedback type="invalid">
               Please enter your email address.
             </Form.Control.Feedback>
@@ -92,7 +92,7 @@ class LogInController extends React.Component<Props, State> {
               placeholder="Password"
               onChange={e => this.setState({ password: e.target.value })}
             />
-            <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
+            
             <Form.Control.Feedback type="invalid">
               Please enter your password.
             </Form.Control.Feedback>


### PR DESCRIPTION
Now it would not show "looks good"

![6229a8670577c776690742bb7abc92c](https://user-images.githubusercontent.com/127426375/236646413-a93a13c2-139d-41ea-a39c-86e1fbe00181.jpg)

(However, it will still shows ✓. should I remove ✓? Or is it enough now?)

By the way, please run "npm run build" to apply the change. The Node.js version should be 16.20.x. If the node.js 's version is other version, such as 18.x.x(the default version in ubuntu 22), please change the version to 16.20.x, then you could run "npm run build" successfully.

how to use node.js 16.20.x:
curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
nvm install 16.20
nvm use 16.20


