### PR TITLE
solves #985 pip installation failure from psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ docutils==0.14
 gunicorn==19.6.0
 jmespath==0.9.3
 mailchimp==2.0.9
-psycopg2==2.9.6
 psycopg2-binary==2.9.6
 python-dateutil==2.8.2
 pytz==2023.3


### PR DESCRIPTION
replacing another pr as it had the wrong branch to merge.

```
removed psycopg2==2.9.6 from requirements.txt
```