### PR TITLE
remove postgres from example.env

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,9 +1,3 @@
-### Postgres credentials ###
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=change_me_asap
-POSTGRES_DB=postgres
-POSTGRES_HOST=db
-
 ### AWS Configs ###
 S3_BUCKET=s3_bucket_name
 


### PR DESCRIPTION
closes #979 
I have removed Postgres credentials from example.env, and added Postgres credentials in .env setting up to DemocracyLab Contributor Guide.