### PR TITLE
fix: block TRACE/TRACK methods

### DIFF
--- a/common/helpers/malicious_requests.py
+++ b/common/helpers/malicious_requests.py
@@ -1,24 +1,26 @@
 import re
 from django.conf import settings
-from django.core.exceptions import MiddlewareNotUsed, SuspiciousOperation
+from django.core.exceptions import SuspiciousOperation
+
+# TRACE and TRACK have no legitimate use in a web application and are
+# commonly used as cheap flood vectors (TRACE also enables Cross-Site Tracing).
+_ALWAYS_BLOCKED_METHODS = frozenset({'TRACE', 'TRACK'})
 
 
 class MaliciousRequestsMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
-        # One-time configuration and initialization.
-        used = False
         if settings.MALICIOUS_URL_PATTERNS is not None:
             url_patterns = settings.MALICIOUS_URL_PATTERNS.split(',')
             self.malicious_url_patterns = list(map(lambda pattern: re.compile(pattern, re.IGNORECASE), url_patterns))
-            used = True
         if settings.MALICIOUS_FWD_PATTERNS is not None:
             fwd_patterns = settings.MALICIOUS_FWD_PATTERNS.split(',')
             self.malicious_fwd_patterns = list(map(lambda pattern: re.compile(pattern, re.IGNORECASE), fwd_patterns))
-            used = True
 
-        if not used:
-            raise MiddlewareNotUsed
+    def check_request_method(self, request):
+        if request.method in _ALWAYS_BLOCKED_METHODS:
+            self.log_filter_action(f'Blocking disallowed HTTP method "{request.method}"')
+            raise SuspiciousOperation("Disallowed HTTP method")
 
     def check_request_url(self, request):
         path = request.get_full_path()
@@ -39,16 +41,9 @@ class MaliciousRequestsMiddleware:
         print(f'[MaliciousRequestsMiddleware] {log_msg}')
 
     def __call__(self, request):
-        # Code to be executed for each request before
-        # the view (and later middleware) are called.
-
+        self.check_request_method(request)
         hasattr(self, 'malicious_url_patterns') and self.check_request_url(request)
         hasattr(self, 'malicious_fwd_patterns') and self.check_request_fwd(request)
 
-        response = self.get_response(request)
-
-        # Code to be executed for each request/response after
-        # the view is called.
-
-        return response
+        return self.get_response(request)
 

--- a/common/tests/test_malicious_requests_middleware.py
+++ b/common/tests/test_malicious_requests_middleware.py
@@ -1,0 +1,105 @@
+from unittest.mock import MagicMock
+from django.core.exceptions import SuspiciousOperation
+from django.test import TestCase, override_settings
+
+from common.helpers.malicious_requests import MaliciousRequestsMiddleware, _ALWAYS_BLOCKED_METHODS
+
+
+def _make_request(method='GET', path='/', fwd=None):
+    request = MagicMock()
+    request.method = method
+    request.get_full_path.return_value = path
+    request.META = {'REMOTE_ADDR': '127.0.0.1'}
+    if fwd is not None:
+        request.headers = {'X-Forwarded-For': fwd}
+    else:
+        request.headers = {}
+    return request
+
+
+def _middleware(get_response=None):
+    return MaliciousRequestsMiddleware(get_response or MagicMock(return_value=None))
+
+
+@override_settings(MALICIOUS_URL_PATTERNS=None, MALICIOUS_FWD_PATTERNS=None)
+class AlwaysBlockedMethodsTests(TestCase):
+    def test_always_blocked_set_contents(self):
+        self.assertIn('TRACE', _ALWAYS_BLOCKED_METHODS)
+        self.assertIn('TRACK', _ALWAYS_BLOCKED_METHODS)
+
+    def test_trace_is_blocked(self):
+        mw = _middleware()
+        with self.assertRaises(SuspiciousOperation):
+            mw(MagicMock(method='TRACE', get_full_path=MagicMock(return_value='/')))
+
+    def test_track_is_blocked(self):
+        mw = _middleware()
+        with self.assertRaises(SuspiciousOperation):
+            mw(MagicMock(method='TRACK', get_full_path=MagicMock(return_value='/')))
+
+    def test_get_is_allowed(self):
+        mw = _middleware()
+        req = _make_request('GET')
+        mw(req)  # should not raise
+
+    def test_post_is_allowed(self):
+        mw = _middleware()
+        mw(_make_request('POST'))
+
+    def test_put_is_allowed(self):
+        mw = _middleware()
+        mw(_make_request('PUT'))
+
+    def test_delete_is_allowed(self):
+        mw = _middleware()
+        mw(_make_request('DELETE'))
+
+    def test_patch_is_allowed(self):
+        mw = _middleware()
+        mw(_make_request('PATCH'))
+
+    def test_options_is_allowed(self):
+        mw = _middleware()
+        mw(_make_request('OPTIONS'))
+
+    def test_head_is_allowed(self):
+        mw = _middleware()
+        mw(_make_request('HEAD'))
+
+
+@override_settings(MALICIOUS_URL_PATTERNS=r'\.php$,/wp-admin', MALICIOUS_FWD_PATTERNS=None)
+class UrlPatternTests(TestCase):
+    def test_malicious_url_is_blocked(self):
+        mw = _middleware()
+        with self.assertRaises(SuspiciousOperation):
+            mw(_make_request(path='/index.php'))
+
+    def test_another_malicious_url_is_blocked(self):
+        mw = _middleware()
+        with self.assertRaises(SuspiciousOperation):
+            mw(_make_request(path='/wp-admin/login'))
+
+    def test_clean_url_is_allowed(self):
+        mw = _middleware()
+        mw(_make_request(path='/projects/123'))
+
+
+@override_settings(MALICIOUS_URL_PATTERNS=None, MALICIOUS_FWD_PATTERNS=r'^10\.')
+class FwdPatternTests(TestCase):
+    def test_malicious_fwd_is_blocked(self):
+        mw = _middleware()
+        with self.assertRaises(SuspiciousOperation):
+            mw(_make_request(fwd='10.0.0.1'))
+
+    def test_malicious_fwd_header_takes_precedence_over_remote_addr(self):
+        mw = _middleware()
+        with self.assertRaises(SuspiciousOperation):
+            mw(_make_request(fwd='10.1.2.3'))
+
+    def test_clean_fwd_is_allowed(self):
+        mw = _middleware()
+        mw(_make_request(fwd='203.0.113.5'))
+
+    def test_remote_addr_used_when_no_fwd_header(self):
+        mw = _middleware()
+        mw(_make_request())  # REMOTE_ADDR is 127.0.0.1, should not match ^10\.


