### PR TITLE
Issue 976: Remove references to EMAIL_HOST_PASSWORD

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,9 +8,6 @@
     "AWS_SECRET_ACCESS_KEY": {
       "required": true
     },
-    "EMAIL_HOST_PASSWORD": {
-      "required": true
-    },
     "S3_BUCKET": {
       "required": true
     },
@@ -37,7 +34,9 @@
       "quantity": 1
     }
   },
-  "addons": ["heroku-postgresql"],
+  "addons": [
+    "heroku-postgresql"
+  ],
   "buildpacks": [
     {
       "url": "heroku/python"

--- a/democracylab_environment_variables.sh
+++ b/democracylab_environment_variables.sh
@@ -8,9 +8,6 @@ exit 1
 #export AWS_SECRET_ACCESS_KEY=ASK
 #export S3_BUCKET=ASK
 
-# Password for account used to send email
-export EMAIL_HOST_PASSWORD=betterDemocracyViaTechnology
-
 # Url prefix to generate links on the back-end
 export PROTOCOL_DOMAIN=http://127.0.0.1:8000
 
@@ -70,7 +67,6 @@ export VOLUNTEER_RENEW_REMINDER_PERIODS='[7,7,-1]'
 # export MAILCHIMP_SUBSCRIBE_LIST_ID=SECRET
 
 export S3_BUCKET=democracylab-marlok
-export EMAIL_HOST_PASSWORD=betterDemocracyViaTechnology
 
 # ONLY FOR USE IN PRODUCTION
 #export HOTJAR_APPLICATION_ID=1097784

--- a/example.env
+++ b/example.env
@@ -12,7 +12,6 @@ GOOGLE_RECAPTCHA_SECRET_KEY=change_me_asap
 GOOGLE_RECAPTCHA_SITE_KEY=change_me_asap
 
 ### Email Configs ###
-EMAIL_HOST_PASSWORD=change_me_asap
 ADMIN_EMAIL=change_me_asap
 
 ### PayPal Configs ###


### PR DESCRIPTION
Addressing issue 976: https://github.com/DemocracyLab/CivicTechExchange/issues/976

Removes references of `EMAIL_HOST_PASSWORD`.