### PR TITLE
FA preconnect and Google font chain reduction

### DIFF
--- a/civictechprojects/static/css/styles.scss
+++ b/civictechprojects/static/css/styles.scss
@@ -1,11 +1,8 @@
 //import our variables first
 @import "vars";
-//import our fonts from Google Fonts
-@import url("https://fonts.googleapis.com/css?family=Montserrat:400,500,600&display=swap");
 
 //import third-party CSS, so we can use it and override it.
-
-// IMPORTANT: Load our bootstrap overrides first, per Bootstrap's documentation.
+    // IMPORTANT: Load our bootstrap overrides first, per Bootstrap's documentation.
 @import "bootstrapoverride";
 //import required Bootstrap (foundation elements)
 @import "vendor/bootstrap/functions";

--- a/civictechprojects/templates/new_index.html
+++ b/civictechprojects/templates/new_index.html
@@ -16,6 +16,10 @@
     <script src="/static/js/runtime.bundle.js" defer></script>
     <script src="/static/js/main.bundle.js" defer></script>
     <script src="/static/js/vendors.bundle.js" defer></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://use.fontawesome.com" crossorigin>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.1/css/all.css" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="/static/css/main.styles.css"/>
     <link rel="icon" type="image/png" href="{{FAVICON_PATH}}">


### PR DESCRIPTION
Small performance fixes: 
 - add preconnect for FontAwesome connections
 - remove one step in the chain that loads Google Fonts

Specifically, the request chain to load our fonts looks like this right now:
![critpath-main](https://github.com/DemocracyLab/CivicTechExchange/assets/16870466/492cae9b-2563-449b-912d-9408b107d8cd)

This PR will change it to this:
![critpath-branch](https://github.com/DemocracyLab/CivicTechExchange/assets/16870466/96a38f62-d45c-4e88-aa75-d0f5cc59877d)

It just removes one step for the google fonts; our css and our google fonts will now load in parallel, not in sequence. In Lighthouse testing on local, I see a small reduction in first content paint (-0.3s) and total blocking time (-10ms) and +2 points on the Performance statistic (76 to 78) -- I ran these tests multiple times so those are averages but the difference is very small from test to test. The FA preconnect is ... probably insignificant, but anything to help speed up FA loads. 