### PR DESCRIPTION
## Summary

democracylab.org experienced a volumetric DDoS attack using HTTP TRACE requests with randomised cache-busting query parameters. The attack saturated Heroku's dyno request backlog, causing H11 errors and 503 responses for legitimate users.

### Code fix

**File:** `common/helpers/malicious_requests.py`

- Added `_ALWAYS_BLOCKED_METHODS = frozenset({'TRACE', 'TRACK'})` — blocked unconditionally, no env var needed.
- `check_request_method()` is now the first check in `__call__`, short-circuiting before URL/IP checks.
- Removed the `MiddlewareNotUsed` raise: the middleware is always active for method blocking even when neither pattern env var is set.

<details>

## Sample log line

```
Jul 10 01:30:07 PM democracy-lab heroku/router at=error code=H11 desc="Backlog too deep"
method=TRACE path="/user/25463?page=1&Lt4ZGViwIr=RiPKDIuy8N"
host=www.democracylab.org fwd="" status=503
```

## Impact

- Heroku H11 ("Backlog too deep") errors returned as 503 to real users
- No data breach or data loss
- No authentication bypass

## Attack mechanics

| Signal | Meaning |
|---|---|
| `method=TRACE` | TRACE is never used by browsers or legitimate API clients. Cheap to send, forces the server to echo the request body back — used here as a flood vector. Also enables Cross-Site Tracing (XST) if reflected. |
| `Lt4ZGViwIr=RiPKDIuy8N` (randomised query param) | Each request has a unique key=value pair (~10 random chars each). Defeats any upstream HTTP cache (Heroku router, CDN) so every request reaches a dyno. |
| `fwd=""` (empty X-Forwarded-For) | Heroku's router populates `X-Forwarded-For` for all inbound traffic. An empty value suggests the attacker reached the app through an atypical path, or stripped the header. Makes IP-based blocking unreliable for this incident. |

## Background: TRACE and TRACK

**TRACE** is defined in [RFC 9110 §9.3.8](https://www.rfc-editor.org/rfc/rfc9110#section-9.3.8) (the current HTTP semantics standard). It is a diagnostic method — the server echoes back the received request so the client can inspect what intermediaries modified in transit. No browser or legitimate API client sends TRACE in production; its only real-world use is manual debugging with `curl` or similar tools.

**Cross-Site Tracing (XST):** Described by Jeremiah Grossman in 2003 and documented in [OWASP's XST article](https://owasp.org/www-community/attacks/Cross_Site_Tracing). Because TRACE echoes all request headers — including `HttpOnly` cookies and `Authorization` headers — back in the response body, a malicious script can read that body and exfiltrate credentials that `HttpOnly` was specifically designed to keep out of JS reach. Modern browsers now block cross-origin TRACE requests, but the method remains a defense-in-depth concern.

**TRACK** is a Microsoft IIS-specific, non-standard variant of TRACE — not defined in any RFC. It carries the same XST risks with no legitimate use case on a Django application.

[OWASP's HTTP Methods testing guide](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods) recommends disabling both methods on all production servers.

In this incident TRACE was not used for XST but as a **flood vector**: it is cheap to send, forces the server to process and echo the request body, and — combined with cache-busting query params — bypasses all upstream caching so every request reaches a dyno.

## Why existing defences didn't catch it

1. **DRF throttling** (`AnonRateThrottle`, `UserRateThrottle`) only wraps DRF views. `/user/<id>` is a standard Django view, so throttling never fired.
2. **`MaliciousRequestsMiddleware`** filtered by URL pattern and forwarded-for IP, but had no HTTP method check. It also raised `MiddlewareNotUsed` when neither env var was set, removing itself from the stack entirely.
3. **No edge-layer protection** — all traffic reaches Heroku dynos; there is no CDN or WAF in front.