### PR TITLE
solution1 to solve issue 696:"Clicking back from Signup/Forgot password crashes page"

### DIFF
--- a/common/components/chrome/MainHeader.jsx
+++ b/common/components/chrome/MainHeader.jsx
@@ -331,10 +331,13 @@ class MainHeader extends React.Component<{||}, State> {
   }
 
   _handleHeightChange(height: number) {
-    UniversalDispatcher.dispatch({
-      type: "SET_HEADER_HEIGHT",
-      headerHeight: height,
-    });
+    // Use setTimeout with a delay of 0 ms to break the dispatch chain
+    setTimeout(() => {
+      UniversalDispatcher.dispatch({
+        type: "SET_HEADER_HEIGHT",
+        headerHeight: height,
+      });
+    }, 0);
     this.props.onMainHeaderHeightChange(height);
   }
 


### PR DESCRIPTION
Using setTimeout to break the dispatch chain.

In the test environment, after checkout to this branch, please run "npm run build" to let this change being applied. And then, clear cookies、cache of the broswer. Then close the browser and reopen the broswer, go to the website. And you could see this solution takes effect.

