### PR TITLE
chore: update boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-boto3==1.26.114
-botocore==1.29.114
+boto3==1.28.37
 dj-database-url==0.4.1
 Django==4.2
 django-allauth==0.44


### PR DESCRIPTION
This PR updates python aws sdk from 1.26 to 1.28 and removes unused `botocore` since it's a dependency of `boto3` and we're using `boto3` not `botocore`.

Fixes #1031 