### PR TITLE
#1027 Restrict Sensntive Data Exposure via API Call

### DIFF
--- a/common/components/utils/ProjectAPIUtils.js
+++ b/common/components/utils/ProjectAPIUtils.js
@@ -113,14 +113,7 @@ export type VolunteerDetailsAPIData = {|
 export type VolunteerMinimalDetailsAPIData = {|
   +application_id: number,
   +user: VolunteerUserData,
-  +application_text: string,
-  +application_date: string,
-  +platform_date_joined: string,
   +roleTag: TagDefinition,
-  +isApproved: boolean,
-  +isCoOwner: boolean,
-  +isTeamLeader: boolean,
-  +isUpForRenewal: boolean,
 |};
 
 export type ProjectDetailsAPIData = {|

--- a/common/components/utils/ProjectAPIUtils.js
+++ b/common/components/utils/ProjectAPIUtils.js
@@ -109,6 +109,20 @@ export type VolunteerDetailsAPIData = {|
   +isUpForRenewal: boolean,
 |};
 
+// Structure for minimal volunteer data exposure
+export type VolunteerMinimalDetailsAPIData = {|
+  +application_id: number,
+  +user: VolunteerUserData,
+  +application_text: string,
+  +application_date: string,
+  +platform_date_joined: string,
+  +roleTag: TagDefinition,
+  +isApproved: boolean,
+  +isCoOwner: boolean,
+  +isTeamLeader: boolean,
+  +isUpForRenewal: boolean,
+|};
+
 export type ProjectDetailsAPIData = {|
   +project_id: number,
   +project_description: string,
@@ -136,7 +150,7 @@ export type ProjectDetailsAPIData = {|
   +project_links: $ReadOnlyArray<LinkInfo>,
   +project_files: $ReadOnlyArray<FileInfo>,
   +project_owners: $ReadOnlyArray<VolunteerUserData>,
-  +project_volunteers: $ReadOnlyArray<VolunteerDetailsAPIData>,
+  +project_volunteers: $ReadOnlyArray<VolunteerMinimalDetailsAPIData>,
   +project_date_modified: Date,
   +project_events: $ReadOnlyArray<EventTileAPIData>,
   +event_created_from: ?number,


### PR DESCRIPTION
The GET `api/team` API shows team information for Democracy Lab members on the page: `https://www.democracylab.org/about`. The API exposed sensitive volunteer data like application test, joining date, isCoOwner, etc. These fields are not displayed/used on the front-end but are still returned as a part of the API response.

This fix creates a new structure called `VolunteerMinimalDetailsAPIData` that contains only the required information about every volunteer. This new structure is integrated into `ProjectDetailsAPIData` structure.

Closes Issue: #1027