### PR TITLE
About Page: Updated Annual Report for 2023

### DIFF
--- a/common/components/controllers/AboutUsController.jsx
+++ b/common/components/controllers/AboutUsController.jsx
@@ -239,8 +239,8 @@ class AboutUsController extends React.PureComponent<{||}, State> {
             <h3>Annual Report</h3>
             <p>
               Please review our{" "}
-              <a href="https://d1agxr2dqkgkuy.cloudfront.net/documents/2022%20Annual%20Report.pdf">
-                2022 Annual Report
+              <a href="https://d1agxr2dqkgkuy.cloudfront.net/documents/2023%20Annual%20Report.pdf">
+                2023 Annual Report
               </a>{" "}
               to learn about the impact of our programs and platform last year.
             </p>


### PR DESCRIPTION
Updating About Page's annual report link to reflect the new 2023 report