### PR TITLE
solves #985 requirements.txt installation failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ docutils==0.14
 gunicorn==19.6.0
 jmespath==0.9.3
 mailchimp==2.0.9
-psycopg2==2.9.6
 psycopg2-binary==2.9.6
 python-dateutil==2.8.2
 pytz==2023.3


### PR DESCRIPTION
running 
```
pip install -r requirements.txt
```
currently yields an installation error.

this was solved by simply removing `psycopg2` from the list of required modules, but keeping the precompiled `psycopg2-bin`.