### PR TITLE
#1014 Restrict volunteering with project to only listed roles

### DIFF
--- a/common/components/common/projects/ProjectVolunteerButton.jsx
+++ b/common/components/common/projects/ProjectVolunteerButton.jsx
@@ -151,28 +151,34 @@ class ProjectVolunteerButton extends React.PureComponent<Props, State> {
   }
 
   _renderVolunteerButton(): React$Node {
-    return this.state.isAlreadyVolunteering ? (
+    if (this.state.isAlreadyVolunteering) {
       // TODO: Make this its own component and hook up to My Projects page
-      <Button
+      return (<Button
         className="AboutProject-button"
         type="button"
         variant="destructive"
         onClick={this.handleShowLeaveModal}
       >
         Leave Project
-      </Button>
-    ) : (
-      <Button
-        variant="primary"
-        className="AboutProject-button"
-        type="button"
-        disabled={this.state.buttonDisabled}
-        title={this.state.buttonTitle}
-        onClick={this.handleShowJoinModal}
-      >
-        Volunteer With Project
-      </Button>
-    );
+      </Button>);
+
+    } else {
+      if (!_.isEmpty(this.props.positions)) {
+        return (
+          <Button
+            variant="primary"
+            className="AboutProject-button"
+            type="button"
+            disabled={this.state.buttonDisabled}
+            title={this.state.buttonTitle}
+            onClick={this.handleShowJoinModal}
+          >
+            Volunteer With Project
+          </Button>
+        );
+
+      }
+    }
   }
 
   _renderLinkToSignInButton(): React$Node {

--- a/common/components/common/projects/ProjectVolunteerButton.jsx
+++ b/common/components/common/projects/ProjectVolunteerButton.jsx
@@ -152,35 +152,34 @@ class ProjectVolunteerButton extends React.PureComponent<Props, State> {
   }
 
   _renderVolunteerButton(): React$Node {
+    const hasProjectPositions = !_.isEmpty(this.state.project.project_positions) && this.state.project.project_positions.some(position => !position.isHidden);
     if (this.state.isAlreadyVolunteering) {
       // TODO: Make this its own component and hook up to My Projects page
-      return (<Button
-        className="AboutProject-button"
-        type="button"
-        variant="destructive"
-        onClick={this.handleShowLeaveModal}
-      >
-        Leave Project
-      </Button>);
-
+      return (
+        <Button
+          className="AboutProject-button"
+          type="button"
+          variant="destructive"
+          onClick={this.handleShowLeaveModal}
+        >
+          Leave Project
+        </Button>
+      );
+    } else if (hasProjectPositions) {
+      return (
+        <Button
+          variant="primary"
+          className="AboutProject-button"
+          type="button"
+          disabled={this.state.buttonDisabled}
+          title={this.state.buttonTitle}
+          onClick={this.handleShowJoinModal}
+        >
+          Volunteer With Project
+        </Button>
+      );
     } else {
-        if (!_.isEmpty(this.state.project.project_positions)) {
-        return (
-          <Button
-            variant="primary"
-            className="AboutProject-button"
-            type="button"
-            disabled={this.state.buttonDisabled}
-            title={this.state.buttonTitle}
-            onClick={this.handleShowJoinModal}
-          >
-            Volunteer With Project
-          </Button>
-        );
-      }
-      else{
-        return null
-      }
+      return null;
     }
   }
 

--- a/common/components/common/projects/ProjectVolunteerButton.jsx
+++ b/common/components/common/projects/ProjectVolunteerButton.jsx
@@ -19,6 +19,7 @@ type LeaveProjectParams = {|
 type Props = {|
   project: ?ProjectDetailsAPIData,
   positionToJoin: ?PositionInfo,
+  positions: $ReadOnlyArray<PositionInfo>,
   onVolunteerClick: () => void,
 |};
 type State = {|
@@ -163,7 +164,7 @@ class ProjectVolunteerButton extends React.PureComponent<Props, State> {
       </Button>);
 
     } else {
-      if (!_.isEmpty(this.props.positions)) {
+        if (!_.isEmpty(this.state.project.project_positions)) {
         return (
           <Button
             variant="primary"
@@ -176,7 +177,9 @@ class ProjectVolunteerButton extends React.PureComponent<Props, State> {
             Volunteer With Project
           </Button>
         );
-
+      }
+      else{
+        return null
       }
     }
   }

--- a/common/components/common/projects/ProjectVolunteerModal.jsx
+++ b/common/components/common/projects/ProjectVolunteerModal.jsx
@@ -234,18 +234,10 @@ class ProjectVolunteerModal extends React.PureComponent<Props, State> {
     );
   }
 
-  _selectedExistingPositionTag(): ?string {
+  _selectedTag(): ?string {
     return this.state.existingPositionOption
       ? this.state.existingPositionOption.value
       : null;
-  }
-
-  _selectedOtherRoleTag(): ?string {
-    return this.state.roleTag && this.state.roleTag.tag_name;
-  }
-
-  _selectedTag(): ?string {
-    return this._selectedExistingPositionTag() || this._selectedOtherRoleTag();
   }
 
   _renderExistingPositionDropdown(): React$Node {
@@ -262,21 +254,6 @@ class ProjectVolunteerModal extends React.PureComponent<Props, State> {
           simpleValue={true}
           isClearable={false}
           isMulti={false}
-        />
-      </div>
-    );
-  }
-
-  _renderOtherRoleDropdown(): React$Node {
-    return (
-      <div className="form-group">
-        <label htmlFor="project_technologies">Role You are Applying For</label>
-        <TagSelector
-          value={[this.state.roleTag]}
-          category={TagCategory.ROLE}
-          allowMultiSelect={false}
-          isClearable={false}
-          onSelection={this.onRoleChange.bind(this)}
         />
       </div>
     );

--- a/common/components/common/projects/ProjectVolunteerModal.jsx
+++ b/common/components/common/projects/ProjectVolunteerModal.jsx
@@ -44,7 +44,6 @@ const volunteerPeriodsInDays: $ReadOnlyArray<SelectOption> = [
   ["6 months - 1 year", 365],
 ].map(textDaysPair => ({ label: textDaysPair[0], value: textDaysPair[1] }));
 
-const OtherRoleOption: SelectOption = { label: "Other", value: "Other" };
 
 /**
  * Modal for volunteering to join a project
@@ -80,7 +79,6 @@ class ProjectVolunteerModal extends React.PureComponent<Props, State> {
           value: position.roleTag.tag_name,
           label: tagOptionDisplay(position.roleTag),
         }))
-        .concat(OtherRoleOption)
     );
 
     let state: State = {
@@ -187,12 +185,6 @@ class ProjectVolunteerModal extends React.PureComponent<Props, State> {
                 {!_.isEmpty(this.props.positions)
                   ? this._renderExistingPositionDropdown()
                   : null}
-                {_.isEmpty(this.props.positions) ||
-                (this.state.existingPositionOption &&
-                  this.state.existingPositionOption.value ===
-                    OtherRoleOption.value)
-                  ? this._renderOtherRoleDropdown()
-                  : null}
                 <Form.Label>
                   How long do you expect to be able to contribute to this
                   project?
@@ -243,8 +235,7 @@ class ProjectVolunteerModal extends React.PureComponent<Props, State> {
   }
 
   _selectedExistingPositionTag(): ?string {
-    return this.state.existingPositionOption &&
-      this.state.existingPositionOption.value !== OtherRoleOption.value
+    return this.state.existingPositionOption
       ? this.state.existingPositionOption.value
       : null;
   }


### PR DESCRIPTION
- [x] For a project with roles, upon clicking 'Volunteer with Project', do not list the 'Other' option (which currently lets them select any role)
- [x] Do not show 'Volunteer with Project' button on project profile if the project has no open roles