### PR TITLE
Encrypt username in s3 key

### DIFF
--- a/civictechprojects/views.py
+++ b/civictechprojects/views.py
@@ -50,7 +50,11 @@ from common.helpers.request_helpers import is_ajax
 from django.views.decorators.cache import cache_page
 from rest_framework.decorators import api_view
 import requests
+from cryptography.fernet import Fernet
 
+# define a encryption with a global key
+key = b'yLyb7itt7-e0Z9eiPiX-lVnppwbK0v3TjQsk3J4ZgbY='
+cipher_suite = Fernet(key)
 
 def tags(request):
     url_parts = request.GET.urlencode()
@@ -650,8 +654,12 @@ def presign_project_thumbnail_upload(request):
     file_type = request.GET['file_type']
     file_extension = file_type.split('/')[-1]
     unique_file_name = file_name + '_' + str(time())
+
+    # encode user name
+    encrypted_uploader = cipher_suite.encrypt(uploader.encode())
+
     s3_key = 'thumbnails/%s/%s.%s' % (
-        uploader, unique_file_name, file_extension)
+        encrypted_uploader, unique_file_name, file_extension)
     return presign_s3_upload(
         raw_key=s3_key, file_name=file_name, file_type=file_type, acl="public-read")
 

--- a/common/helpers/s3.py
+++ b/common/helpers/s3.py
@@ -8,13 +8,17 @@ from urllib import parse
 from civictechprojects.models import FileCategory
 from .random import generate_uuid
 from .request_helpers import ResourceNotFound
+from cryptography.fernet import Fernet
 
+# define a encryption with a global key
+key = b'yLyb7itt7-e0Z9eiPiX-lVnppwbK0v3TjQsk3J4ZgbY='
+cipher_suite = Fernet(key)
 
 class S3Key:
     def __init__(self, raw_key):
         key_parts = raw_key.split('/')
         self.file_category = key_parts[0]
-        self.username = key_parts[1]
+        self.username = cipher_suite.decrypt(key_parts[1]).decode()
         self.file_name = key_parts[2]
 
 


### PR DESCRIPTION
Use ```cryptography``` to encrypt the user name before defining a s3 key.  Define a global key for now for encryption and decryption. The admin can improve based on this pull request to define a secrete key.