### PR TITLE
builds but doesn't run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install -r requirements.txt
 # Copy files needed for yarn install.
 COPY package.json yarn.lock /code/
 RUN yarn config set ignore-engines true
-RUN yarn --frozen-lockfile --link-duplicates --ignore-scripts
+RUN yarn --link-duplicates --ignore-scripts
 # Permission issue with node-sass https://github.com/sass/node-sass/issues/1579
 RUN npm rebuild node-sass
 # Copy folders and files whitelisted by .dockerignore.

--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
     "regenerator-runtime": "^0.13.2",
     "sass": "^1.52.1",
     "sync-exec": "~0.6.2",
-    "terser-webpack-plugin": "^2.3.5",
-    "webpack": "^4.42.0",
-    "webpack-cli": "^3.3.0",
-    "webpack-dev-server": "^3.3.0",
+    "terser-webpack-plugin": "^5.3.10",
+    "webpack": "^5.65.0",
+    "webpack-cli": "^4.9.1",
+    "webpack-dev-server": "^4.6.0",
     "webpack-merge": "^4.2.2"
   },
   "resolutions": {
@@ -101,7 +101,7 @@
     "dns-packet": "^1.3.4",
     "browserslist": "^4.16.6",
     "async": "^2.6.4",
-    "terser": "^4.8.1",
+    "terser": "^5.31.3",
     "decode-uri-component": "^0.2.2",
     "json5": "^1.0.2",
     "word-wrap": "1.2.4",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -37,11 +37,14 @@ module.exports = {
   resolve: {
     aliasFields: ['browser']
   },
-  node: {
-      child_process: "empty",
-      fs: "empty",
-      tls: "empty"
+  resolve:{
+    extensions: ['*', '.js', '.jsx'],
+    fallback: {
+      fs: false,
+      tls: false
+    }
   },
+  node: false,
   plugins: [
     new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
@@ -57,14 +60,8 @@ module.exports = {
   ],
   optimization: {
     runtimeChunk: 'single',
-    splitChunks: {
-      cacheGroups: {
-        vendor: {
-          test: /[\\/]node_modules[\\/]/,
-          name: 'vendors',
-          chunks: 'all',
-        },
-      },
+    splitChunks: { 
+      chunks: 'all'
     },
   },
 }


### PR DESCRIPTION
I have installed webpack 5 and it builds and runs, but pages don't load.  With the change from webpack4 to 5 there have been changes to the way it chunks to javascript files to be served to the browser, and it's the python/django side that's serving them.  

I'll keep working on figuring it out on the python side, but it anything jumps out at you let me know.

Here is the error:

The build is okay, but the docker-compose run I get these warnings:
```
ddfri@ddfri2022dec MINGW64 ~/git/democracy-lab/CivicTechExchange (webpack5#1111)
$ docker-compose up
[+] Building 0.0s (0/0)
[+] Running 4/0
 ✔ Container civictechexchange-db-1            Created                                                                                        0.0s 
 ✔ Container civictechexchange-create_table-1  Created                                                                                        0.0s 
 ✔ Container civictechexchange-web-1           Created                                                                                        0.0s 
 ✔ Container civictechexchange-migrate-1       Created                                                                                        0.0s 
Attaching to civictechexchange-create_table-1, civictechexchange-db-1, civictechexchange-migrate-1, civictechexchange-web-1
civictechexchange-db-1            | 
civictechexchange-db-1            | PostgreSQL Database directory appears to contain a database; Skipping initialization
civictechexchange-db-1            |
civictechexchange-db-1            | 2024-08-09 17:56:08.788 UTC [1] LOG:  starting PostgreSQL 15.3 (Debian 15.3-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
civictechexchange-db-1            | 2024-08-09 17:56:08.789 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
civictechexchange-db-1            | 2024-08-09 17:56:08.789 UTC [1] LOG:  listening on IPv6 address "::", port 5432
civictechexchange-db-1            | 2024-08-09 17:56:08.794 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
civictechexchange-db-1            | 2024-08-09 17:56:08.802 UTC [29] LOG:  database system was interrupted; last known up at 2024-08-08 19:55:14 UTC
civictechexchange-db-1            | 2024-08-09 17:56:09.047 UTC [29] LOG:  database system was not properly shut down; automatic recovery in progress
civictechexchange-db-1            | 2024-08-09 17:56:09.055 UTC [29] LOG:  redo starts at 0/640A0F8
civictechexchange-db-1            | 2024-08-09 17:56:09.055 UTC [29] LOG:  invalid record length at 0/640A1E0: wanted 24, got 0
civictechexchange-db-1            | 2024-08-09 17:56:09.055 UTC [29] LOG:  redo done at 0/640A1A8 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s
civictechexchange-db-1            | 2024-08-09 17:56:09.061 UTC [27] LOG:  checkpoint starting: end-of-recovery immediate wait
civictechexchange-db-1            | 2024-08-09 17:56:09.073 UTC [27] LOG:  checkpoint complete: wrote 3 buffers (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.003 s, sync=0.002 s, total=0.014 s; sync files=2, longest=0.001 s, average=0.001 s; distance=0 kB, estimate=0 kB
civictechexchange-db-1            | 2024-08-09 17:56:09.076 UTC [1] LOG:  database system is ready to accept connections
civictechexchange-web-1           | 
civictechexchange-web-1           | > CivicTechExchange@0.1.0 dev /code
civictechexchange-web-1           | > webpack --config webpack.dev.js && npm run buildtask:collectstatic
civictechexchange-web-1           |
civictechexchange-web-1           | (node:169) [DEP_WEBPACK_MAIN_TEMPLATE_RENDER_MANIFEST] DeprecationWarning: MainTemplate.hooks.renderManifest is deprecated (use Compilation.hooks.renderManifest instead)
civictechexchange-web-1           | (node:169) [DEP_WEBPACK_CHUNK_TEMPLATE_RENDER_MANIFEST] DeprecationWarning: ChunkTemplate.hooks.renderManifest is deprecated (use Compilation.hooks.renderManifest instead)
civictechexchange-web-1           | (node:169) [DEP_WEBPACK_MAIN_TEMPLATE_HASH_FOR_CHUNK] DeprecationWarning: MainTemplate.hooks.hashForChunk is deprecated (use JavascriptModulesPlugin.getCompilationHooks().chunkHash instead)
civictechexchange-web-1           | (node:169) [DEP_WEBPACK_COMPILATION_NORMAL_MODULE_LOADER_HOOK] DeprecationWarning: Compilation.hooks.normalModuleLoader was moved to NormalModule.getCompilationHooks(compilation).loader
civictechexchange-create_table-1 exited with code 0
civictechexchange-migrate-1       | Operations to perform:
civictechexchange-migrate-1       |   Apply all migrations: account, admin, auth, civictechprojects, common, contenttypes, democracylab, sessions, sites, socialaccount, taggit
civictechexchange-migrate-1       | Running migrations:
civictechexchange-migrate-1       |   No migrations to apply.
civictechexchange-migrate-1       |   Your models in app(s): 'account', 'civictechprojects', 'common', 'democracylab', 'socialaccount' have changes that are not yet reflected in a migration, and so won't be applied.
civictechexchange-migrate-1       |   Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.    
civictechexchange-migrate-1 exited with code 0

```
